### PR TITLE
chore: remove dead code in base_node.py

### DIFF
--- a/src/nodetool/workflows/base_node.py
+++ b/src/nodetool/workflows/base_node.py
@@ -2202,9 +2202,6 @@ class Preview(BaseNode):
         """Consume inbound preview values as a stream to avoid missing items."""
         return True
 
-    # def result_for_client(self, result: dict[str, Any]) -> dict[str, Any]:
-    #     return self.result_for_all_outputs(result)
-
 
 def find_node_class_by_name(class_name: str) -> type[BaseNode] | None:
     """Find a node class by its class name (without namespace).


### PR DESCRIPTION
🎯 **What:** Removed the commented-out `result_for_client` method in `src/nodetool/workflows/base_node.py` inside the `Preview` class.

💡 **Why:** The code was commented out and thus dead. Removing it improves readability and maintainability of the codebase.

✅ **Verification:**
- Ran `uv run ruff check src/nodetool/workflows/base_node.py` (Passed)
- Ran `uv run pytest tests/workflows/test_base_node.py tests/workflows/test_result_for_client_assetref.py` (Passed)

✨ **Result:** Cleaner code in `BaseNode` module.

---
*PR created automatically by Jules for task [3943921602203649214](https://jules.google.com/task/3943921602203649214) started by @georgi*