### PR TITLE
Add MCPTool for integrating MCP services

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -12,3 +12,24 @@ Key features include:
 - **Workspace** – subtasks read and write files in a dedicated workspace directory.
 
 See the source [README](../src/nodetool/agents/README.md) for a detailed architecture overview and example usage.
+
+## MCP Tools
+
+The `MCPTool` class makes it easy to call tools hosted on any [Model Context Protocol](https://modelcontextprotocol.io) server.
+Configure the endpoint and token via the `MCP_API_URL` and `MCP_TOKEN` environment variables. Tools can be instantiated dynamically:
+
+```python
+from nodetool.agents.tools import MCPTool
+
+summarize = MCPTool(
+    tool="summarize",
+    description="Summarize a block of text using the remote MCP service",
+    input_schema={
+        "type": "object",
+        "properties": {"text": {"type": "string"}},
+        "required": ["text"],
+    },
+)
+```
+
+During execution the tool posts the parameters to the configured MCP server and returns the JSON response.

--- a/src/nodetool/agents/tools/__init__.py
+++ b/src/nodetool/agents/tools/__init__.py
@@ -44,6 +44,9 @@ from .openai_tools import (
     OpenAIWebSearchTool,
 )
 
+# MCP tools
+from .mcp_tools import MCPTool
+
 # PDF tools
 from .pdf_tools import (
     ConvertPDFToMarkdownTool,
@@ -96,6 +99,7 @@ __all__ = [
     "OpenAIImageGenerationTool",
     "OpenAITextToSpeechTool",
     "OpenAIWebSearchTool",
+    "MCPTool",
     "ReadAssetTool",
     "ReadFileTool",
     "SaveAssetTool",

--- a/src/nodetool/agents/tools/mcp_tools.py
+++ b/src/nodetool/agents/tools/mcp_tools.py
@@ -1,0 +1,52 @@
+from typing import Any, Dict, Optional
+import httpx
+
+from nodetool.agents.tools.base import Tool
+from nodetool.workflows.processing_context import ProcessingContext
+from nodetool.common.environment import Environment
+
+
+class MCPTool(Tool):
+    """Generic tool for calling a Model Context Protocol service."""
+
+    def __init__(
+        self,
+        tool: str,
+        *,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        input_schema: Optional[Dict[str, Any]] = None,
+        base_url: Optional[str] = None,
+        token: Optional[str] = None,
+    ) -> None:
+        self.tool = tool
+        self.name = name or tool
+        self.description = description or f"Execute the MCP tool '{tool}'"
+        self.input_schema = input_schema or {
+            "type": "object",
+            "properties": {"input": {"type": "string"}},
+            "required": ["input"],
+        }
+        self.base_url = base_url or Environment.get(
+            "MCP_API_URL", "http://localhost:8000"
+        )
+        self.token = token or Environment.get("MCP_TOKEN")
+
+    def get_container_env(self) -> Dict[str, str]:
+        env: Dict[str, str] = {}
+        if self.base_url:
+            env["MCP_API_URL"] = self.base_url
+        if self.token:
+            env["MCP_TOKEN"] = self.token
+        return env
+
+    async def process(self, context: ProcessingContext, params: Dict[str, Any]) -> Any:
+        url = f"{self.base_url.rstrip('/')}/tools/{self.tool}"
+        headers = {}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        try:
+            response = await context.http_post(url, json=params, headers=headers)
+            return response.json()
+        except httpx.HTTPError as e:
+            return {"error": str(e)}


### PR DESCRIPTION
## Summary
- add `MCPTool` for connecting to Model Context Protocol servers
- export `MCPTool` in tool package
- document MCP tools
- test MCP tool behaviour

## Testing
- `ruff check src/nodetool/agents/tools/mcp_tools.py tests/agents/test_tools.py`
- `black --check src/nodetool/agents/tools/mcp_tools.py tests/agents/test_tools.py`
- `mypy src/nodetool/agents/tools/mcp_tools.py tests/agents/test_tools.py` *(fails: environment issue)*
- `pytest -q tests/agents/test_tools.py` *(fails: environment issue)*