### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal via Symbolic Links

### DIFF
--- a/src/nodetool/io/path_utils.py
+++ b/src/nodetool/io/path_utils.py
@@ -67,14 +67,16 @@ def resolve_workspace_path(workspace_dir: str | None, path: str) -> str:
 
     # Prevent path traversal attempts (e.g., ../../etc/passwd)
     # Join the workspace directory with the potentially cleaned relative path
-    abs_path = os.path.abspath(os.path.join(workspace_dir, relative_path))
+    # Use realpath to fully resolve any symbolic links to prevent symlink traversal attacks
+    abs_path = os.path.realpath(os.path.join(workspace_dir, relative_path))
 
     # Final check: ensure the resolved path is still within the workspace directory
     # Use commonpath for robustness across OS (prevents partial path traversal)
-    common_path = os.path.commonpath([os.path.abspath(workspace_dir), abs_path])
-    if os.path.abspath(workspace_dir) != common_path:
+    workspace_real_path = os.path.realpath(workspace_dir)
+    common_path = os.path.commonpath([workspace_real_path, abs_path])
+    if workspace_real_path != common_path:
         log.error(
-            f"Resolved path '{abs_path}' is outside the workspace directory '{workspace_dir}'. Original path: '{path}'"
+            f"Resolved path '{abs_path}' is outside the workspace directory '{workspace_real_path}'. Original path: '{path}'"
         )
         # Option 1: Raise an error
         raise ValueError(f"Resolved path '{abs_path}' is outside the workspace directory.")

--- a/tests/common/test_path_utils.py
+++ b/tests/common/test_path_utils.py
@@ -60,6 +60,32 @@ class TestPathUtils(unittest.TestCase):
             resolve_workspace_path(self.workspace_dir, "../../../etc/passwd")
         self.assertIn("outside the workspace directory", str(context.exception))
 
+    def test_resolve_workspace_path_with_symlink_traversal_attack(self):
+        """Test that symlink traversal attacks are prevented."""
+        import tempfile
+        import shutil
+
+        # Create a completely separate directory outside workspace
+        outside_dir = tempfile.mkdtemp()
+        try:
+            # Create a secret file outside the workspace
+            secret_file = os.path.join(outside_dir, "secret.txt")
+            with open(secret_file, "w") as f:
+                f.write("top secret data")
+
+            # Create a symlink inside the workspace pointing to the outside directory
+            symlink_path = os.path.join(self.workspace_dir, "link_to_outside")
+            os.symlink(outside_dir, symlink_path)
+
+            # Try to access the secret file through the symlink
+            with self.assertRaises(ValueError) as context:
+                # The attacker requests "link_to_outside/secret.txt"
+                resolve_workspace_path(self.workspace_dir, "link_to_outside/secret.txt")
+
+            self.assertIn("outside the workspace directory", str(context.exception))
+        finally:
+            shutil.rmtree(outside_dir)
+
     def test_resolve_workspace_path_with_empty_workspace_dir(self):
         """Test that empty workspace directory raises ValueError."""
         with self.assertRaises(ValueError) as context:


### PR DESCRIPTION
This PR fixes a security vulnerability in `src/nodetool/io/path_utils.py` where `os.path.abspath` was being used to evaluate whether a requested file path was within the designated `workspace_dir`.

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Symlink-based Path Traversal
🎯 **Impact:** If a malicious user or external process were able to create a symbolic link within their workspace that points to a directory outside of the workspace (e.g., `/` or `/etc`), `os.path.abspath` would not resolve the symlink. This allowed requests traversing the symlink to pass the `commonpath` boundary check, granting arbitrary read/write access to the host filesystem.
🔧 **Fix:** Replaced `os.path.abspath` with `os.path.realpath` for both the workspace root and the target path. `os.path.realpath` fully resolves all symbolic links before evaluating the boundaries, correctly denying access to outside files.
✅ **Verification:** A test case `test_resolve_workspace_path_with_symlink_traversal_attack` was added to `tests/common/test_path_utils.py` to ensure traversing an outside symlink correctly throws a `ValueError`. The fix has been verified and passes tests.

---
*PR created automatically by Jules for task [12244774363765268999](https://jules.google.com/task/12244774363765268999) started by @georgi*