### PR TITLE
Remove stray test.swift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ Thumbs.db
 *.csr.pem
 *.csr.pem.crt
 ffmpeg-release-amd64-static.tar.xz
+
+# Temporary local files
+tmp/

--- a/tmp/test.swift
+++ b/tmp/test.swift
@@ -1,1 +1,0 @@
-import UIKit


### PR DESCRIPTION
## Summary
- clean up `tmp/` test file
- ignore `tmp/` for future local experiments

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'nodetool.chat.tools')*
- `poetry run ruff check .` *(fails: found 391 errors)*
- `poetry run black --check .` *(fails: would reformat 10 files)*
- `poetry run mypy .` *(fails: module name shadowing)*