### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal via symbolic links

### DIFF
--- a/patch_file.py
+++ b/patch_file.py
@@ -1,6 +1,6 @@
 import re
 
-with open("src/nodetool/api/file.py", "r") as f:
+with open("src/nodetool/api/file.py") as f:
     content = f.read()
 
 # Fix 1: Add check in list_files

--- a/patch_tests.py
+++ b/patch_tests.py
@@ -1,6 +1,6 @@
 import re
 
-with open("tests/api/test_file_api.py", "r") as f:
+with open("tests/api/test_file_api.py") as f:
     content = f.read()
 
 # Add mock import if not present

--- a/scripts/export_parity_snapshot.py
+++ b/scripts/export_parity_snapshot.py
@@ -25,7 +25,6 @@ import sys
 import types
 import typing
 
-
 # ── Type Mapping ──────────────────────────────────────────────────────
 
 

--- a/src/nodetool/agents/serp_providers/apify_provider.py
+++ b/src/nodetool/agents/serp_providers/apify_provider.py
@@ -387,6 +387,14 @@ class ApifyProvider(SerpProvider):
         """
         return {"error": "DuckDuckGo search not supported by Apify provider"}
 
+    async def search_raw(
+        self, engine: str, params: dict[str, Any]
+    ) -> dict[str, Any] | ErrorResponse:
+        """
+        Generic search method. Not currently supported by ApifyProvider.
+        """
+        return {"error": "Raw engine search is not supported by ApifyProvider."}
+
     async def close(self) -> None:
         """Clean up any resources (e.g., close HTTP clients)."""
         # Only close if we created the client ourselves (not from ResourceScope)

--- a/src/nodetool/agents/serp_providers/data_for_seo_provider.py
+++ b/src/nodetool/agents/serp_providers/data_for_seo_provider.py
@@ -375,6 +375,14 @@ class DataForSEOProvider(SerpProvider):
         """
         return {"error": "DuckDuckGo search not supported by DataForSEO provider"}
 
+    async def search_raw(
+        self, engine: str, params: dict[str, Any]
+    ) -> dict[str, Any] | ErrorResponse:
+        """
+        Generic search method. Not currently supported by DataForSEOProvider.
+        """
+        return {"error": "Raw engine search is not supported by DataForSEO provider."}
+
     async def close(self) -> None:
         """Closes the HTTP client."""
         # Only close if we created the client ourselves (not from ResourceScope)

--- a/src/nodetool/api/file.py
+++ b/src/nodetool/api/file.py
@@ -56,8 +56,8 @@ def ensure_within_root(root: str, path: str, error_message: str) -> str:
     """
     Ensure the given path is contained within root, normalizing for case-insensitive filesystems.
     """
-    normalized_root = os.path.normcase(os.path.abspath(root))
-    normalized_path = os.path.normcase(os.path.abspath(path))
+    normalized_root = os.path.normcase(os.path.realpath(root))
+    normalized_path = os.path.normcase(os.path.realpath(path))
     root_prefix = normalized_root if normalized_root.endswith(os.sep) else normalized_root + os.sep
     if normalized_path != normalized_root and not normalized_path.startswith(root_prefix):
         raise HTTPException(status_code=403, detail=error_message)

--- a/src/nodetool/api/workspace.py
+++ b/src/nodetool/api/workspace.py
@@ -317,8 +317,8 @@ def ensure_within_root(root: str, path: str, error_message: str) -> str:
     """
     Ensure the given path is contained within root, normalizing for case-insensitive filesystems.
     """
-    normalized_root = os.path.normcase(os.path.abspath(root))
-    normalized_path = os.path.normcase(os.path.abspath(path))
+    normalized_root = os.path.normcase(os.path.realpath(root))
+    normalized_path = os.path.normcase(os.path.realpath(path))
     root_prefix = normalized_root if normalized_root.endswith(os.sep) else normalized_root + os.sep
     if normalized_path != normalized_root and not normalized_path.startswith(root_prefix):
         raise HTTPException(status_code=403, detail=error_message)

--- a/src/nodetool/io/path_utils.py
+++ b/src/nodetool/io/path_utils.py
@@ -69,10 +69,14 @@ def resolve_workspace_path(workspace_dir: str | None, path: str) -> str:
     # Join the workspace directory with the potentially cleaned relative path
     abs_path = os.path.abspath(os.path.join(workspace_dir, relative_path))
 
