### PR TITLE
🛡️ Sentinel: [HIGH] Fix SQL Injection in PostgresAdapter

### DIFF
--- a/src/nodetool/models/postgres_adapter.py
+++ b/src/nodetool/models/postgres_adapter.py
@@ -185,6 +185,29 @@ def translate_postgres_params(query: str, params: dict[str, Any]) -> tuple[str, 
     return translated_query, params
 
 
+VALID_COLUMN_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+def _validate_column_name(column_name: str) -> str:
+    """Validate column name to prevent SQL injection.
+
+    Args:
+        column_name: The column name to validate.
+
+    Returns:
+        The validated column name.
+
+    Raises:
+        ValueError: If the column name contains invalid characters.
+    """
+    # Allow "*" as a special case for selecting all columns
+    if column_name == "*":
+        return column_name
+    if not VALID_COLUMN_NAME_RE.match(column_name):
+        raise ValueError(f"Invalid column name: {column_name}")
+    return column_name
+
+
 class PostgresAdapter(DatabaseAdapter):
     """Adapts DBModel operations to a PostgreSQL database."""
 
@@ -214,7 +237,7 @@ class PostgresAdapter(DatabaseAdapter):
             indexes: List of index definitions for the table.
         """
         self.db_params = db_params
-        self.table_name = table_schema["table_name"]
+        self.table_name = _validate_column_name(table_schema["table_name"])
         self.table_schema = table_schema
         self.fields = fields
         self.indexes = indexes
@@ -412,13 +435,14 @@ class PostgresAdapter(DatabaseAdapter):
             A tuple containing the SQL Composed object for the WHERE clause and a list of parameters.
         """
         if isinstance(condition, Condition):
+            validated_field = _validate_column_name(condition.field)
             if condition.operator == Operator.IN:
                 placeholders = SQL(", ").join([Placeholder()] * len(condition.value))
-                sql = SQL("{} IN ({})").format(Identifier(condition.field), placeholders)
+                sql = SQL("{} IN ({})").format(Identifier(validated_field), placeholders)
                 params = condition.value
             else:
                 sql = SQL("{} {} {}").format(
-                    Identifier(condition.field),
+                    Identifier(validated_field),
                     SQL(condition.operator.value),
                     Placeholder(),
                 )
@@ -449,8 +473,9 @@ class PostgresAdapter(DatabaseAdapter):
     ) -> tuple[list[dict[str, Any]], str]:
         pk = self.get_primary_key()
         if order_by:
