### PR TITLE
Add workflow API documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ The documentation is organized into the following sections:
 - [**Getting Started**](getting-started/index.md) - Guides for new users
 - [**Concepts**](concepts/index.md) - Core concepts and architecture
 - [**API Reference**](api-reference/index.md) - Detailed API documentation
+- [**Workflow API**](workflow-api.md) - How to call workflows programmatically
 - [**CLI Reference**](cli.md) - Command line usage
 - [**Examples**](../examples/README.md) - Example workflows
 

--- a/docs/workflow-api.md
+++ b/docs/workflow-api.md
@@ -1,0 +1,160 @@
+# Workflow API Guide
+
+NodeTool exposes an HTTP and WebSocket API so you can integrate workflows into your own applications.
+This page collects the basics from the project README.
+
+## Loading Workflows
+
+```javascript
+const response = await fetch("http://localhost:8000/api/workflows/");
+const workflows = await response.json();
+```
+
+## Running a Workflow
+
+### HTTP API
+
+```bash
+curl -X POST "http://localhost:8000/api/workflows/<workflow_id>/run" \
+-H "Content-Type: application/json" \
+-d '{
+    "params": {
+        "param_name": "param_value"
+    }
+}'
+```
+
+```javascript
+const response = await fetch(
+  "http://localhost:8000/api/workflows/<workflow_id>/run",
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      params: params,
+    }),
+  }
+);
+
+const outputs = await response.json();
+// outputs is an object with one property for each output node in the workflow
+// the value is the output of the node, which can be a string, image, audio, etc.
+```
+
+## Streaming API
+
+The streaming API provides real-time job updates. See
+[`run_workflow_streaming.js`](../examples/run_workflow_streaming.js) for a full example.
+
+Updates include:
+
+- `job_update` – overall job status
+- `node_update` – status of a specific node
+- `node_progress` – progress of a node
+
+```javascript
+const response = await fetch(
+  "http://localhost:8000/api/workflows/<workflow_id>/run?stream=true",
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      params: params,
+    }),
+  }
+);
+
+const reader = response.body.getReader();
+const decoder = new TextDecoder();
+
+while (true) {
+  const { done, value } = await reader.read();
+  if (done) break;
+
+  const lines = decoder.decode(value).split("\n");
+  for (const line of lines) {
+    if (line.trim() === "") continue;
+
+    const message = JSON.parse(line);
+    switch (message.type) {
+      case "job_update":
+        console.log("Job status:", message.status);
+        if (message.status === "completed") {
+          console.log("Workflow completed:", message.result);
+        }
+        break;
+      case "node_progress":
+        console.log(
+          "Node progress:",
+          message.node_name,
+          (message.progress / message.total) * 100
+        );
+        break;
+      case "node_update":
+        console.log(
+          "Node update:",
+          message.node_name,
+          message.status,
+          message.error
+        );
+        break;
+    }
+  }
+}
+```
+
+## WebSocket API
+
+The WebSocket API uses a binary protocol for efficiency and allows cancelling jobs.
+See [`run_workflow_websocket.js`](../examples/run_workflow_websocket.js) for more details.
+
+```javascript
+const socket = new WebSocket("ws://localhost:8000/predict");
+
+const request = {
+  type: "run_job_request",
+  workflow_id: "YOUR_WORKFLOW_ID",
+  params: {
+    /* workflow parameters */
+  },
+};
+
+// Run a workflow
+socket.send(
+  msgpack.encode({
+    command: "run_job",
+    data: request,
+  })
+);
+
+// Handle messages from the server
+socket.onmessage = async (event) => {
+  const data = msgpack.decode(new Uint8Array(await event.data.arrayBuffer()));
+  if (data.type === "job_update" && data.status === "completed") {
+    console.log("Workflow completed:", data.result);
+  } else if (data.type === "node_update") {
+    console.log("Node update:", data.node_name, data.status, data.error);
+  } else if (data.type === "node_progress") {
+    console.log("Progress:", (data.progress / data.total) * 100);
+  }
+  // Handle other message types as needed
+};
+
+// Cancel a running job
+socket.send(msgpack.encode({ command: "cancel_job" }));
+
+// Get the status of the job
+socket.send(msgpack.encode({ command: "get_status" }));
+```
+
+## API Demo
+
+- Download the [html file](<(api-demo.html)>)
+- Open it in a browser locally.
+- Select the endpoint (local or `api.nodetool.ai` for alpha users).
+- Enter an API token from the NodeTool settings dialog.
+- Select a workflow and run it.


### PR DESCRIPTION
## Summary
- document usage of the HTTP and WebSocket workflow APIs
- link the new page from the docs index

## Testing
- `pytest -q` *(fails: command not found)*