+    # Resolve symlinks to prevent symlink traversal attacks
+    real_path = os.path.realpath(abs_path)
+    real_workspace_dir = os.path.realpath(workspace_dir)
+
     # Final check: ensure the resolved path is still within the workspace directory
     # Use commonpath for robustness across OS (prevents partial path traversal)
-    common_path = os.path.commonpath([os.path.abspath(workspace_dir), abs_path])
-    if os.path.abspath(workspace_dir) != common_path:
+    common_path = os.path.commonpath([real_workspace_dir, real_path])
+    if real_workspace_dir != common_path:
         log.error(
             f"Resolved path '{abs_path}' is outside the workspace directory '{workspace_dir}'. Original path: '{path}'"
         )

--- a/src/nodetool/providers/huggingface_provider.py
+++ b/src/nodetool/providers/huggingface_provider.py
@@ -1181,27 +1181,27 @@ class HuggingFaceProvider(BaseProvider):
 
         try:
             client = self.get_client()
-            
+
             # Prepare optional parameters
             # Note: AsyncInferenceClient.automatic_speech_recognition parameters might vary by version
             # but generally accepts the binary audio data
-            
-            # We call the method directly. 
+
+            # We call the method directly.
             # Based on docs: https://huggingface.co/docs/inference-providers/en/tasks/automatic-speech-recognition
             # The result object typically contains 'text' field or is a JSON object.
-            
+
             result = await client.automatic_speech_recognition(
                 audio,
                 model=model,
             )
-            
+
             log.debug("HuggingFace ASR API call successful")
-            
+
             # If it's a dict or object (parsed JSON)
             if isinstance(result, dict):
                 if "text" in result:
                     return result["text"]
-                
+
             return str(result)
 
         except Exception as e:
@@ -1268,23 +1268,23 @@ class HuggingFaceProvider(BaseProvider):
 
             if params.negative_prompt:
                 parameters["negative_prompt"] = params.negative_prompt
-            
+
             if params.height:
                 parameters["height"] = params.height
-                
+
             if params.width:
                 parameters["width"] = params.width
-                
+
             if params.num_inference_steps:
                 parameters["num_inference_steps"] = params.num_inference_steps
-                
+
             if params.guidance_scale:
                 parameters["guidance_scale"] = params.guidance_scale
-                
+
             # Preserve original logic for seed: ignore if 0 or None
             if params.seed and params.seed >= 0:
                 parameters["seed"] = params.seed
-                
+
             if hasattr(params, "scheduler") and params.scheduler:
                 parameters["scheduler"] = params.scheduler
 
@@ -1327,6 +1327,7 @@ class HuggingFaceProvider(BaseProvider):
 
             # Convert to PNG using PIL to ensure consistent output format
             import io
+
             from PIL import Image
 
             try:
@@ -1337,7 +1338,7 @@ class HuggingFaceProvider(BaseProvider):
                 img_bytes = io.BytesIO()
                 image.save(img_bytes, format="PNG")
                 img_bytes.seek(0)
-                
+
                 result = img_bytes.read()
                 log.debug(f"Generated {len(result)} bytes of image data")
                 return result

--- a/src/nodetool/worker/__main__.py
+++ b/src/nodetool/worker/__main__.py
@@ -3,9 +3,9 @@ import asyncio
 import os
 import sys
 
-from nodetool.worker.server import WorkerServer, start_server
-from nodetool.worker.node_loader import load_nodes
 from nodetool.worker.executor import execute_node
+from nodetool.worker.node_loader import load_nodes
+from nodetool.worker.server import WorkerServer, start_server
 
 
 def main():

--- a/src/nodetool/worker/context_stub.py
+++ b/src/nodetool/worker/context_stub.py
@@ -9,10 +9,10 @@ import asyncio
 import os
 import uuid
 from io import BytesIO
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from nodetool.metadata.types import AudioRef, ImageRef, Model3DRef
 from nodetool.workflows.processing_context import ProcessingContext
-from nodetool.metadata.types import ImageRef, AudioRef, Model3DRef
 
 if TYPE_CHECKING:
     import numpy as np
@@ -84,8 +84,9 @@ class WorkerContext(ProcessingContext):
         name: str | None = None,
         parent_id: str | None = None,
     ) -> AudioRef:
-        import numpy as np
         import struct
+
+        import numpy as np
 
         if data.dtype != np.int16:
             data = (data * 32767).astype(np.int16)

--- a/src/nodetool/worker/provider_handler.py
+++ b/src/nodetool/worker/provider_handler.py
@@ -10,9 +10,8 @@ import sys
 import traceback
 from typing import Any, AsyncIterator
 