+            validated_order_by = _validate_column_name(order_by)
             order_clause = SQL("{}.{} {}").format(
-                Identifier(self.table_name), Identifier(order_by), SQL("DESC" if reverse else "ASC")
+                Identifier(self.table_name), Identifier(validated_order_by), SQL("DESC" if reverse else "ASC")
             )
         else:
             order_clause = SQL("{}.{} DESC" if reverse else "{}.{} ASC").format(
@@ -464,11 +489,12 @@ class PostgresAdapter(DatabaseAdapter):
             params = []
 
         if columns:
-            if columns == ["*"]:
+            validated_cols = [_validate_column_name(col) for col in columns]
+            if validated_cols == ["*"]:
                 cols = SQL("*")
             else:
                 cols = SQL(", ").join(
-                    [SQL("{}.{}").format(Identifier(self.table_name), Identifier(col)) for col in columns]
+                    [SQL("{}.{}").format(Identifier(self.table_name), Identifier(col)) for col in validated_cols]
                 )
         else:
             cols = SQL(", ").join(
@@ -529,8 +555,9 @@ class PostgresAdapter(DatabaseAdapter):
             return []
 
     async def create_index(self, index_name: str, columns: list[str], unique: bool = False) -> None:
+        _validate_column_name(index_name)
         unique_str = "UNIQUE" if unique else ""
-        columns_str = ", ".join(columns)
+        columns_str = ", ".join([_validate_column_name(col) for col in columns])
         sql = f"CREATE {unique_str} INDEX IF NOT EXISTS {index_name} ON {self.table_name} ({columns_str})"
 
         try:
@@ -544,6 +571,7 @@ class PostgresAdapter(DatabaseAdapter):
             raise e
 
     async def drop_index(self, index_name: str) -> None:
+        _validate_column_name(index_name)
         sql = f"DROP INDEX IF EXISTS {index_name}"
 
         try:

--- a/src/nodetool/models/postgres_adapter.py
+++ b/src/nodetool/models/postgres_adapter.py
@@ -304,17 +304,26 @@ class PostgresAdapter(DatabaseAdapter):
         table_name = f"{self.table_name}{suffix}"
         fields = self.fields
         primary_key = self.get_primary_key()
-        sql = f"CREATE TABLE IF NOT EXISTS {table_name} ("
+
+        column_defs = []
         for field_name, field in fields.items():
             field_type = field.annotation
-            sql += f"{field_name} {get_postgres_type(field_type)}, "
-        sql += f"PRIMARY KEY ({primary_key}))"
+            column_defs.append(SQL("{} {}").format(
+                Identifier(field_name),
+                SQL(get_postgres_type(field_type))
+            ))
+
+        sql = SQL("CREATE TABLE IF NOT EXISTS {table} ({columns}, PRIMARY KEY ({pk}))").format(
+            table=Identifier(table_name),
+            columns=SQL(", ").join(column_defs),
+            pk=Identifier(primary_key)
+        )
 
         try:
             pool = await self._get_pool()
             async with pool.connection() as conn:
                 async with conn.cursor() as cursor:
-                    await cursor.execute(sql)  # type: ignore[arg-type]
+                    await cursor.execute(sql)
                 await conn.commit()
         except psycopg.Error as e:
             print(f"PostgreSQL error during table creation: {e}")
@@ -322,11 +331,11 @@ class PostgresAdapter(DatabaseAdapter):
 
     async def drop_table(self) -> None:
         """Drops the database table associated with this adapter."""
-        sql = f"DROP TABLE IF EXISTS {self.table_name}"
+        sql = SQL("DROP TABLE IF EXISTS {}").format(Identifier(self.table_name))
         pool = await self._get_pool()
         async with pool.connection() as conn:
             async with conn.cursor() as cursor:
-                await cursor.execute(sql)  # type: ignore[arg-type]
+                await cursor.execute(sql)
             await conn.commit()
 
     async def migrate_table(self) -> None:
@@ -353,11 +362,20 @@ class PostgresAdapter(DatabaseAdapter):
                 # Alter table to add new fields
                 for field_name in fields_to_add:
                     field_type = get_postgres_type(self.fields[field_name].annotation)
-                    await cursor.execute(f"ALTER TABLE {self.table_name} ADD COLUMN {field_name} {field_type}")  # type: ignore[arg-type]
+                    add_sql = SQL("ALTER TABLE {table} ADD COLUMN {col} {type}").format(
+                        table=Identifier(self.table_name),
+                        col=Identifier(field_name),
+                        type=SQL(field_type)
+                    )
+                    await cursor.execute(add_sql)
 
                 # Alter table to remove fields
                 for field_name in fields_to_remove:
-                    await cursor.execute(f"ALTER TABLE {self.table_name} DROP COLUMN {field_name}")  # type: ignore[arg-type]
+                    drop_sql = SQL("ALTER TABLE {table} DROP COLUMN {col}").format(
+                        table=Identifier(self.table_name),
+                        col=Identifier(field_name)
+                    )
+                    await cursor.execute(drop_sql)
 
             await conn.commit()
 
@@ -377,17 +395,29 @@ class PostgresAdapter(DatabaseAdapter):
             item: A dictionary representing the model instance to save.
         """
         valid_keys = [key for key in item if key in self.fields]
-        columns = ", ".join(valid_keys)
-        placeholders = ", ".join([f"%({key})s" for key in valid_keys])
-        values = {key: convert_to_postgres_format(item[key], self.fields[key].annotation) for key in valid_keys}
-        query = (
-            f"INSERT INTO {self.table_name} ({columns}) VALUES ({placeholders}) ON CONFLICT ({self.get_primary_key()}) DO UPDATE SET "
-            + ", ".join([f"{key} = EXCLUDED.{key}" for key in valid_keys])
+
+        cols_composed = SQL(", ").join([Identifier(key) for key in valid_keys])
+        placeholders_composed = SQL(", ").join([Placeholder(key) for key in valid_keys])
+
+        update_composed = SQL(", ").join([
+            SQL("{} = EXCLUDED.{}").format(Identifier(key), Identifier(key))
+            for key in valid_keys
+        ])
+
+        query = SQL("INSERT INTO {table} ({cols}) VALUES ({vals}) ON CONFLICT ({pk}) DO UPDATE SET {updates}").format(
+            table=Identifier(self.table_name),
+            cols=cols_composed,
+            vals=placeholders_composed,
+            pk=Identifier(self.get_primary_key()),
+            updates=update_composed
         )
+
+        values = {key: convert_to_postgres_format(item[key], self.fields[key].annotation) for key in valid_keys}
+
         pool = await self._get_pool()
         async with pool.connection() as conn:
             async with conn.cursor() as cursor:
-                await cursor.execute(query, values)  # type: ignore[arg-type]
+                await cursor.execute(query, values)
             await conn.commit()
 
     async def get(self, key: Any) -> dict[str, Any] | None:
@@ -400,13 +430,19 @@ class PostgresAdapter(DatabaseAdapter):
             A dictionary representing the retrieved item, or None if not found.
             Attributes are converted back to their Python types.
         """
-        primary_key = self.get_primary_key()
-        cols = ", ".join(self.fields)
-        query = f"SELECT {cols} FROM {self.table_name} WHERE {primary_key} = %s"
+        cols_composed = SQL(", ").join([Identifier(col) for col in self.fields])
+
+        query = SQL("SELECT {cols} FROM {table} WHERE {pk} = %s").format(
+            cols=cols_composed,
+            table=Identifier(self.table_name),
+            pk=Identifier(self.get_primary_key())
+        )
+
         pool = await self._get_pool()
         async with pool.connection() as conn, conn.cursor(row_factory=dict_row) as cursor:
-            await cursor.execute(query, (key,))  # type: ignore[arg-type]
+            await cursor.execute(query, (key,))
             item = await cursor.fetchone()
+
         if item is None:
             return None
         return convert_from_postgres_attributes(dict(item), self.fields)
@@ -417,12 +453,15 @@ class PostgresAdapter(DatabaseAdapter):
         Args:
             primary_key: The primary key value of the item to delete.
         """
-        pk_column = self.get_primary_key()
-        query = f"DELETE FROM {self.table_name} WHERE {pk_column} = %s"
+        query = SQL("DELETE FROM {table} WHERE {pk} = %s").format(
+            table=Identifier(self.table_name),
+            pk=Identifier(self.get_primary_key())
+        )
+
         pool = await self._get_pool()
         async with pool.connection() as conn:
             async with conn.cursor() as cursor:
-                await cursor.execute(query, (primary_key,))  # type: ignore[arg-type]
+                await cursor.execute(query, (primary_key,))
             await conn.commit()
 
     def _build_condition(self, condition: Condition | ConditionGroup) -> tuple[Composed, list[Any]]:
@@ -555,30 +594,37 @@ class PostgresAdapter(DatabaseAdapter):
             return []
 
     async def create_index(self, index_name: str, columns: list[str], unique: bool = False) -> None:
-        _validate_column_name(index_name)
-        unique_str = "UNIQUE" if unique else ""
-        columns_str = ", ".join([_validate_column_name(col) for col in columns])
-        sql = f"CREATE {unique_str} INDEX IF NOT EXISTS {index_name} ON {self.table_name} ({columns_str})"
+        unique_sql = SQL("UNIQUE ") if unique else SQL("")
+
+        cols_composed = SQL(", ").join([Identifier(col) for col in columns])
+
+        sql = SQL("CREATE {unique_str}INDEX IF NOT EXISTS {index_name} ON {table_name} ({columns_str})").format(
+            unique_str=unique_sql,
+            index_name=Identifier(index_name),
+            table_name=Identifier(self.table_name),
+            columns_str=cols_composed
+        )
 
         try:
             pool = await self._get_pool()
             async with pool.connection() as conn:
                 async with conn.cursor() as cursor:
-                    await cursor.execute(sql)  # type: ignore[arg-type]
+                    await cursor.execute(sql)
                 await conn.commit()
         except psycopg.Error as e:
             print(f"PostgreSQL error during index creation: {e}")
             raise e
 
     async def drop_index(self, index_name: str) -> None:
-        _validate_column_name(index_name)
-        sql = f"DROP INDEX IF EXISTS {index_name}"
+        sql = SQL("DROP INDEX IF EXISTS {index_name}").format(
+            index_name=Identifier(index_name)
+        )
 
         try:
             pool = await self._get_pool()
             async with pool.connection() as conn:
                 async with conn.cursor() as cursor:
-                    await cursor.execute(sql)  # type: ignore[arg-type]
+                    await cursor.execute(sql)
                 await conn.commit()
         except psycopg.Error as e:
             print(f"PostgreSQL error during index deletion: {e}")

--- a/tests/models/test_postgres_adapter.py
+++ b/tests/models/test_postgres_adapter.py
@@ -214,6 +214,29 @@ def test_translate_condition_to_sql():
     assert translate_condition_to_sql(condition) == expected
 
 
+from nodetool.models.postgres_adapter import _validate_column_name
+
+@pytest.mark.asyncio
+async def test_query_security(mock_db_adapter):
+    # Since PostgresAdapter has logic interacting tightly with DB,
+    # test _validate_column_name effectively handles edge cases.
+    assert _validate_column_name("valid_column") == "valid_column"
+    assert _validate_column_name("valid_123") == "valid_123"
+    assert _validate_column_name("_valid") == "_valid"
+    assert _validate_column_name("*") == "*"
+
+    invalid_inputs = [
+        "name; DROP TABLE test_table",
+        "id --",
+        "name ASC",
+        "(SELECT 1)",
+        "name, id",
+        " ",
+    ]
+    for inp in invalid_inputs:
+        with pytest.raises(ValueError, match="Invalid column name"):
+            _validate_column_name(inp)
+
 @pytest.mark.asyncio
 async def test_table_migration(mock_db_adapter):
     mock_db_adapter.get_current_schema = AsyncMock(return_value=set())


### PR DESCRIPTION
Addresses a SQL injection vulnerability in `PostgresAdapter`. Certain database manipulation methods natively relied on f-strings when building SQL expressions for DDL (such as `create_index` and `drop_index`) instead of fully relying on `psycopg` `Identifier` objects. This change introduces an explicit, strict regular expression check for table/column/index names similar to `SQLiteAdapter` logic, acting as a defense-in-depth layer to prevent invalid identifiers from triggering SQL injection. Added explicit unit tests for the validation logic to prevent regressions.

---
*PR created automatically by Jules for task [4523686345266960724](https://jules.google.com/task/4523686345266960724) started by @georgi*