### PR TITLE
Cleanup commented-out deprecated imports in openai_prediction.py

### DIFF
--- a/src/nodetool/providers/openai_prediction.py
+++ b/src/nodetool/providers/openai_prediction.py
@@ -490,14 +490,7 @@ async def run_openai(prediction: Prediction, env: dict[str, str]) -> AsyncGenera
 
 
 # --- Cost Calculation Helpers (DEPRECATED) ---
-# These functions are deprecated. Please use the new centralized cost calculator instead:
-# from nodetool.providers.cost_calculator import (
-#     calculate_chat_cost,
-#     calculate_embedding_cost,
-#     calculate_speech_cost,
-#     calculate_whisper_cost,
-#     calculate_image_cost,
-# )
+# These functions are deprecated. Please use nodetool.providers.cost_calculator instead.
 # Or use BaseProvider.track_usage() for automatic cost tracking.
 
 


### PR DESCRIPTION
This PR removes a block of commented-out, deprecated import statements in `src/nodetool/providers/openai_prediction.py`. 

**Changes:**
- Removed commented-out `from nodetool.providers.cost_calculator import ...` lines.
- Updated the comment to explicitly direct developers to `nodetool.providers.cost_calculator` or `BaseProvider.track_usage()`.

**Verification:**
- Verified file content.
- Ran the script `src/nodetool/providers/openai_prediction.py` to ensure it parses correctly (fails at runtime due to missing API key as expected).
- Ran `ruff check` and `ruff format` to ensure linting compliance.
- Ran `pytest tests/providers/test_cost_calculator.py` to ensure the referred module is still working correctly.

---
*PR created automatically by Jules for task [17226296084123142617](https://jules.google.com/task/17226296084123142617) started by @georgi*