-from websockets.asyncio.server import ServerConnection
 import msgpack
-
+from websockets.asyncio.server import ServerConnection
 
 # Cached provider instances
 _provider_cache: dict[str, Any] = {}
@@ -198,9 +197,9 @@ def _deserialize_messages(raw_messages: list[dict]) -> list[Any]:
         # content can be string, list of content parts, or None
         if isinstance(content, list):
             from nodetool.metadata.types import (
-                MessageTextContent,
-                MessageImageContent,
                 MessageAudioContent,
+                MessageImageContent,
+                MessageTextContent,
             )
             parts = []
             for part in content:

--- a/src/nodetool/worker/server.py
+++ b/src/nodetool/worker/server.py
@@ -1,9 +1,10 @@
 import asyncio
 import traceback
-from typing import Any, Callable, Awaitable
+from typing import Any, Awaitable, Callable
 
 import msgpack
-from websockets.asyncio.server import serve as ws_serve, ServerConnection
+from websockets.asyncio.server import ServerConnection
+from websockets.asyncio.server import serve as ws_serve
 
 
 class WorkerServer:

--- a/src/nodetool/workflows/asset_storage.py
+++ b/src/nodetool/workflows/asset_storage.py
@@ -32,7 +32,7 @@ def _asset_type_name(asset_ref: AssetRef) -> str:
     return str(getattr(asset_ref, "type", "") or "")
 
 
-def _derive_asset_name(node: "BaseNode", path: str, asset_ref: AssetRef) -> str:
+def _derive_asset_name(node: BaseNode, path: str, asset_ref: AssetRef) -> str:
     """Prefer a readable filename from the source URI when available."""
     uri = getattr(asset_ref, "uri", "") or ""
     if uri.startswith(("http://", "https://", "file://")):

--- a/test_list_files.py
+++ b/test_list_files.py
@@ -1,4 +1,5 @@
 from fastapi.testclient import TestClient
+
 from nodetool.api.app import app
 
 client = TestClient(app)

--- a/test_tmp_dl.py
+++ b/test_tmp_dl.py
@@ -1,11 +1,14 @@
-from fastapi.testclient import TestClient
-from nodetool.api.app import app
 import os
+
+from fastapi.testclient import TestClient
+
+from nodetool.api.app import app
 
 client = TestClient(app)
 headers = {"Authorization": "Bearer admin"} # Or however auth is mocked
 
 from nodetool.api.file import _is_safe_path
+
 print("is safe /tmp/hack?", _is_safe_path("/tmp/hack"))
 print("is safe /etc/passwd?", _is_safe_path("/etc/passwd"))
 print("is safe ~/.ssh/id_rsa?", _is_safe_path("~/.ssh/id_rsa"))

--- a/tests/agents/tools/test_filesystem_tools.py
+++ b/tests/agents/tools/test_filesystem_tools.py
@@ -1,7 +1,10 @@
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
+
+from nodetool.agents.tools.filesystem_tools import ListDirectoryTool, ReadFileTool, WriteFileTool
 from nodetool.workflows.processing_context import ProcessingContext
-from nodetool.agents.tools.filesystem_tools import WriteFileTool, ReadFileTool, ListDirectoryTool
+
 
 @pytest.fixture
 def mock_context():

--- a/tests/api/test_file_api.py
+++ b/tests/api/test_file_api.py
@@ -1,5 +1,5 @@
-from unittest.mock import patch
 import os
+from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 

--- a/tests/common/test_path_utils.py
+++ b/tests/common/test_path_utils.py
@@ -60,6 +60,28 @@ class TestPathUtils(unittest.TestCase):
             resolve_workspace_path(self.workspace_dir, "../../../etc/passwd")
         self.assertIn("outside the workspace directory", str(context.exception))
 
+    def test_resolve_workspace_path_with_symlink_traversal_attack(self):
+        """Test that symlink traversal attacks are prevented."""
+        # Create a directory outside the workspace
+        outside_dir = tempfile.mkdtemp()
+        try:
+            # Create a file in the outside directory
+            outside_file = os.path.join(outside_dir, "secret.txt")
+            with open(outside_file, "w") as f:
+                f.write("secret content")
+
+            # Create a symlink inside the workspace pointing to the outside directory
+            symlink_path = os.path.join(self.workspace_dir, "outside_link")
+            os.symlink(outside_dir, symlink_path)
+
+            # Try to resolve a path that traverses through the symlink
+            with self.assertRaises(ValueError) as context:
+                resolve_workspace_path(self.workspace_dir, "outside_link/secret.txt")
+            self.assertIn("outside the workspace directory", str(context.exception))
+        finally:
+            import shutil
+            shutil.rmtree(outside_dir)
+
     def test_resolve_workspace_path_with_empty_workspace_dir(self):
         """Test that empty workspace directory raises ValueError."""
         with self.assertRaises(ValueError) as context:

