### PR TITLE
Add manual workflow for coding agent example

### DIFF
--- a/.github/workflows/coding-agent.yml
+++ b/.github/workflows/coding-agent.yml
@@ -1,0 +1,32 @@
+name: Run Coding Agent Example
+
+on:
+  workflow_dispatch:
+
+jobs:
+  coding-agent:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install FFmpeg via apt-get
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+          echo "FFmpeg version:"
+          ffmpeg -version
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: |
+          uv pip install --system .
+
+      - name: Run Coding Agent Example
+        run: python examples/test_coding_agent.py


### PR DESCRIPTION
## Summary
- add a manual GitHub workflow to run the coding agent example

## Testing
- `poetry run pytest -q` *(fails: Command not found)*