### PR TITLE
fix: ensure async event loop on Windows

### DIFF
--- a/src/nodetool/api/server.py
+++ b/src/nodetool/api/server.py
@@ -1,4 +1,6 @@
 import os
+import asyncio
+import platform
 from typing import Any, List
 import dotenv
 from fastapi.exceptions import RequestValidationError
@@ -24,6 +26,9 @@ import mimetypes
 from nodetool.common.websocket_updates import websocket_updates
 from multiprocessing import Process
 from nodetool.api.openai import create_openai_compatible_router
+
+if platform.system() == "Windows":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 # FIX: Windows: mimetypes.guess_type() returns None for some files
 # See:

--- a/src/nodetool/api/worker.py
+++ b/src/nodetool/api/worker.py
@@ -1,3 +1,5 @@
+import asyncio
+import platform
 import dotenv
 from fastapi import FastAPI, WebSocket, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -23,6 +25,9 @@ from nodetool.common.huggingface_models import (
 )
 from nodetool.metadata.types import HuggingFaceModel
 from typing import List
+
+if platform.system() == "Windows":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 try:
     from nodes import init_extra_nodes  # type: ignore


### PR DESCRIPTION
## Summary
- ensure Windows uses `WindowsSelectorEventLoopPolicy` for server and worker

## Testing
- `pytest` *(fails: AttributeError in tests/chat/test_base_chat_runner.py)*
- `flake8` *(fails: style errors in test files)*

------
https://chatgpt.com/codex/tasks/task_b_68a1035784c4832fb1a0428271380498