### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in workspace resolution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,8 @@
 **Vulnerability:** The `_legacy_export_to_video_bytes` function in `src/nodetool/media/video/video_utils.py` used a hardcoded path (`/tmp/temp_video.mp4`) for temporary file storage during video encoding. This allowed for symlink attacks, race conditions, and cross-tenant data leakage if multiple processes or users executed the function concurrently.
 **Learning:** Hardcoded temporary paths are a common anti-pattern that can easily be overlooked in fallback or legacy code paths. They violate the principle of isolation and can lead to severe vulnerabilities in multi-user environments.
 **Prevention:** Always use secure temporary file creation mechanisms like `tempfile.NamedTemporaryFile` with appropriate cleanup logic (e.g., `delete=False` followed by a `try...finally` block for manual removal) to guarantee uniqueness and prevent race conditions.
+
+## 2025-04-07 - Fixed Path Traversal in Workspace Resolution
+**Vulnerability:** The function `resolve_workspace_path` used `os.path.abspath` when joining a workspace directory with a relative path. This permitted path traversal attacks where the relative path could contain a symlink that points outside the allowed workspace boundary, as `os.path.abspath` merely normalizes the path without resolving underlying symlinks.
+**Learning:** Checking path boundaries (e.g. `os.path.commonpath`) on symlink-containing paths is unreliable because the path components might appear valid while ultimately pointing outside the safe directory.
+**Prevention:** Always use `os.path.realpath` to resolve all symlinks *before* performing boundary validation to ensure the true resolved path resides within the intended directory limits.

--- a/src/nodetool/io/path_utils.py
+++ b/src/nodetool/io/path_utils.py
@@ -67,12 +67,12 @@ def resolve_workspace_path(workspace_dir: str | None, path: str) -> str:
 
     # Prevent path traversal attempts (e.g., ../../etc/passwd)
     # Join the workspace directory with the potentially cleaned relative path
-    abs_path = os.path.abspath(os.path.join(workspace_dir, relative_path))
+    abs_path = os.path.realpath(os.path.join(workspace_dir, relative_path))
 
     # Final check: ensure the resolved path is still within the workspace directory
     # Use commonpath for robustness across OS (prevents partial path traversal)
-    common_path = os.path.commonpath([os.path.abspath(workspace_dir), abs_path])
-    if os.path.abspath(workspace_dir) != common_path:
+    common_path = os.path.commonpath([os.path.realpath(workspace_dir), abs_path])
+    if os.path.realpath(workspace_dir) != common_path:
         log.error(
             f"Resolved path '{abs_path}' is outside the workspace directory '{workspace_dir}'. Original path: '{path}'"
         )

--- a/tests/io/test_path_utils.py
+++ b/tests/io/test_path_utils.py
@@ -1,0 +1,32 @@
+import os
+import pytest
+from nodetool.io.path_utils import resolve_workspace_path
+
+def test_resolve_workspace_path_basic(tmp_path):
+    workspace = str(tmp_path)
+    # basic resolution
+    assert resolve_workspace_path(workspace, "test.txt") == os.path.join(workspace, "test.txt")
+    assert resolve_workspace_path(workspace, "/workspace/test.txt") == os.path.join(workspace, "test.txt")
+    assert resolve_workspace_path(workspace, "workspace/test.txt") == os.path.join(workspace, "test.txt")
+    assert resolve_workspace_path(workspace, "/test.txt") == os.path.join(workspace, "test.txt")
+
+def test_resolve_workspace_path_traversal(tmp_path):
+    workspace = str(tmp_path / "workspace")
+    os.makedirs(workspace)
+    with pytest.raises(ValueError):
+        resolve_workspace_path(workspace, "../test.txt")
+
+def test_resolve_workspace_path_symlink_traversal(tmp_path):
+    workspace = str(tmp_path / "workspace")
+    os.makedirs(workspace)
+
+    # Create a symlink pointing outside the workspace
+    outside_dir = str(tmp_path / "outside")
+    os.makedirs(outside_dir)
+
+    symlink_path = os.path.join(workspace, "symlink_dir")
+    os.symlink(outside_dir, symlink_path)
+
+    # Resolving a path through the symlink should raise ValueError if properly protected
+    with pytest.raises(ValueError):
+        resolve_workspace_path(workspace, "symlink_dir/test.txt")


### PR DESCRIPTION
Replaced `os.path.abspath` with `os.path.realpath` to properly resolve symlinks before validating path boundaries against the workspace, mitigating a potential traversal attack via malicious symlinks. Includes new symlink traversal unit tests.

---
*PR created automatically by Jules for task [16414542142924723535](https://jules.google.com/task/16414542142924723535) started by @georgi*