### PR TITLE
Improve context length handling

### DIFF
--- a/tests/agents/test_sub_task_context.py
+++ b/tests/agents/test_sub_task_context.py
@@ -94,3 +94,13 @@ def test_write_content_md(tmp_path):
         content = f.read()
     assert "title: My Note" in content
     assert "hello" in content
+
+
+def test_is_context_length_error_detection():
+    err1 = Exception("maximum context length is 4096 tokens")
+    err2 = Exception("Exceeded the token limit in context window")
+    err3 = Exception("some other error")
+
+    assert SubTaskContext._is_context_length_error(err1)
+    assert SubTaskContext._is_context_length_error(err2)
+    assert not SubTaskContext._is_context_length_error(err3)


### PR DESCRIPTION
## Summary
- add `_is_context_length_error` helper
- call error helper from `_process_iteration`
- test context-length error detection

## Testing
- `pre-commit run --files src/nodetool/agents/sub_task_context.py tests/agents/test_sub_task_context.py` *(fails: pre-commit not installed)*
- `pytest -q tests/agents/test_sub_task_context.py` *(fails: pytest not installed)*