### PR TITLE
Add Chat CLI docs

### DIFF
--- a/docs/chat-cli.md
+++ b/docs/chat-cli.md
@@ -1,0 +1,44 @@
+# Chat CLI
+
+The `nodetool chat` command starts an interactive terminal interface for conversing with language models and running tools.
+
+## Starting the Interface
+
+Run `nodetool chat` from your shell. A welcome panel appears with the current model, agent status, and workspace path. Type `/help` at any time to see available commands.
+
+## CLI Commands
+
+Commands use a `/` prefix. Important commands include:
+
+- **/help** – Show available commands and workspace operations.
+- **/models** – List models from the current provider.
+- **/model <id>** – Select the language model to use.
+- **/agent [on|off]** – Toggle agent mode for tool‑augmented conversations.
+- **/debug [on|off]** – Display tool calls and results.
+- **/analysis [on|off]** – Enable or disable the agent analysis phase.
+- **/flow [on|off]** – Control data‑flow analysis.
+- **/reasoning <id|default>** – Set the reasoning model.
+- **/tools [name]** – List available tools or show details for one.
+- **/usage** – Show usage statistics for the current provider.
+- **/exit** – Quit the chat session.
+
+## Workspace Commands
+
+Within the chat you can manage files in a sandboxed workspace located under `~/.nodetool-workspaces`. Workspace operations do not use the `/` prefix:
+
+- `pwd` – Print the current directory.
+- `ls [path]` – List directory contents.
+- `cd [path]` – Change directory.
+- `mkdir <dir>` – Create a directory.
+- `rm <path>` – Remove a file or directory.
+- `open <file>` – Open a file with the system default application.
+- `cat <file>` – Display file contents with syntax highlighting.
+- `cp <src> <dest>` – Copy files or directories.
+- `mv <src> <dest>` – Move or rename items.
+- `grep <pattern> [path]` – Search text within files.
+- `cdw` – Jump to the workspace root.
+
+## Settings and History
+
+Session settings are stored in `~/.nodetool_settings` and command history in `~/.nodetool_history`. These files allow the chat interface to remember your model choice, agent mode, and other options between runs.
+

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,7 +5,7 @@ Available commands:
 - **serve**: Serve the Nodetool API server.
 - **worker**: Start a Nodetool worker instance.
 - **run**: Run a workflow from a file.
-- **chat**: Start a nodetool chat.
+- **chat**: Start a nodetool chat. See [Chat CLI](chat-cli.md) for usage.
 - **explorer**: Explore files in an interactive text UI.
 - **codegen**: Generate DSL modules from node definitions.
 - **settings**: Commands for managing NodeTool settings and secrets.

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ The documentation is organized into the following sections:
 - [**Concepts**](concepts/index.md) - Core concepts and architecture
 - [**API Reference**](api-reference/index.md) - Detailed API documentation
 - [**CLI Reference**](cli.md) - Command line usage
+- [**Chat CLI**](chat-cli.md) - Interactive chat application
 - [**Examples**](../examples/README.md) - Example workflows
 
 ## Community


### PR DESCRIPTION
## Summary
- document the command-line chat application
- link from CLI and docs index

## Testing
- `pytest -q` *(fails: command not found)*