### PR TITLE
Add docs for Hugging Face utilities

### DIFF
--- a/docs/api-reference/huggingface.md
+++ b/docs/api-reference/huggingface.md
@@ -1,0 +1,7 @@
+# nodetool.common Hugging Face utilities
+
+Utilities for interacting with the Hugging Face Hub. These modules manage cached models, download files, and fetch metadata.
+
+- **huggingface_cache** - Download repository files with WebSocket progress updates and caching helpers.
+- **huggingface_models** - Inspect and manage locally cached Hugging Face models and fetch model info.
+- **huggingface_file** - Retrieve metadata about specific files in a repository using the Hugging Face FileSystem.

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -3,3 +3,4 @@
 This section contains documentation generated from the source code.
 
 - [Workflows](workflows.md) - Core workflow classes and utilities.
+- [Hugging Face Utilities](huggingface.md) - Cache management and model helpers.

--- a/src/nodetool/common/huggingface_file.py
+++ b/src/nodetool/common/huggingface_file.py
@@ -1,3 +1,5 @@
+"""Helpers for retrieving information about individual Hugging Face files."""
+
 from pydantic import BaseModel
 from huggingface_hub import HfFileSystem
 
@@ -14,6 +16,19 @@ class HFFileRequest(BaseModel):
 
 
 def get_huggingface_file_infos(requests: list[HFFileRequest]) -> list[HFFileInfo]:
+    """Return file metadata for a list of ``repo_id``/``path`` pairs.
+
+    Parameters
+    ----------
+    requests:
+        A list of :class:`HFFileRequest` describing the files to query.
+
+    Returns
+    -------
+    list[HFFileInfo]
+        Metadata for each requested file, including its size in bytes.
+    """
+
     fs = HfFileSystem()
     file_infos = []
 


### PR DESCRIPTION
## Summary
- document Hugging Face helper modules
- link new docs page from API reference index
- add module docstring and function docs for `huggingface_file`

## Testing
- `pytest -q` *(fails: command not found)*