### PR TITLE
🛡️ Sentinel: [HIGH] Fix disabled SSL verification in httpx requests

### DIFF
--- a/src/nodetool/providers/llama_provider.py
+++ b/src/nodetool/providers/llama_provider.py
@@ -456,7 +456,7 @@ class LlamaProvider(BaseProvider, OpenAICompat):
         except RuntimeError:
             # Fallback if no scope is bound (shouldn't happen in normal operation)
             log.warning("No ResourceScope bound, creating fallback HTTP client for Llama")
-            http_client = httpx.AsyncClient(follow_redirects=True, timeout=600, verify=False)
+            http_client = httpx.AsyncClient(follow_redirects=True, timeout=600)
 
         # llama-server accepts any API key; None is fine when auth is disabled
         return openai.AsyncClient(
@@ -500,7 +500,7 @@ class LlamaProvider(BaseProvider, OpenAICompat):
             return []
 
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(2.0, connect=0.5), verify=False) as client:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(2.0, connect=0.5)) as client:
                 response = await client.get(f"{self._base_url}/v1/models")
                 response.raise_for_status()
                 payload = response.json()

--- a/src/nodetool/runtime/resources.py
+++ b/src/nodetool/runtime/resources.py
@@ -532,7 +532,6 @@ class ResourceScope:
             self._http_client = httpx.AsyncClient(
                 follow_redirects=True,
                 timeout=600,
-                verify=False,
                 headers=HTTP_HEADERS.copy(),
             )
             # Mark that we own this HTTP client


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Several instances of `httpx.AsyncClient` were explicitly configured with `verify=False`, which completely disables TLS/SSL certificate validation.
🎯 **Impact**: This creates a critical vulnerability to Man-in-the-Middle (MitM) attacks. An attacker could intercept, read, or maliciously modify network traffic, potentially exposing sensitive data or injecting malicious responses.
🔧 **Fix**: Removed `verify=False` from all affected `httpx.AsyncClient` instantiations in `src/nodetool/runtime/resources.py` and `src/nodetool/providers/llama_provider.py`. The default behavior of `verify=True` is now used, ensuring connections are securely validated against a trusted certificate authority.
✅ **Verification**: Run `pytest tests/chat/providers/test_llama_provider.py` and `pytest tests/workflows/test_processing_context_db.py` to ensure core functionality is preserved with secure connections. Checked codebase using `bandit -r src/ | grep -B 2 -A 5 "verify=False"`.

---
*PR created automatically by Jules for task [103404262293754125](https://jules.google.com/task/103404262293754125) started by @georgi*