### PR TITLE
🧹 Implement RunPod endpoint deletion via API

### DIFF
--- a/src/nodetool/deploy/runpod.py
+++ b/src/nodetool/deploy/runpod.py
@@ -16,6 +16,7 @@ from nodetool.config.deployment import (
     RunPodDeployment,
 )
 from nodetool.deploy.deploy_to_runpod import deploy_to_runpod
+from nodetool.deploy.runpod_api import delete_runpod_endpoint_by_name
 from nodetool.deploy.state import StateManager
 
 logger = logging.getLogger(__name__)
@@ -231,14 +232,20 @@ class RunPodDeployer:
         }
 
         try:
-            results["steps"].append("Destroying RunPod endpoint...")
+            results["steps"].append(f"Destroying RunPod endpoint '{self.deployment_name}'...")
 
-            # TODO: Implement endpoint deletion via RunPod API
-            # For now, user must delete manually via RunPod console
-            results["steps"].append("⚠️  RunPod endpoint deletion must be done manually via RunPod console")
-            results["steps"].append(
-                f"Visit https://www.runpod.io/console/serverless and delete endpoint '{self.deployment_name}'"
-            )
+            # Delete endpoint via RunPod API
+            if delete_runpod_endpoint_by_name(self.deployment_name):
+                results["steps"].append(f"RunPod endpoint '{self.deployment_name}' deleted successfully")
+            else:
+                # If deletion failed, it might not exist or there was an error
+                # Since delete_runpod_endpoint_by_name handles "not found" as success (returns True),
+                # returning False implies an actual error occurred.
+                error_msg = f"Failed to delete RunPod endpoint '{self.deployment_name}'"
+                results["steps"].append(f"⚠️  {error_msg}")
+                results["errors"].append(error_msg)
+                results["status"] = "error"
+                raise Exception(error_msg)
 
             # Update state
             self.state_manager.update_deployment_status(self.deployment_name, DeploymentStatus.DESTROYED.value)

--- a/tests/deploy/test_runpod.py
+++ b/tests/deploy/test_runpod.py
@@ -388,36 +388,59 @@ class TestRunPodDeployer:
 
     def test_destroy(self, basic_deployment, mock_state_manager):
         """Test deployment destruction."""
-        deployer = RunPodDeployer(
-            deployment_name="test-deployment",
-            deployment=basic_deployment,
-            state_manager=mock_state_manager,
-        )
+        with patch("nodetool.deploy.runpod.delete_runpod_endpoint_by_name") as mock_delete:
+            mock_delete.return_value = True
 
-        result = deployer.destroy()
+            deployer = RunPodDeployer(
+                deployment_name="test-deployment",
+                deployment=basic_deployment,
+                state_manager=mock_state_manager,
+            )
 
-        assert result["status"] == "success"
-        assert result["deployment_name"] == "test-deployment"
-        assert any("manually" in step for step in result["steps"])
-        assert any("console" in step for step in result["steps"])
+            result = deployer.destroy()
 
-        # Should update state
-        mock_state_manager.update_deployment_status.assert_called_once_with(
-            "test-deployment", DeploymentStatus.DESTROYED.value
-        )
+            assert result["status"] == "success"
+            assert result["deployment_name"] == "test-deployment"
+            assert any("deleted successfully" in step for step in result["steps"])
+            assert not any("manually" in step for step in result["steps"])
+
+            # Should call API
+            mock_delete.assert_called_once_with("test-deployment")
+
+            # Should update state
+            mock_state_manager.update_deployment_status.assert_called_once_with(
+                "test-deployment", DeploymentStatus.DESTROYED.value
+            )
+
+    def test_destroy_api_failure(self, basic_deployment, mock_state_manager):
+        """Test destroy when API returns false."""
+        with patch("nodetool.deploy.runpod.delete_runpod_endpoint_by_name") as mock_delete:
+            mock_delete.return_value = False
+
+            deployer = RunPodDeployer(
+                deployment_name="test-deployment",
+                deployment=basic_deployment,
+                state_manager=mock_state_manager,
+            )
+
+            with pytest.raises(Exception, match="Failed to delete"):
+                deployer.destroy()
 
     def test_destroy_failure(self, basic_deployment, mock_state_manager):
         """Test destroy with state manager failure."""
         mock_state_manager.update_deployment_status.side_effect = Exception("State update failed")
 
-        deployer = RunPodDeployer(
-            deployment_name="test-deployment",
-            deployment=basic_deployment,
-            state_manager=mock_state_manager,
-        )
+        with patch("nodetool.deploy.runpod.delete_runpod_endpoint_by_name") as mock_delete:
+            mock_delete.return_value = True
 
-        with pytest.raises(Exception, match="State update failed"):
-            deployer.destroy()
+            deployer = RunPodDeployer(
+                deployment_name="test-deployment",
+                deployment=basic_deployment,
+                state_manager=mock_state_manager,
+            )
+
+            with pytest.raises(Exception, match="State update failed"):
+                deployer.destroy()
 
 
 class TestRunPodDeployerEdgeCases:


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Implemented automated RunPod endpoint deletion in `RunPodDeployer.destroy`, replacing the manual "TODO" instructions.

💡 **Why:** How this improves maintainability
This integrates the existing RunPod API client to provide a complete lifecycle management for RunPod deployments, removing the need for manual user intervention and resolving a pending TODO.

✅ **Verification:** How you confirmed the change is safe
- Ran `pytest tests/deploy/test_runpod.py` which includes new tests for `destroy` method success and failure paths.
- Verified that `delete_runpod_endpoint_by_name` is correctly called and exceptions are handled.

✨ **Result:** The improvement achieved
Users can now automatically destroy RunPod endpoints using the deployer, and the code health issue regarding missing implementation is resolved.

---
*PR created automatically by Jules for task [7993799208344932105](https://jules.google.com/task/7993799208344932105) started by @georgi*