### PR TITLE
Implement automated RunPod endpoint deletion

### DIFF
--- a/src/nodetool/deploy/runpod.py
+++ b/src/nodetool/deploy/runpod.py
@@ -16,6 +16,10 @@ from nodetool.config.deployment import (
     RunPodDeployment,
 )
 from nodetool.deploy.deploy_to_runpod import deploy_to_runpod
+from nodetool.deploy.runpod_api import (
+    delete_runpod_endpoint_by_name,
+    delete_runpod_template_by_name,
+)
 from nodetool.deploy.state import StateManager
 
 logger = logging.getLogger(__name__)
@@ -233,12 +237,23 @@ class RunPodDeployer:
         try:
             results["steps"].append("Destroying RunPod endpoint...")
 
-            # TODO: Implement endpoint deletion via RunPod API
-            # For now, user must delete manually via RunPod console
-            results["steps"].append("⚠️  RunPod endpoint deletion must be done manually via RunPod console")
-            results["steps"].append(
-                f"Visit https://www.runpod.io/console/serverless and delete endpoint '{self.deployment_name}'"
-            )
+            # Delete endpoint
+            if delete_runpod_endpoint_by_name(self.deployment_name):
+                results["steps"].append(f"RunPod endpoint '{self.deployment_name}' deleted")
+            else:
+                results["steps"].append(
+                    f"Failed to delete RunPod endpoint '{self.deployment_name}' or it does not exist"
+                )
+
+            # Delete template if we know its name
+            state = self.state_manager.read_state(self.deployment_name)
+            template_name = state.get("template_name") if state else self.deployment_name
+
+            if template_name:
+                if delete_runpod_template_by_name(template_name):
+                    results["steps"].append(f"RunPod template '{template_name}' deleted")
+                else:
+                    results["steps"].append(f"Failed to delete RunPod template '{template_name}'")
 
             # Update state
             self.state_manager.update_deployment_status(self.deployment_name, DeploymentStatus.DESTROYED.value)

--- a/tests/deploy/test_runpod.py
+++ b/tests/deploy/test_runpod.py
@@ -388,36 +388,52 @@ class TestRunPodDeployer:
 
     def test_destroy(self, basic_deployment, mock_state_manager):
         """Test deployment destruction."""
-        deployer = RunPodDeployer(
-            deployment_name="test-deployment",
-            deployment=basic_deployment,
-            state_manager=mock_state_manager,
-        )
+        with (
+            patch("nodetool.deploy.runpod.delete_runpod_endpoint_by_name") as mock_delete_endpoint,
+            patch("nodetool.deploy.runpod.delete_runpod_template_by_name") as mock_delete_template,
+        ):
+            mock_delete_endpoint.return_value = True
+            mock_delete_template.return_value = True
 
-        result = deployer.destroy()
+            deployer = RunPodDeployer(
+                deployment_name="test-deployment",
+                deployment=basic_deployment,
+                state_manager=mock_state_manager,
+            )
 
-        assert result["status"] == "success"
-        assert result["deployment_name"] == "test-deployment"
-        assert any("manually" in step for step in result["steps"])
-        assert any("console" in step for step in result["steps"])
+            result = deployer.destroy()
 
-        # Should update state
-        mock_state_manager.update_deployment_status.assert_called_once_with(
-            "test-deployment", DeploymentStatus.DESTROYED.value
-        )
+            assert result["status"] == "success"
+            assert result["deployment_name"] == "test-deployment"
+            assert any("endpoint 'test-deployment' deleted" in step for step in result["steps"])
+
+            # Should update state
+            mock_state_manager.update_deployment_status.assert_called_once_with(
+                "test-deployment", DeploymentStatus.DESTROYED.value
+            )
+            mock_delete_endpoint.assert_called_once_with("test-deployment")
+            # Should delete template as well (using deployment_name as default template name)
+            mock_delete_template.assert_called_once_with("test-deployment")
 
     def test_destroy_failure(self, basic_deployment, mock_state_manager):
         """Test destroy with state manager failure."""
         mock_state_manager.update_deployment_status.side_effect = Exception("State update failed")
 
-        deployer = RunPodDeployer(
-            deployment_name="test-deployment",
-            deployment=basic_deployment,
-            state_manager=mock_state_manager,
-        )
+        with (
+            patch("nodetool.deploy.runpod.delete_runpod_endpoint_by_name") as mock_delete_endpoint,
+            patch("nodetool.deploy.runpod.delete_runpod_template_by_name") as mock_delete_template,
+        ):
+            mock_delete_endpoint.return_value = True
+            mock_delete_template.return_value = True
 
-        with pytest.raises(Exception, match="State update failed"):
-            deployer.destroy()
+            deployer = RunPodDeployer(
+                deployment_name="test-deployment",
+                deployment=basic_deployment,
+                state_manager=mock_state_manager,
+            )
+
+            with pytest.raises(Exception, match="State update failed"):
+                deployer.destroy()
 
 
 class TestRunPodDeployerEdgeCases:

--- a/tests/deploy/test_runpod.py
+++ b/tests/deploy/test_runpod.py
@@ -17,7 +17,7 @@ from nodetool.config.deployment import (
 from nodetool.deploy.runpod import RunPodDeployer
 
 # Mark all tests to not use any fixtures from conftest
-pytest_plugins = ()
+# pytest_plugins = ()
 
 
 class TestRunPodDeployer:


### PR DESCRIPTION
Implemented automated endpoint and template deletion for RunPod deployments.
Previously, the `destroy` command only updated the local state and printed instructions for manual deletion.
Now, it attempts to delete the endpoint and the template via the RunPod API.

Tests were updated to mock the API calls and verify that the deletion functions are invoked correctly.
Existing tests pass.

---
*PR created automatically by Jules for task [11114041520457474917](https://jules.google.com/task/11114041520457474917) started by @georgi*