### PR TITLE
Fix API key for agent workflow

### DIFF
--- a/.github/workflows/coding-agent.yml
+++ b/.github/workflows/coding-agent.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   coding-agent:
     runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## Summary
- expose the OPENAI_API_KEY in coding-agent workflow

## Testing
- `pytest -q`