### PR TITLE
Add per-instance trigger mode for workflow nodes

### DIFF
--- a/docs/api-reference/workflows/base_node.md
+++ b/docs/api-reference/workflows/base_node.md
@@ -36,6 +36,10 @@ _parent_id (str | None): Identifier of the parent node, if any.
 _ui_properties (dict[str, Any]): UI-specific properties for the node.
 _visible (bool): Whether the node is visible in the UI.
 _layout (str): The layout style for the node in the UI.
+_trigger_mode (str): Determines when the node executes after its first run.
+``"all_inputs"`` waits for messages from every input before each run,
+while ``"any_input"`` allows subsequent runs when any single input receives a
+message. The initial run always waits for all inputs.
 
 Methods:
 Includes methods for initialization, property management, metadata generation,

--- a/src/nodetool/metadata/node_metadata.py
+++ b/src/nodetool/metadata/node_metadata.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Annotated
+from typing import Any, List
 import json
 import importlib
 import pkgutil
@@ -27,9 +27,20 @@ class NodeMetadata(BaseModel):
     """
     Metadata for a node.
     """
+
     model_config = ConfigDict(
         json_schema_extra={
-            "required": ["title", "description", "namespace", "node_type", "outputs", "properties", "the_model_info", "recommended_models", "basic_fields"]
+            "required": [
+                "title",
+                "description",
+                "namespace",
+                "node_type",
+                "outputs",
+                "properties",
+                "the_model_info",
+                "recommended_models",
+                "basic_fields",
+            ]
         }
     )
 


### PR DESCRIPTION
## Summary
- make BaseNode `_trigger_mode` configurable per instance
- serialize `trigger_mode` in node dictionaries and parse it when loading
- ensure WorkflowRunner waits for all inputs on first run
- expand tests with additional parallel and trigger mode scenarios

## Testing
- `ruff check src/nodetool/workflows/base_node.py src/nodetool/metadata/node_metadata.py src/nodetool/workflows/workflow_runner.py tests/workflows/test_workflow_runner.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687bfb936480832fb500b135df915487