### PR TITLE
ci: run tests on GitHub runner without Docker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,57 +15,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg libgl1 libglib2.0-0
 
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
 
-      - name: Install dependencies
+      - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e .
           pip install -r requirements-dev.txt
 
-      - name: Build Docker image for tests
-        run: |
-          # Build from the nodetool-core directory with caching
-          docker buildx build \
-            --cache-from type=local,src=/tmp/.buildx-cache \
-            --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
-            --load \
-            -t nodetool \
-            -f Dockerfile \
-            .
-
-          # Move cache to avoid growing indefinitely
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-          # Verify the image was built
-          docker images | grep nodetool
-
-          # Test that the nodetool CLI works with --jsonl flag
-          docker run --rm --entrypoint nodetool nodetool run --help | grep -q jsonl || \
-            (echo "ERROR: Built image does not have --jsonl flag!" && exit 1)
-
-      - name: Run tests (excluding Docker tests)
+      - name: Run tests
         run: |
           pytest -v --ignore=tests/workflows/test_docker_job_execution.py
-
-      - name: Run Docker-dependent tests
-        run: |
-          pytest -v tests/workflows/test_docker_job_execution.py
-        env:
-          # Ensure tests use the freshly built image
-          DOCKER_IMAGE: nodetool


### PR DESCRIPTION
## Summary
- simplify the test workflow to execute directly on the GitHub runner instead of building a Docker image
- install ffmpeg and supporting system libraries before installing project dependencies

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911c5c7dc9c832d85b1201cb88de703)