### PR TITLE
fix: retain tool history in help processor

### DIFF
--- a/src/nodetool/messaging/processors/help.py
+++ b/src/nodetool/messaging/processors/help.py
@@ -7,9 +7,7 @@ This module provides the processor for help mode messages.
 import logging
 import asyncio
 import json
-import uuid
 from typing import List
-import textwrap
 import httpx
 from nodetool.agents.tools.tool_registry import resolve_tool_by_name
 from pydantic import BaseModel
@@ -209,7 +207,9 @@ class HelpMessageProcessor(MessageProcessor):
 
             # Process messages with tool execution
             while True:
-                messages_to_send = effective_messages + unprocessed_messages
+                # Persist unprocessed messages so the provider sees the full history
+                effective_messages.extend(unprocessed_messages)
+                messages_to_send = effective_messages
                 unprocessed_messages = []
                 assert last_message.model, "Model is required"
 

--- a/tests/messaging/test_help_processor_history.py
+++ b/tests/messaging/test_help_processor_history.py
@@ -1,0 +1,99 @@
+import pytest
+
+from nodetool.chat.chat_websocket_runner import ChatWebSocketRunner
+from nodetool.chat.base_chat_runner import BaseChatRunner
+from nodetool.chat.providers.base import MockProvider
+from nodetool.messaging.processors.help import HelpMessageProcessor
+from nodetool.metadata.types import Message, ToolCall, Provider
+from nodetool.workflows.processing_context import ProcessingContext
+
+
+class DummyRunner(BaseChatRunner):
+    def __init__(self):
+        super().__init__(auth_token=None)
+        self.sent: list[dict] = []
+
+    async def connect(self, **kwargs):  # type: ignore[override]
+        return None
+
+    async def disconnect(self):  # type: ignore[override]
+        return None
+
+    async def send_message(self, message: dict):  # type: ignore[override]
+        self.sent.append(message)
+
+    async def receive_message(self):  # type: ignore[override]
+        return None
+
+
+class ResolvingRunner(DummyRunner):
+    async def send_message(self, message: dict):  # type: ignore[override]
+        self.sent.append(message)
+        if message.get("type") == "tool_call":
+            call_id = message["tool_call_id"]
+            tool_bridge.resolve_result(
+                call_id,
+                {
+                    "type": "tool_result",
+                    "tool_call_id": call_id,
+                    "thread_id": message.get("thread_id"),
+                    "ok": True,
+                    "result": {"ok": True},
+                    "elapsed_ms": 1,
+                },
+            )
+
+
+@pytest.mark.asyncio
+async def test_help_processor_appends_tool_history():
+    tool_call1 = ToolCall(id="tc1", name="ui_add_node", args={"node": {}})
+    tool_call2 = ToolCall(id="tc2", name="ui_add_node", args={"node": {}})
+    provider = MockProvider(
+        responses=[
+            Message(role="assistant", tool_calls=[tool_call1]),
+            Message(role="assistant", tool_calls=[tool_call2]),
+            Message(role="assistant", content="done"),
+        ]
+    )
+    processor = HelpMessageProcessor(provider)
+
+    tool_manifest = {
+        "name": "ui_add_node",
+        "description": "Add a node to the current workflow graph.",
+        "parameters": {
+            "type": "object",
+            "properties": {"node": {"type": "object"}},
+            "required": ["node"],
+        },
+    }
+
+    global tool_bridge
+    tool_bridge = ChatWebSocketRunner().tool_bridge
+    context = ProcessingContext(
+        tool_bridge=tool_bridge,
+        ui_tool_names={"ui_add_node"},
+        client_tools_manifest={"ui_add_node": tool_manifest},
+    )
+
+    chat_history = [
+        Message(
+            role="user",
+            content="Please add nodes",
+            provider=Provider.OpenAI,
+            model="gpt-test",
+            thread_id="t1",
+        )
+    ]
+
+    runner = ResolvingRunner()
+
+    await runner._run_processor(
+        processor=processor,
+        chat_history=chat_history,
+        processing_context=context,
+    )
+
+    assert len(provider.call_log) == 3
+    third_call_msgs = provider.call_log[2]["messages"]
+    tool_ids = {m.tool_call_id for m in third_call_msgs if m.role == "tool"}
+    assert tool_ids == {"tc1", "tc2"}


### PR DESCRIPTION
## Summary
- ensure HelpMessageProcessor persists tool-call messages so providers see full history
- add regression test verifying help processor forwards consecutive UI tool results

## Testing
- `ruff check src/nodetool/messaging/processors/help.py`
- `ruff check tests/messaging/test_help_processor_history.py`
- `black src/nodetool/messaging/processors/help.py`
- `black tests/messaging/test_help_processor_history.py`
- `mypy src/nodetool/messaging/processors/help.py` *(fails: process hangs)*
- `pytest tests/messaging/test_help_processor_history.py tests/test_ui_tools_flow.py -q` *(fails: import error - chromadb/tenacity)*

------
https://chatgpt.com/codex/tasks/task_b_68bc5b7eac94832fa5600deacd038865