### PR TITLE
Run package registry operations in separate threads

### DIFF
--- a/src/nodetool/api/package.py
+++ b/src/nodetool/api/package.py
@@ -1,4 +1,5 @@
 from typing import List, Optional
+import asyncio
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
@@ -44,7 +45,7 @@ async def list_available_packages(
     user: str = Depends(current_user),
 ) -> PackageListResponse:
     """List all available packages from the registry."""
-    packages = registry.list_available_packages()
+    packages = await asyncio.to_thread(registry.list_available_packages)
     return PackageListResponse(packages=packages, count=len(packages))
 
 
@@ -89,7 +90,7 @@ async def list_installed_packages(
     user: str = Depends(current_user),
 ) -> InstalledPackageListResponse:
     """List all installed packages."""
-    packages = registry.list_installed_packages()
+    packages = await asyncio.to_thread(registry.list_installed_packages)
     return InstalledPackageListResponse(packages=packages, count=len(packages))
 
 

--- a/src/nodetool/packages/registry.py
+++ b/src/nodetool/packages/registry.py
@@ -375,7 +375,7 @@ class Registry:
             List[Dict[str, Any]]: A list of node metadata dictionaries
         """
         all_nodes = []
-        available_packages = self.list_available_packages()
+        available_packages = await asyncio.to_thread(self.list_available_packages)
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             # Create tasks for all package metadata fetches


### PR DESCRIPTION
## Summary
- offload list_available_packages to a thread when fetching nodes
- run package registry endpoints in a background thread to avoid blocking

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named ...)*

------
https://chatgpt.com/codex/tasks/task_b_68a21d69a99c832fbc50cd9c05d121b8