### PR TITLE
Add get_size API for storages

### DIFF
--- a/src/nodetool/api/storage.py
+++ b/src/nodetool/api/storage.py
@@ -10,7 +10,6 @@ from fastapi import HTTPException
 from email.utils import parsedate_to_datetime
 from fastapi.responses import StreamingResponse
 from nodetool.api.utils import current_user
-from nodetool.storage.abstract_storage import AbstractStorage
 from nodetool.common.content_types import EXTENSION_TO_CONTENT_TYPE
 from nodetool.common.environment import Environment
 
@@ -97,7 +96,8 @@ async def get(key: str, request: Request):
             # If range is invalid, ignore it and return full content
             pass
 
-    # TODO: Add Content-Length header
+    size = await storage.get_size(key)
+    headers["Content-Length"] = str(size)
 
     return StreamingResponse(
         content=storage.download_stream(key),

--- a/src/nodetool/storage/abstract_storage.py
+++ b/src/nodetool/storage/abstract_storage.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import IO, AsyncIterator, Iterator
+from typing import IO, AsyncIterator
 from datetime import datetime
 
 
@@ -15,6 +15,10 @@ class AbstractStorage(ABC):
 
     @abstractmethod
     async def get_mtime(self, key: str) -> datetime:
+        pass
+
+    @abstractmethod
+    async def get_size(self, key: str) -> int:
         pass
 
     @abstractmethod

--- a/src/nodetool/storage/file_storage.py
+++ b/src/nodetool/storage/file_storage.py
@@ -1,8 +1,7 @@
 from datetime import datetime
 import os
-import shutil
 import aiofiles
-from typing import IO, AsyncIterator, Iterator
+from typing import IO, AsyncIterator
 
 from nodetool.storage.abstract_storage import AbstractStorage
 
@@ -33,6 +32,9 @@ class FileStorage(AbstractStorage):
             return datetime.fromtimestamp(mtime, tz=datetime.now().astimezone().tzinfo)
         except FileNotFoundError:
             return None
+
+    async def get_size(self, key: str) -> int:
+        return os.path.getsize(os.path.join(self.base_path, key))
 
     async def download_stream(self, key: str) -> AsyncIterator[bytes]:
         with open(os.path.join(self.base_path, key), "rb") as f:

--- a/src/nodetool/storage/memory_storage.py
+++ b/src/nodetool/storage/memory_storage.py
@@ -24,6 +24,12 @@ class MemoryStorage(AbstractStorage):
     async def get_mtime(self, key: str):
         return self.mtimes.get(key, datetime.now())
 
+    async def get_size(self, key: str) -> int:
+        if key in self.storage:
+            return len(self.storage[key])
+        else:
+            raise FileNotFoundError(f"File {key} not found")
+
     def download_stream(self, key: str) -> AsyncIterator[bytes]:
         if key in self.storage:
             return AsyncByteStream(self.storage[key])

--- a/src/nodetool/storage/s3_storage.py
+++ b/src/nodetool/storage/s3_storage.py
@@ -52,6 +52,12 @@ class S3Storage(AbstractStorage):
         )
         return response["LastModified"]
 
+    async def get_size(self, key: str) -> int:
+        response = await asyncio.to_thread(
+            self.s3.head_object, Bucket=self.bucket_name, Key=key
+        )
+        return response["ContentLength"]
+
     async def download(self, key: str, stream: IO):
         """
         Downloads a blob from the bucket.


### PR DESCRIPTION
## Summary
- add `get_size` to `AbstractStorage`
- implement `get_size` for FileStorage, MemoryStorage and S3Storage
- set `Content-Length` header in storage API using new method
- test `Content-Length` header for streamed assets

## Testing
- `./.venv/bin/python -m pytest -q tests`