### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix symlink path traversal vulnerability

### DIFF
--- a/src/nodetool/io/path_utils.py
+++ b/src/nodetool/io/path_utils.py
@@ -70,15 +70,18 @@ def resolve_workspace_path(workspace_dir: str | None, path: str) -> str:
     abs_path = os.path.abspath(os.path.join(workspace_dir, relative_path))
 
     # Final check: ensure the resolved path is still within the workspace directory
-    # Use commonpath for robustness across OS (prevents partial path traversal)
-    common_path = os.path.commonpath([os.path.abspath(workspace_dir), abs_path])
-    if os.path.abspath(workspace_dir) != common_path:
+    # Use realpath to resolve symlinks and commonpath for robustness across OS (prevents partial path traversal)
+    real_workspace_dir = os.path.realpath(workspace_dir)
+    real_abs_path = os.path.realpath(abs_path)
+
+    common_path = os.path.commonpath([real_workspace_dir, real_abs_path])
+    if real_workspace_dir != common_path:
         log.error(
-            f"Resolved path '{abs_path}' is outside the workspace directory '{workspace_dir}'. Original path: '{path}'"
+            f"Resolved path '{real_abs_path}' is outside the workspace directory '{real_workspace_dir}'. Original path: '{path}'"
         )
         # Option 1: Raise an error
-        raise ValueError(f"Resolved path '{abs_path}' is outside the workspace directory.")
+        raise ValueError(f"Resolved path '{real_abs_path}' is outside the workspace directory.")
         # Option 2: Return a default safe path or the workspace root (less ideal)
         # return workspace_dir
 
-    return abs_path
+    return real_abs_path

--- a/tests/common/test_path_utils.py
+++ b/tests/common/test_path_utils.py
@@ -92,6 +92,24 @@ class TestPathUtils(unittest.TestCase):
         # The behavior depends on the filesystem, but the function should not crash
         self.assertIsInstance(result, str)
 
+    def test_resolve_workspace_path_with_symlink_traversal_attack(self):
+        """Test that symlink traversal attacks are prevented."""
+        # Create a secret file outside workspace
+        secret_file = os.path.join(self.workspace_dir, "..", "secret.txt")
+        with open(secret_file, "w") as f:
+            f.write("secret")
+
+        # Create a symlink in workspace pointing to the secret
+        symlink_path = os.path.join(self.workspace_dir, "symlink")
+        os.symlink(secret_file, symlink_path)
+
+        with self.assertRaises(ValueError) as context:
+            resolve_workspace_path(self.workspace_dir, "symlink")
+        self.assertIn("outside the workspace directory", str(context.exception))
+
+        # Cleanup
+        os.remove(secret_file)
+        os.remove(symlink_path)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes a critical symlink-based path traversal vulnerability in `resolve_workspace_path` (CWE-59 / CWE-22) by ensuring that symlinks are fully resolved using `os.path.realpath` before running the `os.path.commonpath` boundary check. Without this change, a symlink within the workspace could point outside the workspace directory and evade detection because `os.path.abspath` does not resolve symlinks. A regression test (`test_resolve_workspace_path_with_symlink_traversal_attack`) has been added to ensure the correct behavior is enforced.

---
*PR created automatically by Jules for task [9269887949818549559](https://jules.google.com/task/9269887949818549559) started by @georgi*