### PR TITLE
🧹 Remove dead code: commented out `pop_message` method

### DIFF
--- a/src/nodetool/workflows/processing_context.py
+++ b/src/nodetool/workflows/processing_context.py
@@ -581,16 +581,6 @@ class ProcessingContext:
         """
         return await _in_thread(self.message_queue.get)
 
-    # def pop_message(self) -> ProcessingMessage:
-    #     """
-    #     Removes and returns the next message from the message queue.
-
-    #     Returns:
-    #         The next message from the message queue.
-    #     """
-    #     assert isinstance(self.message_queue, Queue)
-    #     return self.message_queue.get()
-
     def post_message(self, message: ProcessingMessage):
         """
         Posts a message to the message queue.


### PR DESCRIPTION
**What:** Removed the commented-out `pop_message` method in `src/nodetool/workflows/processing_context.py`.
**Why:** The code was dead and commented out, replaced by `pop_message_async`. Removing it improves code cleanliness and readability.
**Verification:**
- Ran `grep` to ensure no references to `pop_message` exist (except `pop_message_async`).
- Ran `pytest tests/workflows/test_processing_context_db.py` to ensure `pop_message_async` works correctly.
- Ran `ruff check src/nodetool/workflows/processing_context.py`.
**Result:** The `ProcessingContext` class is cleaner without commented-out legacy code.

---
*PR created automatically by Jules for task [6579115605833979625](https://jules.google.com/task/6579115605833979625) started by @georgi*