### PR TITLE
Implement dynamic outputs

### DIFF
--- a/src/nodetool/workflows/workflow_runner.py
+++ b/src/nodetool/workflows/workflow_runner.py
@@ -1154,21 +1154,7 @@ class WorkflowRunner:
                 slot_name: str = item[0]
                 value: Any = item[1]
 
-            # Check if the yielded slot_name is a declared output for the node.
-            # This assumes BaseNode has a method get_output_fields() -> list[str].
-            # If this method doesn't exist or has a different signature on BaseNode,
-            # this part will need adaptation based on how output fields are actually defined/retrieved.
-            return_type = node.return_type()
-            if return_type is None:
-                raise ValueError(
-                    f"Streaming node {node.get_title()} ({node._id}) has no return type."
-                )
-            if not isinstance(return_type, dict):
-                raise ValueError(
-                    f"Streaming node {node.get_title()} ({node._id}) has invalid return type: {type(return_type)}"
-                )
-
-            declared_outputs = list(return_type.keys())
+            declared_outputs = [o.name for o in node.outputs()]
             if slot_name not in declared_outputs:
                 error_message = (
                     f"Streaming node {node.get_title()} ({node._id}) yielded for undeclared output slot: '{slot_name}'. "

--- a/tests/workflows/test_base_node.py
+++ b/tests/workflows/test_base_node.py
@@ -232,3 +232,19 @@ def test_base_node_get_json_schema():
     assert schema["type"] == "object"
     assert "properties" in schema
     assert "prop" in schema["properties"]
+
+
+class DynamicOutputNode(BaseNode):
+    value: int = 0
+
+    async def process(self, context: ProcessingContext):
+        return {"dynamic": self.value}
+
+
+def test_dynamic_outputs():
+    node = DynamicOutputNode(dynamic_outputs={"dynamic": TypeMetadata(type="int")})
+    outputs = node.outputs()
+    assert any(o.name == "dynamic" and o.type.type == "int" for o in outputs)
+    node_dict = node.to_dict()
+    node2 = DynamicOutputNode.from_dict(node_dict)
+    assert "dynamic" in node2._dynamic_outputs


### PR DESCRIPTION
## Summary
- support per-node dynamic outputs alongside dynamic properties
- include dynamic outputs in workflow node serialization
- handle dynamic outputs when streaming results
- test BaseNode dynamic outputs

## Testing
- `ruff check src/nodetool/workflows/base_node.py tests/workflows/test_base_node.py src/nodetool/workflows/workflow_runner.py`
- `black --check src/nodetool/workflows/base_node.py tests/workflows/test_base_node.py src/nodetool/workflows/workflow_runner.py`
- `mypy src/nodetool/workflows/base_node.py tests/workflows/test_base_node.py src/nodetool/workflows/workflow_runner.py`
- `pytest -q`