### PR TITLE
Add Docker agent endpoint example

### DIFF
--- a/docs/docker-agent-endpoint.md
+++ b/docs/docker-agent-endpoint.md
@@ -1,0 +1,75 @@
+# Docker Agent Endpoint
+
+This guide shows how to package a simple NodeTool agent as a small API service.
+The service exposes one HTTP endpoint that runs the agent and returns the result.
+
+## Example Server
+
+The example server is located in `examples/docker_agent_endpoint/main.py`:
+
+```python
+from fastapi import FastAPI
+from pydantic import BaseModel
+from nodetool.agents.agent import Agent
+from nodetool.agents.tools import BrowserTool, GoogleSearchTool
+from nodetool.chat.providers import get_provider
+from nodetool.metadata.types import Provider
+from nodetool.workflows.processing_context import ProcessingContext
+from nodetool.workflows.types import Chunk
+
+app = FastAPI()
+
+class AgentRequest(BaseModel):
+    objective: str
+
+@app.post("/run")
+async def run_agent(req: AgentRequest):
+    context = ProcessingContext()
+    agent = Agent(
+        name="Research Agent",
+        objective=req.objective,
+        provider=get_provider(Provider.OpenAI),
+        model="gpt-4o-mini",
+        tools=[GoogleSearchTool(), BrowserTool()],
+        enable_analysis_phase=False,
+    )
+
+    chunks: list[str] = []
+    async for item in agent.execute(context):
+        if isinstance(item, Chunk):
+            chunks.append(item.content)
+
+    return {"result": "".join(chunks), "workspace": context.workspace_dir}
+```
+
+## Dockerfile
+
+A minimal Dockerfile to run the server:
+
+```Dockerfile
+FROM python:3.11-slim
+WORKDIR /app
+COPY main.py /app/main.py
+RUN pip install --no-cache-dir nodetool-core fastapi uvicorn
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+## Building and Running
+
+```bash
+docker build -t agent-endpoint examples/docker_agent_endpoint
+
+docker run -p 8000:8000 \
+  -e OPENAI_API_KEY=YOUR_KEY \
+  agent-endpoint
+```
+
+The service exposes a `/run` endpoint. Send a POST request with a JSON body:
+
+```bash
+curl -X POST http://localhost:8000/run \
+     -H "Content-Type: application/json" \
+     -d '{"objective": "Explain Docker"}'
+```
+
+The response contains the agent output and the workspace directory used during execution.

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ The documentation is organized into the following sections:
 - [**Agents**](agents.md) - Multi-step agent framework
 - [**Chat Module**](chat.md) - Conversational interface
 - [**Chat Providers**](chat-providers.md) - Supported LLM backends
+- [**Docker Agent Endpoint**](docker-agent-endpoint.md) - Deploy a single agent as an HTTP service
 - [**Examples**](../examples/README.md) - Example workflows
 
 ## Community

--- a/examples/docker_agent_endpoint/Dockerfile
+++ b/examples/docker_agent_endpoint/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY main.py /app/main.py
+RUN pip install --no-cache-dir nodetool-core fastapi uvicorn
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/examples/docker_agent_endpoint/main.py
+++ b/examples/docker_agent_endpoint/main.py
@@ -1,0 +1,39 @@
+import asyncio
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from nodetool.agents.agent import Agent
+from nodetool.agents.tools import BrowserTool, GoogleSearchTool
+from nodetool.chat.providers import get_provider
+from nodetool.metadata.types import Provider
+from nodetool.workflows.processing_context import ProcessingContext
+from nodetool.workflows.types import Chunk
+
+app = FastAPI()
+
+class AgentRequest(BaseModel):
+    objective: str
+
+@app.post("/run")
+async def run_agent(req: AgentRequest):
+    """Run the research agent with the given objective."""
+    context = ProcessingContext()
+    agent = Agent(
+        name="Research Agent",
+        objective=req.objective,
+        provider=get_provider(Provider.OpenAI),
+        model="gpt-4o-mini",
+        tools=[GoogleSearchTool(), BrowserTool()],
+        enable_analysis_phase=False,
+    )
+
+    chunks: list[str] = []
+    async for item in agent.execute(context):
+        if isinstance(item, Chunk):
+            chunks.append(item.content)
+
+    return {"result": "".join(chunks), "workspace": context.workspace_dir}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("main:app", host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- show how to deploy a simple agent behind a single HTTP endpoint
- document the workflow in new `docker-agent-endpoint.md`
- link the new doc from `docs/index.md`

## Testing
- `pytest -q`