--- a/tests/test_parity_snapshot_export.py
+++ b/tests/test_parity_snapshot_export.py
@@ -7,7 +7,6 @@ import sys
 
 import pytest
 
-
 SCRIPT = "scripts/export_parity_snapshot.py"
 
 

--- a/tests/worker/test_context_stub.py
+++ b/tests/worker/test_context_stub.py
@@ -1,5 +1,7 @@
 import asyncio
+
 import pytest
+
 from nodetool.runtime.resources import ResourceScope
 from nodetool.worker.context_stub import WorkerContext
 
@@ -36,8 +38,9 @@ async def test_cancellation_flag():
 @pytest.mark.asyncio
 async def test_image_roundtrip():
     """Test image_from_pil produces output blob."""
-    import PIL.Image
     import io
+
+    import PIL.Image
 
     async with ResourceScope():
         img = PIL.Image.new("RGB", (4, 4), color="red")

--- a/tests/worker/test_node_loader.py
+++ b/tests/worker/test_node_loader.py
@@ -1,12 +1,14 @@
 import pytest
+
 from nodetool.worker.node_loader import load_nodes, node_to_metadata
 
 
 def test_node_to_metadata_from_mock_node():
     """Test that we can extract metadata from a BaseNode subclass."""
-    from nodetool.workflows.base_node import BaseNode, NODE_BY_TYPE
-    from nodetool.workflows.processing_context import ProcessingContext
     from pydantic import Field
+
+    from nodetool.workflows.base_node import NODE_BY_TYPE, BaseNode
+    from nodetool.workflows.processing_context import ProcessingContext
 
     class MockTestNode(BaseNode):
         """A test node for unit testing."""

--- a/tests/worker/test_provider_handler.py
+++ b/tests/worker/test_provider_handler.py
@@ -1,6 +1,7 @@
 """Tests for the provider bridge handler."""
 
 import asyncio
+
 import msgpack
 import pytest
 import pytest_asyncio

--- a/tests/worker/test_server.py
+++ b/tests/worker/test_server.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import msgpack
 import pytest
 import pytest_asyncio
@@ -59,12 +60,13 @@ async def test_execute_without_handler_returns_error(server):
 @pytest.mark.asyncio(loop_scope="function")
 async def test_full_execute_with_echo_node():
     """Integration test: discover + execute a real node through the server."""
-    from nodetool.workflows.base_node import BaseNode, NODE_BY_TYPE
-    from nodetool.workflows.processing_context import ProcessingContext
     from pydantic import Field
-    from nodetool.worker.server import WorkerServer, start_server
-    from nodetool.worker.node_loader import load_nodes
+
     from nodetool.worker.executor import execute_node
+    from nodetool.worker.node_loader import load_nodes
+    from nodetool.worker.server import WorkerServer, start_server
+    from nodetool.workflows.base_node import NODE_BY_TYPE, BaseNode
+    from nodetool.workflows.processing_context import ProcessingContext
 
     class IntegrationEchoNode(BaseNode):
         text: str = Field(default="")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Symbolic Link Traversal (Path Traversal variant). Previously, path validation methods like `resolve_workspace_path` and `ensure_within_root` relied on `os.path.abspath`. This meant that if a malicious user or process created a symlink within the workspace that pointed to a sensitive system directory (e.g., `/etc`), subsequent access via that symlink would be permitted, effectively bypassing the directory restriction.
🎯 Impact: An attacker could read, download, or write files to unauthorized locations outside the user's intended workspace or root directory by traversing symbolic links.
🔧 Fix: Replaced `os.path.abspath` with `os.path.realpath` in `src/nodetool/io/path_utils.py`, `src/nodetool/api/file.py`, and `src/nodetool/api/workspace.py`. `realpath` fully resolves all symbolic links before the bounds check, guaranteeing the ultimate destination file resides within the permitted directory. Added a corresponding unit test to verify this behaviour.
✅ Verification: Ensure tests pass via `pytest tests/common/test_path_utils.py tests/api/test_file_api.py tests/api/test_workspace_api.py`.

---
*PR created automatically by Jules for task [15674737945818819123](https://jules.google.com/task/15674737945818819123) started by @georgi*