### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix symlink-based path traversal in `ensure_within_root`

### DIFF
--- a/src/nodetool/api/file.py
+++ b/src/nodetool/api/file.py
@@ -56,8 +56,8 @@ def ensure_within_root(root: str, path: str, error_message: str) -> str:
     """
     Ensure the given path is contained within root, normalizing for case-insensitive filesystems.
     """
-    normalized_root = os.path.normcase(os.path.abspath(root))
-    normalized_path = os.path.normcase(os.path.abspath(path))
+    normalized_root = os.path.normcase(os.path.realpath(root))
+    normalized_path = os.path.normcase(os.path.realpath(path))
     root_prefix = normalized_root if normalized_root.endswith(os.sep) else normalized_root + os.sep
     if normalized_path != normalized_root and not normalized_path.startswith(root_prefix):
         raise HTTPException(status_code=403, detail=error_message)

--- a/src/nodetool/api/workspace.py
+++ b/src/nodetool/api/workspace.py
@@ -317,8 +317,8 @@ def ensure_within_root(root: str, path: str, error_message: str) -> str:
     """
     Ensure the given path is contained within root, normalizing for case-insensitive filesystems.
     """
-    normalized_root = os.path.normcase(os.path.abspath(root))
-    normalized_path = os.path.normcase(os.path.abspath(path))
+    normalized_root = os.path.normcase(os.path.realpath(root))
+    normalized_path = os.path.normcase(os.path.realpath(path))
     root_prefix = normalized_root if normalized_root.endswith(os.sep) else normalized_root + os.sep
     if normalized_path != normalized_root and not normalized_path.startswith(root_prefix):
         raise HTTPException(status_code=403, detail=error_message)


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `ensure_within_root` function used `os.path.abspath` to normalize paths, which does not resolve symlinks. This allows an attacker to create a symlink inside the allowed root directory that points to an arbitrary location (e.g., `/etc/passwd`) outside the boundary, successfully bypassing the directory boundary check.
🎯 **Impact:** Unauthorized access and arbitrary file read outside the designated `SAFE_ROOTS` or workspace boundaries.
🔧 **Fix:** Replaced `os.path.abspath` with `os.path.realpath` in `ensure_within_root` (both in `src/nodetool/api/file.py` and `src/nodetool/api/workspace.py`) to fully resolve any symlinks before boundary validation, effectively closing the path traversal vulnerability.
✅ **Verification:** Ran pytest tests `tests/api/test_workspace_api.py` and `tests/api/test_file_api.py` and everything works as expected.

---
*PR created automatically by Jules for task [8004189946230261931](https://jules.google.com/task/8004189946230261931) started by @georgi*