### PR TITLE
fix: skip media tests without OpenCV and avoid creating event loop during pytest shutdown

### DIFF
--- a/tests/common/test_media_utils.py
+++ b/tests/common/test_media_utils.py
@@ -2,9 +2,10 @@ import os
 import shutil
 from io import BytesIO
 
-import cv2
 import numpy as np
 import pytest
+
+cv2 = pytest.importorskip("cv2")
 
 from nodetool.media.common.media_utils import (
     create_image_thumbnail,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -560,19 +560,19 @@ def pytest_sessionfinish(session, exitstatus):
     gc.collect()
 
     # Close any lingering event loops
+    loop = None
     try:
         # Try to get running loop first (preferred in Python 3.10+)
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            # No running loop, try the deprecated method for cleanup purposes
-            loop = asyncio.get_event_loop_policy().get_event_loop()
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # Avoid creating a new event loop during shutdown cleanup.
+        loop = None
+
+    if loop is not None:
         if loop.is_running():
             loop.stop()
         if not loop.is_closed():
             loop.close()
-    except RuntimeError:
-        pass  # No event loop in current thread
 
     # Log any non-daemon threads that might prevent exit
     main_thread = threading.main_thread()


### PR DESCRIPTION
### Motivation
- Prevent test collection failures when OpenCV native libs (e.g. `libGL.so.1`) are not available by making the `cv2` import optional in the media tests.
- Avoid creating a new asyncio event loop during pytest shutdown which can trigger logging errors on closed streams and noisy teardown failures.

### Description
- Replace direct `cv2` import in `tests/common/test_media_utils.py` with `cv2 = pytest.importorskip("cv2")` so the module is skipped when OpenCV is unavailable.
- Harden `pytest_sessionfinish` in `tests/conftest.py` to only operate on an already-running loop obtained via `asyncio.get_running_loop()` and to avoid calling `get_event_loop_policy().get_event_loop()` during teardown.

### Testing
- Ran `uv run pytest -q tests/common/test_media_utils.py`, which resulted in the module being skipped when `cv2` was not present (expected behavior).
- Ran `uv run pytest -q tests/common/test_path_utils.py` and received `10 passed`.
- Ran `uv run ruff check tests/common/test_media_utils.py tests/conftest.py` and all checks passed.
- `make test` in this environment failed due to `pytest` being invoked with `-n` while `pytest-xdist`/`-n` support is unavailable, and `make typecheck` reported unrelated pre-existing diagnostics; these failures are not caused by this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c554790a0832db5c4815ab52ae848)