### PR TITLE
ci: install nodetool-base dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install git+https://github.com/nodetool-ai/nodetool-base
           pip install -e .
+          pip install git+https://github.com/nodetool-ai/nodetool-base
           pip install -r requirements-dev.txt
 
       - name: Run tests


### PR DESCRIPTION
## Summary
- install nodetool-base from source during the test workflow to satisfy node dependencies

## Testing
- Not run (workflow change only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911da48bd80832d9e1caf7fb818b8b5)