### PR TITLE
Add HF inference endpoint deployment

### DIFF
--- a/docs/hf-deployment.md
+++ b/docs/hf-deployment.md
@@ -1,0 +1,15 @@
+# Hugging Face Inference Endpoint Deployment
+
+This guide explains how to deploy NodeTool workflows as Hugging Face Inference Endpoints.
+
+```bash
+nodetool deploy-hf \
+  --workflow-id YOUR_WORKFLOW_ID \
+  --endpoint-name my-endpoint \
+  --repository username/my-repo \
+  --docker-username mydockeruser
+```
+
+The command builds a Docker image containing the workflow and uploads it to your Docker registry. An Inference Endpoint is then created using that image.
+
+The deployed container uses `hf_inference.py` which runs the workflow when Hugging Face calls the `predict` function.

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,7 @@ The documentation is organized into the following sections:
 - [**Chat Providers**](chat-providers.md) - Supported LLM backends
 - [**Examples**](../examples/README.md) - Example workflows
 - [**Runpod Deployment**](runpod-deployment.md) - Runpod Deployment
+- [**Hugging Face Deployment**](hf-deployment.md) - Deploy to HF Inference Endpoints
 - [**Runpod Testing Guide**](runpod_testing_guide.md) - Runpod Testing Guide
 
 ## Community

--- a/src/nodetool/deploy/Dockerfile.hf
+++ b/src/nodetool/deploy/Dockerfile.hf
@@ -1,0 +1,23 @@
+FROM pytorch/pytorch:2.1.0-cuda11.8-cudnn8-runtime
+
+# Install dependencies
+RUN apt-get update && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir hf-transfer huggingface-hub \
+    git+https://github.com/nodetool-ai/nodetool-core \
+    git+https://github.com/nodetool-ai/nodetool-base \
+    git+https://github.com/nodetool-ai/nodetool-huggingface
+
+WORKDIR /app
+
+ENV HF_HUB_CACHE=/app/.cache/huggingface/hub
+RUN mkdir -p $HF_HUB_CACHE
+
+COPY hf_inference.py /app/inference.py
+COPY workflow.json /app/workflow.json
+COPY models.json /app/models.json
+COPY download_models.py /app/download_models.py
+
+RUN python /app/download_models.py /app/models.json || echo "Model download completed with some errors"
+
+CMD ["python", "-u", "/app/inference.py"]

