### PR TITLE
Configure uvicorn loop and worker settings

### DIFF
--- a/tests/api/test_server.py
+++ b/tests/api/test_server.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+import sys
+
+from nodetool.api.server import run_uvicorn_server
+
+
+def test_run_uvicorn_server_configures_loop_and_workers(monkeypatch):
+    dummy_app = object()
+
+    class _DummyUvloop:  # pragma: no cover - placeholder module
+        pass
+
+    monkeypatch.setitem(sys.modules, "uvloop", _DummyUvloop())
+
+    with (
+        patch("nodetool.api.server.uvicorn") as mock_run,
+        patch("nodetool.api.server.multiprocessing.cpu_count", return_value=2),
+        patch("nodetool.api.server.platform.system", return_value="Linux"),
+        patch(
+            "nodetool.api.server.get_nodetool_package_source_folders", return_value=[]
+        ),
+    ):
+        run_uvicorn_server(dummy_app, host="0.0.0.0", port=8123, reload=False)
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs["loop"] == "uvloop"
+        assert kwargs["workers"] == 2


### PR DESCRIPTION
## Summary
- ensure NodeTool and API servers select an appropriate event loop and worker count when starting Uvicorn
- add tests verifying loop selection and worker configuration

## Testing
- `pre-commit run --files src/nodetool/deploy/fastapi_server.py src/nodetool/api/server.py tests/deploy/test_fastapi_server.py tests/api/test_server.py` (fails: src/nodetool/api/server.py:23: error: No parent module -- cannot perform relative import)
- `PYTHONPATH=src pytest tests/deploy/test_fastapi_server.py::test_run_nodetool_server_invokes_uvicorn_run tests/api/test_server.py`


------
https://chatgpt.com/codex/tasks/task_b_68a218effc94832f94fbebe76fa6cd13