### PR TITLE
Store compressed streaming outputs in temp storage

### DIFF
--- a/src/nodetool/workflows/output_serialization.py
+++ b/src/nodetool/workflows/output_serialization.py
@@ -16,10 +16,14 @@ Important for Streaming:
 - Store compressed chunks in temp storage if needed
 """
 
+import gzip
+import io
 import json
+import uuid
 from typing import Any
 
 from nodetool.config.logging_config import get_logger
+from nodetool.runtime.resources import maybe_scope
 
 log = get_logger(__name__)
 
@@ -270,7 +274,7 @@ def deserialize_outputs_dict(serialized_outputs: dict[str, dict]) -> dict[str, A
     return result
 
 
-def compress_streaming_outputs(outputs: dict[str, Any]) -> dict:
+async def compress_streaming_outputs(outputs: dict[str, Any]) -> dict:
     """Compress streaming outputs into single log entry.
 
     Streaming nodes can emit thousands of chunks (e.g., 1000 video frames),
@@ -285,13 +289,13 @@ def compress_streaming_outputs(outputs: dict[str, Any]) -> dict:
         - {'type': 'streaming_compressed', 'chunk_count': N, 'storage_id': 'not_implemented', 'size_bytes': X}
 
     Note:
-        The actual chunks should be stored in temp storage (not implemented yet).
+        The actual chunks should be stored in temp storage.
         This prevents bloating the event log while maintaining recoverability.
 
     Example:
         >>> # Node emits 1000 image chunks
         >>> outputs = {'frames': [ImageRef(...) for _ in range(1000)]}
-        >>> compressed = compress_streaming_outputs(outputs)
+        >>> compressed = await compress_streaming_outputs(outputs)
         >>> compressed['chunk_count']
         1000
         >>> compressed['type']
@@ -310,16 +314,43 @@ def compress_streaming_outputs(outputs: dict[str, Any]) -> dict:
         serialized = json.dumps(outputs, default=str)
         size_bytes = len(serialized.encode("utf-8"))
     except Exception:
+        serialized = "{}"
         size_bytes = 0
 
+    storage_id = "not_implemented"
+
+    # Compress and store in temp storage
+    try:
+        scope = maybe_scope()
+        if scope:
+            temp_storage = scope.get_temp_storage()
+            if temp_storage:
+                # Compress
+                compressed_io = io.BytesIO()
+                with gzip.GzipFile(fileobj=compressed_io, mode="wb") as gz:
+                    gz.write(serialized.encode("utf-8"))
+                compressed_io.seek(0)
+
+                # Upload
+                key = f"streaming/{uuid.uuid4()}.json.gz"
+                storage_id = await temp_storage.upload(key, compressed_io)
+            else:
+                log.warning("No temp storage available in current scope")
+        else:
+            log.warning("No resource scope available for streaming outputs")
+
+    except Exception as e:
+        log.error(f"Failed to compress streaming outputs: {e}")
+        storage_id = f"error_{str(e)[:50]}"
+
     log.debug(
-        f"Compressing streaming outputs: {chunk_count} chunks, ~{size_bytes} bytes (should store in temp storage)"
+        f"Compressing streaming outputs: {chunk_count} chunks, ~{size_bytes} bytes (stored as {storage_id})"
     )
 
     return {
         "type": "streaming_compressed",
         "chunk_count": chunk_count,
-        "storage_id": "not_implemented",  # TODO: store in temp storage
+        "storage_id": storage_id,
         "size_bytes": size_bytes,
     }
 

--- a/tests/workflows/test_output_serialization.py
+++ b/tests/workflows/test_output_serialization.py
@@ -2,6 +2,8 @@
 Tests for output serialization utilities.
 """
 
+from unittest.mock import AsyncMock, Mock, patch
+
 import pytest
 
 from nodetool.workflows.output_serialization import (
@@ -192,23 +194,67 @@ def test_deserialize_outputs_dict():
     assert hasattr(result["image"], "uri")
 
 
-def test_compress_streaming_outputs():
+@pytest.mark.asyncio
+async def test_compress_streaming_outputs():
     """Test compression of streaming outputs."""
     from nodetool.metadata.types import ImageRef
     from nodetool.workflows.output_serialization import compress_streaming_outputs
 
     # Simulate 1000 image chunks from streaming node
     outputs = {
-        "frames": [ImageRef(uri=f"temp://frame_{i}.png", asset_id=f"frame_{i}") for i in range(1000)],
+        "frames": [
+            ImageRef(uri=f"temp://frame_{i}.png", asset_id=f"frame_{i}")
+            for i in range(1000)
+        ],
         "metadata": {"fps": 30, "duration": 33.33},
     }
 
-    compressed = compress_streaming_outputs(outputs)
+    # Mock scope and temp storage
+    mock_storage = AsyncMock()
+    mock_storage.upload.return_value = "streaming/mock_uuid.json.gz"
+
+    mock_scope = Mock()
+    mock_scope.get_temp_storage.return_value = mock_storage
+
+    with patch(
+        "nodetool.workflows.output_serialization.maybe_scope", return_value=mock_scope
+    ):
+        compressed = await compress_streaming_outputs(outputs)
 
     assert compressed["type"] == "streaming_compressed"
     assert compressed["chunk_count"] == 1001  # 1000 frames + 1 metadata
     assert "size_bytes" in compressed
-    assert compressed["storage_id"] == "not_implemented"  # TODO: implement temp storage
+    assert compressed["storage_id"] == "streaming/mock_uuid.json.gz"
+
+    # Verify upload was called
+    assert mock_storage.upload.called
+    args, _ = mock_storage.upload.call_args
+    key, content = args
+    assert key.startswith("streaming/")
+    assert key.endswith(".json.gz")
+    # check content is gzipped json
+    import gzip
+    import json
+
+    content.seek(0)
+    with gzip.GzipFile(fileobj=content, mode="rb") as gz:
+        data = json.load(gz)
+        assert len(data["frames"]) == 1000
+
+
+@pytest.mark.asyncio
+async def test_compress_streaming_outputs_no_scope():
+    """Test fallback when no scope is available."""
+    from nodetool.workflows.output_serialization import compress_streaming_outputs
+
+    outputs = {"data": [1, 2, 3]}
+
+    with patch(
+        "nodetool.workflows.output_serialization.maybe_scope", return_value=None
+    ):
+        compressed = await compress_streaming_outputs(outputs)
+
+    assert compressed["storage_id"] == "not_implemented"
 
 
 def test_should_compress_streaming():


### PR DESCRIPTION
Implemented temporary storage for compressed streaming outputs.

Changes:
- `src/nodetool/workflows/output_serialization.py`:
    - Updated `compress_streaming_outputs` to be an `async` function.
    - Added logic to serialize outputs to JSON, compress with Gzip, and upload to temp storage using `maybe_scope().get_temp_storage()`.
    - Generates unique storage keys (`streaming/{uuid}.json.gz`).
    - Returns the actual `storage_id` instead of "not_implemented".
    - added imports: `gzip`, `io`, `uuid`, `maybe_scope`.

- `tests/workflows/test_output_serialization.py`:
    - Updated `test_compress_streaming_outputs` to use `@pytest.mark.asyncio`.
    - Added mocking for `maybe_scope` and `temp_storage`.
    - Verifies that data is correctly compressed and uploaded.
    - Added `test_compress_streaming_outputs_no_scope` to verify fallback behavior.


---
*PR created automatically by Jules for task [14743776903846670975](https://jules.google.com/task/14743776903846670975) started by @georgi*