### PR TITLE
Add docs for RunPodWebSocketRunner

### DIFF
--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -3,3 +3,5 @@
 This section contains documentation generated from the source code.
 
 - [Workflows](workflows.md) - Core workflow classes and utilities.
+- [RunPodWebSocketRunner](runpod-websocket-runner.md) - Execute workflows on RunPod via WebSocket.
+

--- a/docs/api-reference/runpod-websocket-runner.md
+++ b/docs/api-reference/runpod-websocket-runner.md
@@ -1,0 +1,26 @@
+# nodetool.common.runpod_websocket_runner
+
+RunPod WebSocket Runner
+=======================
+
+The `RunPodWebSocketRunner` class allows executing workflows on a [RunPod](https://www.runpod.io/) endpoint over a WebSocket connection.
+It mirrors the behaviour of `WebSocketRunner` but delegates job execution to a remote RunPod endpoint using the RunPod HTTP API.
+
+Key features include:
+
+- WebSocket interface for running, cancelling and monitoring jobs
+- Streaming of RunPod job output in either MessagePack (binary) or JSON (text) format
+- Automatic mapping of RunPod status values to NodeTool job status
+- Support for cancelling jobs and switching modes at runtime
+
+Example usage:
+
+```python
+from nodetool.common.runpod_websocket_runner import RunPodWebSocketRunner
+
+runner = RunPodWebSocketRunner(endpoint_id="YOUR_ENDPOINT_ID")
+await runner.run(websocket)
+```
+
+See the source code for full details on all available methods.
+


### PR DESCRIPTION
## Summary
- document RunPod WebSocket runner class
- link new page from API reference index

## Testing
- `pre-commit run --files docs/api-reference/index.md docs/api-reference/runpod-websocket-runner.md` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*