--- a/src/nodetool/deploy/deploy_to_hf.py
+++ b/src/nodetool/deploy/deploy_to_hf.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Deploy NodeTool workflows to Hugging Face Inference Endpoints."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Dict, Optional
+
+from huggingface_hub import HfApi
+
+
+def run_command(command: str, capture_output: bool = False) -> str:
+    """Run a shell command and optionally capture output."""
+    print(f"Running: {command}")
+    try:
+        if capture_output:
+            result = subprocess.run(
+                command, shell=True, check=True, capture_output=True, text=True
+            )
+            if result.stdout:
+                print(result.stdout.strip())
+            if result.stderr:
+                print(result.stderr.strip(), file=sys.stderr)
+            return result.stdout.strip()
+        process = subprocess.Popen(
+            command,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        if process.stdout:
+            for line in process.stdout:
+                print(line.rstrip())
+        returncode = process.wait()
+        if returncode != 0:
+            raise subprocess.CalledProcessError(returncode, command)
+        return ""
+    except subprocess.CalledProcessError as e:
+        print(f"Command failed with code {e.returncode}: {e.cmd}")
+        sys.exit(1)
+
+
+def format_image_name(
+    base_name: str, docker_username: str, registry: str = "docker.io"
+) -> str:
+    if registry == "docker.io":
+        return f"{docker_username}/{base_name}"
+    return f"{registry}/{docker_username}/{base_name}"
+
+
+def sanitize_name(name: str) -> str:
+    import re
+
+    sanitized = re.sub(r"[^a-zA-Z0-9\-]", "-", name.lower())
+    sanitized = re.sub(r"-+", "-", sanitized).strip("-")
+    return sanitized or "workflow"
+
+
+def generate_image_tag() -> str:
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    random_data = f"{time.time()}{os.getpid()}{os.urandom(8).hex()}"
+    short_hash = hashlib.md5(random_data.encode()).hexdigest()[:6]
+    return f"{timestamp}-{short_hash}"
+
+
+def extract_models(workflow_data: Dict) -> list[Dict]:
+    models: list[Dict] = []
+    if "graph" not in workflow_data or "nodes" not in workflow_data["graph"]:
+        return models
+    for node in workflow_data["graph"]["nodes"]:
+        if "data" not in node:
+            continue
+        model = node["data"].get("model")
+        if isinstance(model, dict) and model.get("type", "").startswith("hf."):
+            if model.get("repo_id"):
+                models.append(
+                    {
+                        "type": model.get("type"),
+                        "repo_id": model["repo_id"],
+                        "path": model.get("path"),
+                        "variant": model.get("variant"),
+                        "allow_patterns": model.get("allow_patterns"),
+                        "ignore_patterns": model.get("ignore_patterns"),
+                    }
+                )
+    return models
+
+
+def create_ollama_pull_script(models: list[Dict], build_dir: str) -> None:
+    from pathlib import Path
+
+    ollama_models = [
+        m
+        for m in models
+        if m.get("type") == "language_model" and m.get("provider") == "ollama"
+    ]
+    script_path = Path(build_dir) / "pull_ollama_models.sh"
+    if not ollama_models:
+        with open(script_path, "w") as f:
+            f.write("#!/bin/bash\necho 'No Ollama models to pull'\n")
+        script_path.chmod(0o755)
+        return
+
+    lines = ["#!/bin/bash", "set -e", "ollama serve &", "PID=$!", "sleep 5"]
+    for model in ollama_models:
+        if model.get("id"):
+            lines.append(f"ollama pull {model['id']}")
+    lines.append("kill $PID")
+    with open(script_path, "w") as f:
+        f.write("\n".join(lines))
+    script_path.chmod(0o755)
+
+
+def build_docker_image(
+    workflow_path: str, image_name: str, tag: str, platform: str = "linux/amd64"
+) -> None:
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    dockerfile_path = os.path.join(script_dir, "Dockerfile.hf")
+    inference_path = os.path.join(script_dir, "hf_inference.py")
+    download_models_path = os.path.join(script_dir, "download_models.py")
+
+    with open(workflow_path, "r") as f:
+        workflow_data = json.load(f)
+    models = extract_models(workflow_data)
+
+    build_dir = tempfile.mkdtemp(prefix="nodetool_hf_build_")
+    try:
+        shutil.copy(workflow_path, os.path.join(build_dir, "workflow.json"))
+        shutil.copy(inference_path, os.path.join(build_dir, "hf_inference.py"))
+        shutil.copy(dockerfile_path, os.path.join(build_dir, "Dockerfile"))
+        shutil.copy(download_models_path, os.path.join(build_dir, "download_models.py"))
+        with open(os.path.join(build_dir, "models.json"), "w") as f:
+            json.dump(models, f)
+        create_ollama_pull_script(models, build_dir)
+        cwd = os.getcwd()
+        os.chdir(build_dir)
+        run_command(f"docker build --platform {platform} -t {image_name}:{tag} .")
+        os.chdir(cwd)
+    finally:
+        shutil.rmtree(build_dir, ignore_errors=True)
+
+
+def push_to_registry(image_name: str, tag: str, registry: str = "docker.io") -> None:
+    run_command(f"docker push {image_name}:{tag}")
+
+
+def fetch_workflow_from_db(workflow_id: str) -> tuple[str, str]:
+    import tempfile
+    from nodetool.models.workflow import Workflow
+
+    workflow = Workflow.get(workflow_id)
+    if not workflow:
+        print(f"Workflow {workflow_id} not found")
+        sys.exit(1)
+    fd, path = tempfile.mkstemp(suffix=".json", prefix="workflow_")
+    with os.fdopen(fd, "w") as f:
+        f.write(workflow.model_dump_json())
+    return path, workflow.name
+
+
+def create_hf_endpoint(
+    name: str,
+    repository: str,
+    image: str,
+    accelerator: str,
+    instance_size: str,
+    instance_type: str,
+    region: str,
+    vendor: str,
+    token: Optional[str] = None,
+) -> None:
+    api = HfApi(token=token)
+    endpoint = api.create_inference_endpoint(
+        name=name,
+        repository=repository,
+        framework="custom",
+        accelerator=accelerator,
+        instance_size=instance_size,
+        instance_type=instance_type,
+        region=region,
+        vendor=vendor,
+        custom_image={"url": image},
+    )
+    print(f"Endpoint {endpoint.name} created with status {endpoint.status}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Deploy workflow to Hugging Face Inference Endpoints"
+    )
+    parser.add_argument("--workflow-id", required=True, help="Workflow ID to deploy")
+    parser.add_argument("--endpoint-name", required=True, help="Name of the endpoint")
+    parser.add_argument(
+        "--repository", required=True, help="Hugging Face repository ID"
+    )
+    parser.add_argument(
+        "--docker-username", required=True, help="Docker registry username"
+    )
+    parser.add_argument(
+        "--docker-registry", default="docker.io", help="Docker registry"
+    )
+    parser.add_argument("--image-name", help="Docker image base name")
+    parser.add_argument("--tag", help="Docker image tag")
+    parser.add_argument(
+        "--platform", default="linux/amd64", help="Docker build platform"
+    )
+    parser.add_argument("--accelerator", default="gpu", help="Compute accelerator")
+    parser.add_argument("--instance-size", default="small", help="Instance size")
+    parser.add_argument("--instance-type", default="nvidia-a10g", help="Instance type")
+    parser.add_argument("--region", default="us-east-1", help="Cloud region")
+    parser.add_argument("--vendor", default="aws", help="Cloud vendor")
+    parser.add_argument("--token", help="Hugging Face access token")
+
+    args = parser.parse_args()
+
+    workflow_path, workflow_name = fetch_workflow_from_db(args.workflow_id)
+    image_base = sanitize_name(args.image_name or workflow_name)
+    full_image = format_image_name(
+        image_base, args.docker_username, args.docker_registry
+    )
+    tag = args.tag or generate_image_tag()
+
+    build_docker_image(workflow_path, full_image, tag, args.platform)
+    push_to_registry(full_image, tag, args.docker_registry)
+
+    image_with_tag = f"{full_image}:{tag}"
+    create_hf_endpoint(
+        name=args.endpoint_name,
+        repository=args.repository,
+        image=image_with_tag,
+        accelerator=args.accelerator,
+        instance_size=args.instance_size,
+        instance_type=args.instance_type,
+        region=args.region,
+        vendor=args.vendor,
+        token=args.token,
+    )
+
+    os.unlink(workflow_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nodetool/deploy/hf_inference.py
+++ b/src/nodetool/deploy/hf_inference.py
@@ -1,0 +1,39 @@
+"""Hugging Face Inference Endpoint handler for NodeTool workflows."""
+
+import asyncio
+import json
+from typing import Any, Dict
+
+from nodetool.types.graph import Graph
+from nodetool.types.job import JobUpdate
+from nodetool.workflows.run_workflow import run_workflow
+from nodetool.workflows.processing_context import ProcessingContext
+from nodetool.workflows.run_job_request import RunJobRequest
+from nodetool.workflows.types import OutputUpdate
+
+with open("/app/workflow.json", "r") as f:
+    _workflow_data = json.load(f)
+
+_graph = Graph.model_validate(_workflow_data["graph"])
+
+
+async def _run_workflow(params: Dict[str, Any]) -> Dict[str, Any]:
+    req = RunJobRequest(params=params)
+    req.graph = _graph
+
+    context = ProcessingContext(upload_assets_to_s3=True)
+    results: Dict[str, Any] = {}
+    async for msg in run_workflow(req, context=context, use_thread=True):
+        if isinstance(msg, JobUpdate) and msg.status == "error":
+            raise Exception(msg.error)
+        if isinstance(msg, OutputUpdate):
+            value = context.encode_assets_as_uri(msg.value)
+            if hasattr(value, "model_dump"):
+                value = value.model_dump()
+            results[msg.node_name] = value
+    return results
+
+
+def predict(inputs: Dict[str, Any]) -> Dict[str, Any]:
+    """Synchronous entry point used by Hugging Face Inference Endpoints."""
+    return asyncio.run(_run_workflow(inputs or {}))


### PR DESCRIPTION
## Summary
- add `deploy-hf` CLI command to deploy workflows to Hugging Face Inference Endpoints
- implement `deploy_to_hf.py` with Docker build, push and endpoint creation logic
- add `hf_inference.py` handler and Dockerfile for HF endpoints
- document usage in new `hf-deployment.md`
- link documentation from index

## Testing
- `pre-commit run --files docs/index.md docs/hf-deployment.md src/nodetool/cli.py src/nodetool/deploy/Dockerfile.hf src/nodetool/deploy/deploy_to_hf.py src/nodetool/deploy/hf_inference.py`
- `pytest -q` *(fails: test_parallel_node_execution)*

------
https://chatgpt.com/codex/tasks/task_b_687e47747c64832f85aaa099292a0413