### PR TITLE
Add py.typed marker for type information

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,3 +140,6 @@ nodetool = "nodetool.cli:cli"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/nodetool"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"src/nodetool/py.typed" = "nodetool/py.typed"

--- a/src/nodetool/py.typed
+++ b/src/nodetool/py.typed
@@ -1,0 +1,1 @@
+# Marker file indicating that nodetool-core ships type information (PEP 561).


### PR DESCRIPTION
## Summary
- add a `py.typed` marker file so downstream users can consume the package's bundled type hints
- configure the Hatch wheel build to force-include the marker file when publishing the package

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69175a51d1e0832d8b1be1ba6cb2d2ce)