### PR TITLE
Implement pluggable configuration system

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -57,7 +57,6 @@ print(nodetool.__version__)
 
 This should print the version of NodeTool Core that you have installed.
 
-
 ## Configuration
 
 After installation, you might want to configure some aspects of NodeTool Core:

--- a/src/nodetool/api/settings.py
+++ b/src/nodetool/api/settings.py
@@ -1,16 +1,16 @@
 from fastapi import APIRouter, HTTPException
 from nodetool.common.environment import Environment
 from nodetool.common.settings import load_settings, save_settings
+from nodetool.common.configuration import Setting, get_settings_registry
 from pydantic import BaseModel
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 
 router = APIRouter(prefix="/api/settings", tags=["settings"])
 
 
 class SettingsResponse(BaseModel):
-    settings: Dict[str, Any]
-    secrets: Dict[str, Any]
+    settings: List[Setting]
 
 
 class SettingsUpdateRequest(BaseModel):
@@ -25,15 +25,15 @@ async def get_settings() -> SettingsResponse:
             status_code=403, detail="Settings cannot be read in production"
         )
 
-    settings, secrets = load_settings()
+    settings = get_settings_registry()
 
-    return SettingsResponse(settings=settings, secrets=secrets)
+    return SettingsResponse(settings=settings)
 
 
 @router.put("/")
 async def update_settings(
     req: SettingsUpdateRequest,
-) -> SettingsResponse:
+) -> Dict[str, str]:
     if Environment.is_production():
         raise HTTPException(
             status_code=403, detail="Settings cannot be updated in production"
@@ -48,4 +48,4 @@ async def update_settings(
 
     Environment.load_settings()
 
-    return SettingsResponse(settings=settings, secrets=secrets)
+    return {"message": "Settings updated successfully"}

--- a/src/nodetool/api/settings.py
+++ b/src/nodetool/api/settings.py
@@ -3,14 +3,23 @@ from nodetool.common.environment import Environment
 from nodetool.common.settings import load_settings, save_settings
 from nodetool.common.configuration import Setting, get_settings_registry
 from pydantic import BaseModel
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 router = APIRouter(prefix="/api/settings", tags=["settings"])
 
 
+class SettingWithValue(BaseModel):
+    package_name: str
+    env_var: str
+    group: str
+    description: str
+    is_secret: bool
+    value: Optional[Any] = None
+
+
 class SettingsResponse(BaseModel):
-    settings: List[Setting]
+    settings: List[SettingWithValue]
 
 
 class SettingsUpdateRequest(BaseModel):
@@ -25,9 +34,35 @@ async def get_settings() -> SettingsResponse:
             status_code=403, detail="Settings cannot be read in production"
         )
 
-    settings = get_settings_registry()
+    settings_registry = get_settings_registry()
+    current_settings, current_secrets = load_settings()
+    
+    settings_with_values = []
+    for setting in settings_registry:
+        value = None
+        if setting.is_secret:
+            # For secrets, create a placeholder matching the length of the actual value
+            secret_value = current_secrets.get(setting.env_var)
+            if secret_value:
+                value = "*" * len(str(secret_value))
+            else:
+                value = None
+        else:
+            # For non-secrets, return the actual value
+            value = current_settings.get(setting.env_var)
+        
+        settings_with_values.append(
+            SettingWithValue(
+                package_name=setting.package_name,
+                env_var=setting.env_var,
+                group=setting.group,
+                description=setting.description,
+                is_secret=setting.is_secret,
+                value=value
+            )
+        )
 
-    return SettingsResponse(settings=settings)
+    return SettingsResponse(settings=settings_with_values)
 
 
 @router.put("/")
@@ -41,8 +76,15 @@ async def update_settings(
 
     settings, secrets = load_settings()
 
+    # Update settings (non-secrets)
     settings.update(req.settings)
-    secrets.update(req.secrets)
+    
+    # Update secrets, but skip if the value is all asterisks (placeholder)
+    for key, value in req.secrets.items():
+        if value and isinstance(value, str) and all(c == '*' for c in value):
+            # Skip placeholder values - don't update the secret
+            continue
+        secrets[key] = value
 
     save_settings(settings, secrets)
 

--- a/src/nodetool/api/settings.py
+++ b/src/nodetool/api/settings.py
@@ -1,25 +1,21 @@
 from fastapi import APIRouter, HTTPException
 from nodetool.common.environment import Environment
-from nodetool.common.settings import (
-    load_settings,
-    save_settings,
-    SettingsModel,
-    SecretsModel,
-)
+from nodetool.common.settings import load_settings, save_settings
 from pydantic import BaseModel
+from typing import Any, Dict
 
 
 router = APIRouter(prefix="/api/settings", tags=["settings"])
 
 
 class SettingsResponse(BaseModel):
-    settings: SettingsModel
-    secrets: SecretsModel
+    settings: Dict[str, Any]
+    secrets: Dict[str, Any]
 
 
 class SettingsUpdateRequest(BaseModel):
-    settings: SettingsModel
-    secrets: SecretsModel
+    settings: Dict[str, Any]
+    secrets: Dict[str, Any]
 
 
 @router.get("/")
@@ -45,11 +41,8 @@ async def update_settings(
 
     settings, secrets = load_settings()
 
-    for key, value in req.settings.model_dump().items():
-        setattr(settings, key, value)
-
-    for key, value in req.secrets.model_dump().items():
-        setattr(secrets, key, value)
+    settings.update(req.settings)
+    secrets.update(req.secrets)
 
     save_settings(settings, secrets)
 

--- a/src/nodetool/common/configuration.py
+++ b/src/nodetool/common/configuration.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class Setting:
+    package_name: str
+    env_var: str
+    group: str
+    description: str
+    is_secret: bool
+
+
+_registry: List[Setting] = []
+
+
+def register_setting(
+    package_name: str,
+    env_var: str,
+    group: str,
+    description: str,
+    is_secret: bool,
+) -> List[Setting]:
+    """Register a new setting.
+
+    Parameters
+    ----------
+    package_name: str
+        Name of the package registering the setting.
+    env_var: str
+        The environment variable name.
+    group: str
+        Group the setting belongs to.
+    description: str
+        Human readable description of the setting.
+    is_secret: bool
+        Flag indicating if the setting contains secrets.
+
+    Returns
+    -------
+    List[Setting]
+        The list of all registered settings.
+    """
+    setting = Setting(package_name, env_var, group, description, is_secret)
+    _registry.append(setting)
+    return list(_registry)
+
+
+def get_settings_registry() -> List[Setting]:
+    """Return the list of all registered settings."""
+    return list(_registry)

--- a/src/nodetool/common/environment.py
+++ b/src/nodetool/common/environment.py
@@ -7,8 +7,6 @@ from nodetool.common.nodetool_api_client import (
 )
 from nodetool.storage.abstract_node_cache import AbstractNodeCache
 from nodetool.common.settings import (
-    SecretsModel,
-    SettingsModel,
     get_system_data_path,
     load_settings,
     get_value,
@@ -86,8 +84,8 @@ class Environment(object):
     development purposes.
     """
 
-    settings: SettingsModel | None = None
-    secrets: SecretsModel | None = None
+    settings: dict[str, Any] | None = None
+    secrets: dict[str, Any] | None = None
     remote_auth: bool = True
 
     @classmethod
@@ -116,10 +114,10 @@ class Environment(object):
         env = DEFAULT_ENV.copy()
         env.update(os.environ)
 
-        for k, v in settings.model_dump().items():
+        for k, v in settings.items():
             if v is not None:
                 env[k] = v
-        for k, v in secrets.model_dump().items():
+        for k, v in secrets.items():
             if v is not None:
                 env[k] = v
 

--- a/src/nodetool/common/settings.py
+++ b/src/nodetool/common/settings.py
@@ -1,34 +1,14 @@
-"""
-Settings management module for nodetool application.
+"""Utility functions for reading and writing configuration files."""
 
-This module provides functionality for managing application settings and secrets
-across different operating systems. It handles:
-
-- Loading/saving settings and secrets from YAML files
-- OS-specific file path resolution for configuration files
-- Environment variable fallbacks
-- Type-safe configuration via Pydantic models
-
-Key components:
-- SettingsModel: Application configuration settings
-- SecretsModel: Sensitive credentials and API keys
-- File locations:
-  - Linux/Mac: ~/.config/nodetool/
-  - Windows: %APPDATA%/nodetool/
-- Data locations:
-  - Linux/Mac: ~/.local/share/nodetool/
-  - Windows: %LOCALAPPDATA%/nodetool/
-
-Usage:
-    settings, secrets = load_settings()
-    value = get_value("API_KEY", settings, secrets, default_env={})
-"""
+from __future__ import annotations
 
 import os
-import yaml
 from pathlib import Path
 from typing import Any, Dict, Tuple
-from pydantic import BaseModel, Field
+
+import yaml
+
+from nodetool.common.configuration import register_setting
 
 # Constants
 SETTINGS_FILE = "settings.yaml"
@@ -36,162 +16,231 @@ SECRETS_FILE = "secrets.yaml"
 MISSING_MESSAGE = "Missing required environment variable: {}"
 NOT_GIVEN = object()
 
+# Built-in settings and secrets are registered here so that other packages can
+# extend the configuration system via :func:`register_setting`.
 
-class SettingsModel(BaseModel):
-    FONT_PATH: str | None = Field(
-        default=None,
-        description="Location of font folder used by image processing nodes like RenderText. "
+# Settings
+register_setting(
+    package_name="nodetool",
+    env_var="FONT_PATH",
+    group="settings",
+    description=(
+        "Location of font folder used by image processing nodes like RenderText. "
         "This should point to a directory containing TrueType (.ttf) or OpenType (.otf) fonts. "
-        "If not specified, the system will use default fonts.",
-    )
-    COMFY_FOLDER: str | None = Field(
-        default=None,
-        description="Location of ComfyUI folder for integration with ComfyUI models and workflows. "
+        "If not specified, the system will use default fonts."
+    ),
+    is_secret=False,
+)
+register_setting(
+    package_name="nodetool",
+    env_var="COMFY_FOLDER",
+    group="settings",
+    description=(
+        "Location of ComfyUI folder for integration with ComfyUI models and workflows. "
         "Set this to use models from your existing ComfyUI installation. "
-        "This allows nodetool to access and use models, checkpoints, and other resources "
-        "from your ComfyUI setup without duplicating files.",
-    )
-    CHROMA_PATH: str | None = Field(
-        default=None,
-        description="Location of ChromaDB folder for vector database storage. "
+        "This allows nodetool to access resources from your ComfyUI setup without duplicating files."
+    ),
+    is_secret=False,
+)
+register_setting(
+    package_name="nodetool",
+    env_var="CHROMA_PATH",
+    group="settings",
+    description=(
+        "Location of ChromaDB folder for vector database storage. "
         "ChromaDB is used to store and retrieve embeddings for semantic search and RAG applications. "
-        "This can be any folder path - ChromaDB will create and manage the storage automatically. "
-        "In Docker deployments, this path is mounted as a volume to persist data between container restarts.",
-    )
+        "In Docker deployments, this path is mounted as a volume to persist data between container restarts."
+    ),
+    is_secret=False,
+)
+
+# Secrets
+register_setting(
+    package_name="nodetool",
+    env_var="OPENAI_API_KEY",
+    group="secrets",
+    description="OpenAI API key for accessing GPT models, DALL-E, and other OpenAI services",
+    is_secret=True,
+)
+register_setting(
+    package_name="nodetool",
+    env_var="ANTHROPIC_API_KEY",
+    group="secrets",
+    description="Anthropic API key for accessing Claude models and other Anthropic services",
+    is_secret=True,
+)
+register_setting(
+    package_name="nodetool",
+    env_var="HF_TOKEN",
+    group="secrets",
+    description="Hugging Face Token for accessing gated or private models on the Hugging Face Hub",
+    is_secret=True,
+)
+register_setting(
+    package_name="nodetool",
+    env_var="REPLICATE_API_TOKEN",
+    group="secrets",
+    description="Replicate API Token for running models on Replicate's cloud infrastructure",
+    is_secret=True,
+)
+register_setting(
+    package_name="nodetool",
+    env_var="AIME_USER",
+    group="secrets",
+    description="Aime user credential for authentication with Aime services",
+    is_secret=True,
+)
+register_setting(
+    package_name="nodetool",
+    env_var="AIME_API_KEY",
+    group="secrets",
+    description="Aime API key for accessing Aime AI services",
+    is_secret=True,
+)
+register_setting(
+    package_name="nodetool",
+    env_var="GOOGLE_MAIL_USER",
+    group="secrets",
+    description="Google mail user for email integration features",
+    is_secret=True,
+)
+register_setting(
+    package_name="nodetool",
+    env_var="GOOGLE_APP_PASSWORD",
+    group="secrets",
+    description="Google app password for secure authentication with Google services",
+    is_secret=True,
+)
+register_setting(
+    package_name="nodetool",
+    env_var="GEMINI_API_KEY",
+    group="secrets",
+    description="Gemini API key for accessing Google's Gemini AI models",
+    is_secret=True,
+)
+register_setting(
+    package_name="nodetool",
+    env_var="ELEVENLABS_API_KEY",
+    group="secrets",
+    description="ElevenLabs API key for high-quality text-to-speech services",
+    is_secret=True,
+)
+register_setting(
+    package_name="nodetool",
+    env_var="FAL_API_KEY",
+    group="secrets",
+    description="FAL API key for accessing FAL.ai's serverless AI infrastructure",
+    is_secret=True,
+)
+register_setting(
+    package_name="nodetool",
+    env_var="SERPAPI_API_KEY",
+    group="secrets",
+    description="API key for accessing SerpAPI scraping infrastructure",
+    is_secret=True,
+)
+register_setting(
+    package_name="nodetool",
+    env_var="BROWSER_URL",
+    group="secrets",
+    description="Browser URL for accessing a browser instance",
+    is_secret=True,
+)
+register_setting(
+    package_name="nodetool",
+    env_var="DATA_FOR_SEO_LOGIN",
+    group="secrets",
+    description="DataForSEO login for accessing DataForSEO's API",
+    is_secret=True,
+)
+register_setting(
+    package_name="nodetool",
+    env_var="DATA_FOR_SEO_PASSWORD",
+    group="secrets",
+    description="DataForSEO password for accessing DataForSEO's API",
+    is_secret=True,
+)
 
 
-class SecretsModel(BaseModel):
-    OPENAI_API_KEY: str | None = Field(
-        default=None,
-        description="OpenAI API key for accessing GPT models, DALL-E, and other OpenAI services",
-    )
-    ANTHROPIC_API_KEY: str | None = Field(
-        default=None,
-        description="Anthropic API key for accessing Claude models and other Anthropic services",
-    )
-    HF_TOKEN: str | None = Field(
-        default=None,
-        description="Hugging Face Token for accessing gated or private models on the Hugging Face Hub",
-    )
-    REPLICATE_API_TOKEN: str | None = Field(
-        default=None,
-        description="Replicate API Token for running models on Replicate's cloud infrastructure",
-    )
-    AIME_USER: str | None = Field(
-        default=None,
-        description="Aime user credential for authentication with Aime services",
-    )
-    AIME_API_KEY: str | None = Field(
-        default=None, description="Aime API key for accessing Aime AI services"
-    )
-    GOOGLE_MAIL_USER: str | None = Field(
-        default=None, description="Google mail user for email integration features"
-    )
-    GOOGLE_APP_PASSWORD: str | None = Field(
-        default=None,
-        description="Google app password for secure authentication with Google services",
-    )
-    GEMINI_API_KEY: str | None = Field(
-        default=None,
-        description="Gemini API key for accessing Google's Gemini AI models",
-    )
-    ELEVENLABS_API_KEY: str | None = Field(
-        default=None,
-        description="ElevenLabs API key for high-quality text-to-speech services",
-    )
-    FAL_API_KEY: str | None = Field(
-        default=None,
-        description="FAL API key for accessing FAL.ai's serverless AI infrastructure",
-    )
-    SERPAPI_API_KEY: str | None = Field(
-        default=None,
-        description="API key for accessing SerpAPI scraping infrastructure",
-    )
-    BROWSER_URL: str | None = Field(
-        default=None,
-        description="Browser URL for accessing a browser instance",
-    )
-    DATA_FOR_SEO_LOGIN: str | None = Field(
-        default=None,
-        description="DataForSEO login for accessing DataForSEO's API",
-    )
-    DATA_FOR_SEO_PASSWORD: str | None = Field(
-        default=None,
-        description="DataForSEO password for accessing DataForSEO's API",
-    )
+# Mapping of all descriptions for CLI display
+SETTING_DESCRIPTIONS = {
+    "FONT_PATH": "Location of font folder used by image processing nodes like RenderText. This should point to a directory containing TrueType (.ttf) or OpenType (.otf) fonts. If not specified, the system will use default fonts.",
+    "COMFY_FOLDER": "Location of ComfyUI folder for integration with ComfyUI models and workflows. Set this to use models from your existing ComfyUI installation. This allows nodetool to access resources from your ComfyUI setup without duplicating files.",
+    "CHROMA_PATH": "Location of ChromaDB folder for vector database storage. ChromaDB is used to store and retrieve embeddings for semantic search and RAG applications. In Docker deployments, this path is mounted as a volume to persist data between container restarts.",
+}
+SECRET_DESCRIPTIONS = {
+    "OPENAI_API_KEY": "OpenAI API key for accessing GPT models, DALL-E, and other OpenAI services",
+    "ANTHROPIC_API_KEY": "Anthropic API key for accessing Claude models and other Anthropic services",
+    "HF_TOKEN": "Hugging Face Token for accessing gated or private models on the Hugging Face Hub",
+    "REPLICATE_API_TOKEN": "Replicate API Token for running models on Replicate's cloud infrastructure",
+    "AIME_USER": "Aime user credential for authentication with Aime services",
+    "AIME_API_KEY": "Aime API key for accessing Aime AI services",
+    "GOOGLE_MAIL_USER": "Google mail user for email integration features",
+    "GOOGLE_APP_PASSWORD": "Google app password for secure authentication with Google services",
+    "GEMINI_API_KEY": "Gemini API key for accessing Google's Gemini AI models",
+    "ELEVENLABS_API_KEY": "ElevenLabs API key for high-quality text-to-speech services",
+    "FAL_API_KEY": "FAL API key for accessing FAL.ai's serverless AI infrastructure",
+    "SERPAPI_API_KEY": "API key for accessing SerpAPI scraping infrastructure",
+    "BROWSER_URL": "Browser URL for accessing a browser instance",
+    "DATA_FOR_SEO_LOGIN": "DataForSEO login for accessing DataForSEO's API",
+    "DATA_FOR_SEO_PASSWORD": "DataForSEO password for accessing DataForSEO's API",
+}
+ALL_DESCRIPTIONS = {**SETTING_DESCRIPTIONS, **SECRET_DESCRIPTIONS}
 
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
 
 def get_system_file_path(filename: str) -> Path:
-    """
-    Returns the path to the settings file for the current OS.
-    """
+    """Return the path to the configuration file for the current OS."""
     import platform
 
     os_name = platform.system()
-    if os_name == "Linux" or os_name == "Darwin":
+    if os_name in {"Linux", "Darwin"}:
         return Path.home() / ".config" / "nodetool" / filename
     elif os_name == "Windows":
         appdata = os.getenv("APPDATA")
         if appdata is not None:
             return Path(appdata) / "nodetool" / filename
-        else:
-            return Path("data") / filename
-    else:
         return Path("data") / filename
+    return Path("data") / filename
 
 
 def get_system_data_path(filename: str) -> Path:
-    """
-    Returns the path to the data folder for the current OS.
-    """
+    """Return the path to the data folder for the current OS."""
     import platform
 
     os_name = platform.system()
-    if os_name == "Linux" or os_name == "Darwin":
+    if os_name in {"Linux", "Darwin"}:
         return Path.home() / ".local" / "share" / "nodetool" / filename
     elif os_name == "Windows":
         appdata = os.getenv("LOCALAPPDATA")
         if appdata is not None:
             return Path(appdata) / "nodetool" / filename
-        else:
-            return Path("data") / filename
-    else:
         return Path("data") / filename
+    return Path("data") / filename
 
 
 def get_log_path(filename: str) -> Path:
-    """
-    Returns the path to the log file for the current OS.
-
-    Logs are stored in:
-    - Linux/Mac: ~/.local/share/nodetool/logs/
-    - Windows: %LOCALAPPDATA%/nodetool/logs/
-    - Other: ./data/logs/
-
-    Args:
-        filename: Name of the log file
-
-    Returns:
-        Path object representing the full path to the log file
-    """
+    """Return the path to the log file for the current OS."""
     base_data_path = get_system_data_path("")
     log_dir = base_data_path / "logs"
-
-    # Ensure the logs directory exists
     os.makedirs(log_dir, exist_ok=True)
-
     return log_dir / filename
 
 
-def load_settings() -> Tuple[SettingsModel, SecretsModel]:
-    """
-    Load the settings from the settings file and the secrets from the secrets file.
-    """
+# ---------------------------------------------------------------------------
+# Settings helpers
+# ---------------------------------------------------------------------------
+
+def load_settings() -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Load settings and secrets from YAML files."""
     settings_file = get_system_file_path(SETTINGS_FILE)
     secrets_file = get_system_file_path(SECRETS_FILE)
 
-    settings = {}
-    secrets = {}
+    settings: Dict[str, Any] = {}
+    secrets: Dict[str, Any] = {}
 
     if settings_file.exists():
         with open(settings_file, "r") as f:
@@ -201,43 +250,33 @@ def load_settings() -> Tuple[SettingsModel, SecretsModel]:
         with open(secrets_file, "r") as f:
             secrets = yaml.safe_load(f) or {}
 
-    return SettingsModel(**settings), SecretsModel(**secrets)
+    return settings, secrets
 
 
-def save_settings(settings: SettingsModel, secrets: SecretsModel):
-    """
-    Save the user settings to the settings file and the user secrets to the secrets file.
-    """
+def save_settings(settings: Dict[str, Any], secrets: Dict[str, Any]) -> None:
+    """Save settings and secrets to their respective YAML files."""
     settings_file = get_system_file_path(SETTINGS_FILE)
     secrets_file = get_system_file_path(SECRETS_FILE)
-
-    print(f"Saving settings to {settings_file}")
-    print(f"Saving secrets to {secrets_file}")
 
     os.makedirs(os.path.dirname(settings_file), exist_ok=True)
     os.makedirs(os.path.dirname(secrets_file), exist_ok=True)
 
     with open(settings_file, "w") as f:
-        yaml.dump(settings.model_dump(), f)
+        yaml.dump(settings, f)
 
     with open(secrets_file, "w") as f:
-        yaml.dump(secrets.model_dump(), f)
+        yaml.dump(secrets, f)
 
 
 def get_value(
     key: str,
-    settings: SettingsModel,
-    secrets: SecretsModel,
+    settings: Dict[str, Any],
+    secrets: Dict[str, Any],
     default_env: Dict[str, Any],
     default: Any = NOT_GIVEN,
 ) -> Any:
-    """
-    Get the value of an environment variable, or a default value.
-
-    If the environment variable is not set, and the key is not in the
-    default values, raise an exception.
-    """
-    value = secrets.model_dump().get(key) or settings.model_dump().get(key)
+    """Retrieve a configuration value from secrets, settings, or environment."""
+    value = secrets.get(key) or settings.get(key)
     if value is None or str(value) == "":
         value = os.environ.get(key)
 
@@ -246,5 +285,5 @@ def get_value(
 
     if value is not NOT_GIVEN:
         return value
-    else:
-        raise Exception(MISSING_MESSAGE.format(key))
+    raise Exception(MISSING_MESSAGE.format(key))
+

--- a/src/nodetool/common/settings.py
+++ b/src/nodetool/common/settings.py
@@ -23,7 +23,7 @@ NOT_GIVEN = object()
 register_setting(
     package_name="nodetool",
     env_var="FONT_PATH",
-    group="settings",
+    group="Folders",
     description=(
         "Location of font folder used by image processing nodes like RenderText. "
         "This should point to a directory containing TrueType (.ttf) or OpenType (.otf) fonts. "
@@ -34,7 +34,7 @@ register_setting(
 register_setting(
     package_name="nodetool",
     env_var="COMFY_FOLDER",
-    group="settings",
+    group="Folders",
     description=(
         "Location of ComfyUI folder for integration with ComfyUI models and workflows. "
         "Set this to use models from your existing ComfyUI installation. "
@@ -45,7 +45,7 @@ register_setting(
 register_setting(
     package_name="nodetool",
     env_var="CHROMA_PATH",
-    group="settings",
+    group="Folders",
     description=(
         "Location of ChromaDB folder for vector database storage. "
         "ChromaDB is used to store and retrieve embeddings for semantic search and RAG applications. "
@@ -58,139 +58,114 @@ register_setting(
 register_setting(
     package_name="nodetool",
     env_var="OPENAI_API_KEY",
-    group="secrets",
+    group="LLM",
     description="OpenAI API key for accessing GPT models, DALL-E, and other OpenAI services",
     is_secret=True,
 )
 register_setting(
     package_name="nodetool",
     env_var="ANTHROPIC_API_KEY",
-    group="secrets",
+    group="LLM",
     description="Anthropic API key for accessing Claude models and other Anthropic services",
     is_secret=True,
 )
 register_setting(
     package_name="nodetool",
+    env_var="GEMINI_API_KEY",
+    group="LLM",
+    description="Gemini API key for accessing Google's Gemini AI models",
+    is_secret=True,
+)
+register_setting(
+    package_name="nodetool",
     env_var="HF_TOKEN",
-    group="secrets",
+    group="Hugging Face",
     description="Hugging Face Token for accessing gated or private models on the Hugging Face Hub",
     is_secret=True,
 )
 register_setting(
     package_name="nodetool",
     env_var="REPLICATE_API_TOKEN",
-    group="secrets",
+    group="Replicate",
     description="Replicate API Token for running models on Replicate's cloud infrastructure",
     is_secret=True,
 )
 register_setting(
     package_name="nodetool",
     env_var="AIME_USER",
-    group="secrets",
+    group="Aime",
     description="Aime user credential for authentication with Aime services",
     is_secret=True,
 )
 register_setting(
     package_name="nodetool",
     env_var="AIME_API_KEY",
-    group="secrets",
+    group="Aime",
     description="Aime API key for accessing Aime AI services",
     is_secret=True,
 )
 register_setting(
     package_name="nodetool",
     env_var="GOOGLE_MAIL_USER",
-    group="secrets",
+    group="Google",
     description="Google mail user for email integration features",
     is_secret=True,
 )
 register_setting(
     package_name="nodetool",
     env_var="GOOGLE_APP_PASSWORD",
-    group="secrets",
+    group="Google",
     description="Google app password for secure authentication with Google services",
     is_secret=True,
 )
 register_setting(
     package_name="nodetool",
-    env_var="GEMINI_API_KEY",
-    group="secrets",
-    description="Gemini API key for accessing Google's Gemini AI models",
-    is_secret=True,
-)
-register_setting(
-    package_name="nodetool",
     env_var="ELEVENLABS_API_KEY",
-    group="secrets",
+    group="ElevenLabs",
     description="ElevenLabs API key for high-quality text-to-speech services",
     is_secret=True,
 )
 register_setting(
     package_name="nodetool",
     env_var="FAL_API_KEY",
-    group="secrets",
+    group="FAL",
     description="FAL API key for accessing FAL.ai's serverless AI infrastructure",
     is_secret=True,
 )
 register_setting(
     package_name="nodetool",
     env_var="SERPAPI_API_KEY",
-    group="secrets",
+    group="SerpAPI",
     description="API key for accessing SerpAPI scraping infrastructure",
     is_secret=True,
 )
 register_setting(
     package_name="nodetool",
     env_var="BROWSER_URL",
-    group="secrets",
+    group="Browser",
     description="Browser URL for accessing a browser instance",
     is_secret=True,
 )
 register_setting(
     package_name="nodetool",
     env_var="DATA_FOR_SEO_LOGIN",
-    group="secrets",
+    group="DataForSEO",
     description="DataForSEO login for accessing DataForSEO's API",
     is_secret=True,
 )
 register_setting(
     package_name="nodetool",
     env_var="DATA_FOR_SEO_PASSWORD",
-    group="secrets",
+    group="DataForSEO",
     description="DataForSEO password for accessing DataForSEO's API",
     is_secret=True,
 )
 
 
-# Mapping of all descriptions for CLI display
-SETTING_DESCRIPTIONS = {
-    "FONT_PATH": "Location of font folder used by image processing nodes like RenderText. This should point to a directory containing TrueType (.ttf) or OpenType (.otf) fonts. If not specified, the system will use default fonts.",
-    "COMFY_FOLDER": "Location of ComfyUI folder for integration with ComfyUI models and workflows. Set this to use models from your existing ComfyUI installation. This allows nodetool to access resources from your ComfyUI setup without duplicating files.",
-    "CHROMA_PATH": "Location of ChromaDB folder for vector database storage. ChromaDB is used to store and retrieve embeddings for semantic search and RAG applications. In Docker deployments, this path is mounted as a volume to persist data between container restarts.",
-}
-SECRET_DESCRIPTIONS = {
-    "OPENAI_API_KEY": "OpenAI API key for accessing GPT models, DALL-E, and other OpenAI services",
-    "ANTHROPIC_API_KEY": "Anthropic API key for accessing Claude models and other Anthropic services",
-    "HF_TOKEN": "Hugging Face Token for accessing gated or private models on the Hugging Face Hub",
-    "REPLICATE_API_TOKEN": "Replicate API Token for running models on Replicate's cloud infrastructure",
-    "AIME_USER": "Aime user credential for authentication with Aime services",
-    "AIME_API_KEY": "Aime API key for accessing Aime AI services",
-    "GOOGLE_MAIL_USER": "Google mail user for email integration features",
-    "GOOGLE_APP_PASSWORD": "Google app password for secure authentication with Google services",
-    "GEMINI_API_KEY": "Gemini API key for accessing Google's Gemini AI models",
-    "ELEVENLABS_API_KEY": "ElevenLabs API key for high-quality text-to-speech services",
-    "FAL_API_KEY": "FAL API key for accessing FAL.ai's serverless AI infrastructure",
-    "SERPAPI_API_KEY": "API key for accessing SerpAPI scraping infrastructure",
-    "BROWSER_URL": "Browser URL for accessing a browser instance",
-    "DATA_FOR_SEO_LOGIN": "DataForSEO login for accessing DataForSEO's API",
-    "DATA_FOR_SEO_PASSWORD": "DataForSEO password for accessing DataForSEO's API",
-}
-ALL_DESCRIPTIONS = {**SETTING_DESCRIPTIONS, **SECRET_DESCRIPTIONS}
-
-
 # ---------------------------------------------------------------------------
 # Path helpers
 # ---------------------------------------------------------------------------
+
 
 def get_system_file_path(filename: str) -> Path:
     """Return the path to the configuration file for the current OS."""
@@ -233,6 +208,7 @@ def get_log_path(filename: str) -> Path:
 # ---------------------------------------------------------------------------
 # Settings helpers
 # ---------------------------------------------------------------------------
+
 
 def load_settings() -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """Load settings and secrets from YAML files."""
@@ -286,4 +262,3 @@ def get_value(
     if value is not NOT_GIVEN:
         return value
     raise Exception(MISSING_MESSAGE.format(key))
-

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,7 +1,7 @@
 from click.testing import CliRunner
 
 from nodetool.cli import cli
-from nodetool.common.settings import SettingsModel, SecretsModel
+from nodetool.common.settings import load_settings
 
 
 def test_cli_help():
@@ -13,7 +13,7 @@ def test_cli_help():
 
 def test_show_settings(monkeypatch):
     def fake_load_settings():
-        return SettingsModel(FONT_PATH="/fonts"), SecretsModel()
+        return {"FONT_PATH": "/fonts"}, {}
 
     monkeypatch.setattr(
         "nodetool.common.settings.load_settings", fake_load_settings
@@ -21,13 +21,13 @@ def test_show_settings(monkeypatch):
     runner = CliRunner()
     result = runner.invoke(cli, ["settings", "show"])
     assert result.exit_code == 0
-    assert "Settings from SettingsModel" in result.output
+    assert "Settings" in result.output
     assert "/fonts" in result.output
 
 
 def test_show_secrets_mask(monkeypatch):
     def fake_load_settings():
-        return SettingsModel(), SecretsModel(OPENAI_API_KEY="secret")
+        return {}, {"OPENAI_API_KEY": "secret"}
 
     monkeypatch.setattr(
         "nodetool.common.settings.load_settings", fake_load_settings
@@ -35,7 +35,7 @@ def test_show_secrets_mask(monkeypatch):
     runner = CliRunner()
     result = runner.invoke(cli, ["settings", "show", "--secrets", "--mask"])
     assert result.exit_code == 0
-    assert "Secrets from SecretsModel" in result.output
+    assert "Secrets" in result.output
     assert "****" in result.output
 
 

--- a/tests/common/test_configuration.py
+++ b/tests/common/test_configuration.py
@@ -1,0 +1,12 @@
+from nodetool.common.configuration import register_setting
+
+
+def test_register_setting():
+    regs = register_setting(
+        package_name="testpkg",
+        env_var="VAR1",
+        group="general",
+        description="desc",
+        is_secret=False,
+    )
+    assert any(s.env_var == "VAR1" and s.package_name == "testpkg" for s in regs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ from fastapi.testclient import TestClient
 import httpx
 import pytest
 from nodetool.api.server import create_app
-from nodetool.common.settings import SettingsModel
 from nodetool.storage.memory_storage import MemoryStorage
 from nodetool.types.graph import Node, Edge
 from nodetool.common.environment import Environment


### PR DESCRIPTION
## Summary
- create a `Setting` registry and retrieval helpers
- replace `SettingsModel`/`SecretsModel` with YAML-backed dictionaries
- adjust CLI and API to use new configuration system
- update tests for the new API

## Testing
- `pytest -q`
