### PR TITLE
Add workflow DSL exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ python -m nodetool.cli --help
 
 See [docs/cli.md](docs/cli.md) for all commands.
 
+### Exporting Workflows as DSL
+
+Generate a runnable Python script for a workflow that sends the graph to the
+`/chat` WebSocket:
+
+```python
+from nodetool.workflows.export_dsl import workflow_to_dsl_code
+
+dsl_code = workflow_to_dsl_code(workflow)
+print(dsl_code)
+```
+
 ## 📖 Documentation
 
 - [Concepts and Architecture](https://docs.nodetool.ai/concepts/)

--- a/src/nodetool/workflows/export_dsl.py
+++ b/src/nodetool/workflows/export_dsl.py
@@ -1,0 +1,89 @@
+import asyncio
+import json
+from typing import Dict
+
+import websockets
+
+from nodetool.types.workflow import Workflow
+
+
+def workflow_to_dsl_code(workflow: Workflow, websocket_url: str = "ws://localhost:8000/chat") -> str:
+    """Generate Python DSL code for a workflow that runs via the chat WebSocket.
+
+    Parameters
+    ----------
+    workflow : Workflow
+        The workflow to export.
+    websocket_url : str, optional
+        The chat WebSocket URL, by default "ws://localhost:8000/chat".
+
+    Returns
+    -------
+    str
+        A Python script as a string.
+    """
+
+    imports = {
+        "base": [
+            "import asyncio",
+            "import json",
+            "import websockets",
+            "from nodetool.dsl.graph import graph",
+        ],
+        "nodes": set(),
+    }
+
+    node_var_by_id: Dict[str, str] = {}
+    node_lines = []
+    connect_lines = []
+
+    for idx, node in enumerate(workflow.graph.nodes):
+        var = f"n{idx}"
+        node_var_by_id[node.id] = var
+        parts = node.type.split(".")
+        module = "nodetool.dsl." + ".".join(parts[:-1])
+        cls = parts[-1]
+        imports["nodes"].add(f"from {module} import {cls}")
+        params = ", ".join(f"{k}={repr(v)}" for k, v in (node.data or {}).items())
+        node_lines.append(f"{var} = {cls}({params})")
+
+    for edge in workflow.graph.edges:
+        src = node_var_by_id.get(edge.source)
+        tgt = node_var_by_id.get(edge.target)
+        if src and tgt:
+            connect_lines.append(
+                f"{tgt}.{edge.targetHandle} = ({src}, \"{edge.sourceHandle}\")"
+            )
+
+    graph_line = f"workflow_graph = graph({', '.join(node_var_by_id.values())})"
+
+    run_lines = [
+        "async def main():",
+        f"    async with websockets.connect('{websocket_url}') as websocket:",
+        "        message = {",
+        "            'role': 'user',",
+        "            'workflow_id': 'exported_workflow',",
+        "            'graph': workflow_graph.model_dump(),",
+        "        }",
+        "        await websocket.send(json.dumps(message))",
+        "        while True:",
+        "            response = await websocket.recv()",
+        "            print(response)",
+        "",
+        "asyncio.run(main())",
+    ]
+
+    lines = []
+    lines.extend(imports["base"])
+    lines.extend(sorted(imports["nodes"]))
+    lines.append("")
+    lines.extend(node_lines)
+    if connect_lines:
+        lines.append("")
+        lines.extend(connect_lines)
+    lines.append("")
+    lines.append(graph_line)
+    lines.append("")
+    lines.extend(run_lines)
+
+    return "\n".join(lines)

--- a/tests/workflows/test_export_dsl.py
+++ b/tests/workflows/test_export_dsl.py
@@ -1,0 +1,25 @@
+from nodetool.types.graph import Graph, Node, Edge
+from nodetool.types.workflow import Workflow
+from nodetool.workflows.export_dsl import workflow_to_dsl_code
+
+
+def test_workflow_to_dsl_code_basic():
+    graph = Graph(
+        nodes=[
+            Node(id="1", type="nodetool.input.StringInput", data={"name": "text"})
+        ],
+        edges=[],
+    )
+    wf = Workflow(
+        id="wf1",
+        name="Test",
+        description="",
+        access="public",
+        created_at="now",
+        updated_at="now",
+        graph=graph,
+    )
+
+    code = workflow_to_dsl_code(wf, websocket_url="ws://example.com/chat")
+    assert "StringInput" in code
+    assert "websockets.connect('ws://example.com/chat')" in code


### PR DESCRIPTION
## Summary
- implement `workflow_to_dsl_code` helper to turn a workflow into runnable DSL code
- document workflow export feature in README
- test exporting a simple workflow

## Testing
- `pytest tests/workflows/test_export_dsl.py -q`
- `pytest -q`