### PR TITLE
Add docker workflow execution feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Option to run workflows inside Docker containers using the `docker_image`
+  parameter on `RunJobRequest`.
+- Workflow containers now receive all variables from local settings and secrets
+  files as environment variables.
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 

--- a/docs/workflow-api.md
+++ b/docs/workflow-api.md
@@ -151,6 +151,23 @@ socket.send(msgpack.encode({ command: "cancel_job" }));
 socket.send(msgpack.encode({ command: "get_status" }));
 ```
 
+### Running Workflows in Docker
+
+Set the `docker_image` field in `RunJobRequest` to execute a workflow inside a
+Docker container. The workspace directory is mounted at `/workspace` inside the
+container and the final results are written back to the host.
+All values from your local `settings.yaml` and `secrets.yaml` are injected as
+environment variables inside the container.
+
+```python
+req = RunJobRequest(
+    workflow_id="<workflow>",
+    docker_image="nodetool",
+)
+async for msg in run_workflow(req):
+    print(msg)
+```
+
 ## API Demo
 
 - Download the [html file](<(api-demo.html)>)

--- a/src/nodetool/workflows/docker_runner.py
+++ b/src/nodetool/workflows/docker_runner.py
@@ -1,0 +1,32 @@
+import asyncio
+import json
+import sys
+from uuid import uuid4
+
+from nodetool.workflows.processing_context import ProcessingContext
+from nodetool.workflows.run_job_request import RunJobRequest
+from nodetool.workflows.run_workflow import run_workflow
+from nodetool.workflows.workflow_runner import WorkflowRunner
+
+
+async def _run(cfg: dict) -> None:
+    context = ProcessingContext(workspace_dir=cfg["workspace_dir"])
+    req = RunJobRequest(**cfg["request"])
+    runner = WorkflowRunner(job_id=uuid4().hex)
+
+    async for _ in run_workflow(req, runner=runner, context=context):
+        pass
+
+    with open(cfg["result_path"], "w") as f:
+        json.dump(runner.outputs, f)
+
+
+def main() -> None:
+    config_path = sys.argv[1]
+    with open(config_path) as f:
+        cfg = json.load(f)
+    asyncio.run(_run(cfg))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nodetool/workflows/run_job_request.py
+++ b/src/nodetool/workflows/run_job_request.py
@@ -37,3 +37,4 @@ class RunJobRequest(BaseModel):
     env: dict[str, Any] | None = None
     graph: Graph | None = None
     explicit_types: bool | None = False
+    docker_image: str | None = None


### PR DESCRIPTION
## Summary
- enable specifying `docker_image` in `RunJobRequest`
- execute workflows in a Docker container when `docker_image` is set
- implement `docker_runner` module for workflow container execution
- pass variables from settings and secrets to the workflow container
- document Docker workflow execution
- note change in changelog

## Testing
- `ruff check src/nodetool/workflows/run_workflow.py`
- `black src/nodetool/workflows/run_workflow.py`
- `pytest -q`
