### PR TITLE
Add missing documentation pages

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,14 @@
+# Agent System
+
+NodeTool includes an agent framework that breaks complex objectives into smaller subtasks.
+Agents use language models and tools to accomplish each step.
+
+Key features include:
+
+- **Smart Task Planning** – objectives are converted into structured plans.
+- **Tool Integration** – built in tools for web browsing, file management and more.
+- **Independent Subtasks** – each subtask runs in its own context for reliability.
+- **Parallel Execution** – independent tasks can run concurrently.
+- **Workspace** – subtasks read and write files in a dedicated workspace directory.
+
+See the source [README](../src/nodetool/agents/README.md) for a detailed architecture overview and example usage.

--- a/docs/api-server.md
+++ b/docs/api-server.md
@@ -1,0 +1,13 @@
+# API Server Overview
+
+The API package implements a FastAPI server used by the NodeTool application. It exposes HTTP endpoints and WebSocket handlers for managing workflows, jobs and assets.
+
+Important modules:
+
+- **server.py** – creates the FastAPI app and registers routers
+- **workflow.py** – CRUD operations for workflows
+- **job.py** – query job status and results
+- **asset.py** – manage uploaded files
+- **runpod_* handlers** – WebSocket runners for remote execution
+
+The full description is available in the [API README](../src/nodetool/api/README.md).

--- a/docs/chat-providers.md
+++ b/docs/chat-providers.md
@@ -1,0 +1,16 @@
+# Chat Providers
+
+Chat providers translate between NodeTool messages and specific LLM APIs.
+Current implementations include OpenAI, Anthropic, Gemini and Ollama.
+
+Each provider supports streaming responses and optional tool calls.
+The table below summarises key features:
+
+| Feature | OpenAI | Anthropic | Gemini | Ollama |
+| ------- | ------ | --------- | ------ | ------ |
+| Streaming | ✅ | ✅ | ✅ | ✅ |
+| Tool Calls | ✅ | ✅ | ✅ | ✅ (model dependent) |
+| JSON Mode | ✅ | ✅ | ✅ | ✅ |
+| API Key Required | ✅ | ✅ | ✅ | Optional |
+
+See [providers README](../src/nodetool/chat/providers/README.md) for more information.

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -1,0 +1,13 @@
+# Chat Module
+
+The chat module provides an interactive command line interface and utilities for conversational AI.
+It supports multiple providers like OpenAI, Anthropic, Gemini and Ollama, and integrates various tools that the assistant can call during a chat session.
+
+Main features:
+
+- Interactive CLI with history and auto-completion
+- Sandboxed workspace for file operations
+- Support for provider specific models
+- Optional agent mode for tool-augmented conversations
+
+For details see the [chat README](../src/nodetool/chat/README.md) and the [Chat CLI guide](chat-cli.md).

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,0 +1,3 @@
+# Core Concepts
+
+- [Key Concepts](key-concepts.md)

--- a/docs/concepts/key-concepts.md
+++ b/docs/concepts/key-concepts.md
@@ -1,0 +1,11 @@
+# Key Concepts
+
+NodeTool workflows are represented as **Directed Acyclic Graphs (DAGs)**. Each node performs a unit of work and passes data to the next node.
+
+- **Nodes** – Encapsulate a specific operation. Nodes have inputs, outputs and configurable properties.
+- **Graph** – A collection of nodes and their connections. Use `graph()` to build graphs and `run_graph()` to execute them.
+- **DSL** – NodeTool provides a Python domain specific language with modules for different domains (`nodetool.dsl.chroma`, `nodetool.dsl.google`, ...).
+- **WorkflowRunner** – The engine that executes graphs. It handles parallel execution, GPU management and progress updates.
+- **ProcessingContext** – Holds runtime information like user data and authentication tokens.
+
+Understanding these concepts will help you design efficient workflows and build your own nodes and agents.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,3 +1,4 @@
 # Getting Started
 
 - [Installation](installation.md)
+- [Quick Start](quick-start.md)

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,0 +1,40 @@
+# Quick Start Guide
+
+This page shows how to install NodeTool Core and run a simple workflow.
+
+## Installation
+
+```bash
+# Install using pip
+pip install nodetool-core
+
+# Or with Poetry
+poetry add nodetool-core
+```
+
+## Basic Usage
+
+```python
+import asyncio
+from nodetool.dsl.graph import graph, run_graph
+from nodetool.dsl.providers.openai import ChatCompletion
+from nodetool.metadata.types import OpenAIModel
+
+# Create a simple workflow
+workflow = ChatCompletion(
+    model=OpenAIModel(model="gpt-4"),
+    messages=[{"role": "user", "content": "Explain quantum computing in simple terms"}],
+)
+
+# Run the workflow
+result = asyncio.run(run_graph(graph(workflow)))
+print(result)
+```
+
+## CLI Usage
+
+```bash
+python -m nodetool.cli --help
+```
+
+See [CLI Reference](../cli.md) for all commands.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,10 +32,14 @@ The documentation is organized into the following sections:
 - [**Getting Started**](getting-started/index.md) - Guides for new users
 - [**Concepts**](concepts/index.md) - Core concepts and architecture
 - [**API Reference**](api-reference/index.md) - Detailed API documentation
+- [**API Server**](api-server.md) - Overview of the FastAPI backend
 - [**Workflow API**](workflow-api.md) - How to call workflows programmatically
 - [**Chat WebSocket API**](chat-api.md) - Real time chat endpoint
 - [**CLI Reference**](cli.md) - Command line usage
 - [**Chat CLI**](chat-cli.md) - Interactive chat application
+- [**Agents**](agents.md) - Multi-step agent framework
+- [**Chat Module**](chat.md) - Conversational interface
+- [**Chat Providers**](chat-providers.md) - Supported LLM backends
 - [**Examples**](../examples/README.md) - Example workflows
 
 ## Community


### PR DESCRIPTION
## Summary
- add Quick Start guide
- document key concepts of the workflow system
- include overview pages for agents, chat, providers and API server
- link new pages from the documentation index

## Testing
- `pytest -q`