### PR TITLE
⚡ Bolt: Optimize PyDub AudioSegment concatenation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-02-12 - Video Export Optimization and Correctness
 **Learning:** Upfront list comprehension for processing large sequences (like video frames) consumes O(N) memory and can lead to OOM. Lazy processing inside the writing loop reduces memory usage to O(1). Additionally, assuming input data types (e.g. float vs uint8) without checking can lead to critical bugs like integer overflow when scaling `uint8` arrays by 255.
 **Action:** Always prefer lazy iteration/generators for large data processing pipelines. Explicitly check `numpy.dtype` before performing arithmetic scaling to ensure correctness and avoid unnecessary operations.
+## 2026-04-15 - Optimizing PyDub AudioSegment Concatenation
+**Learning:** In Python, repeatedly using the `+=` operator on complex objects like `pydub.AudioSegment` in a loop creates a new object and copies all underlying data (byte arrays) on every iteration. This leads to O(n²) time complexity and high peak memory usage, which is a significant bottleneck when concatenating thousands of small audio segments.
+**Action:** When concatenating many audio segments that share the same properties (sample width, frame rate, channels), bypass the `+=` operator and concatenate their underlying raw byte arrays using `b''.join(a.raw_data for a in audios)`. This single memory allocation is O(n) and drastically faster.

--- a/src/nodetool/media/audio/audio_helpers.py
+++ b/src/nodetool/media/audio/audio_helpers.py
@@ -81,6 +81,34 @@ def concatenate_audios(audios: list[AudioSegment]) -> AudioSegment:
     Returns:
         AudioSegment: The concatenated audio segment.
     """
+    if not audios:
+        return AudioSegment.empty()
+
+    # ⚡ Bolt Optimization:
+    # Instead of using `+=` in a loop (which causes O(n^2) performance penalties due to repeated
+    # byte-copying), check if all segments share the same audio properties. If they do,
+    # concatenate the raw bytes directly using `b''.join(...)`.
+    first = audios[0]
+    sample_width = first.sample_width
+    frame_rate = first.frame_rate
+    channels = first.channels
+
+    can_optimize = True
+    for a in audios[1:]:
+        if a.sample_width != sample_width or a.frame_rate != frame_rate or a.channels != channels:
+            can_optimize = False
+            break
+
+    if can_optimize:
+        raw_data = b''.join(a.raw_data for a in audios)
+        return AudioSegment(
+            data=raw_data,
+            sample_width=sample_width,
+            frame_rate=frame_rate,
+            channels=channels,
+        )
+
+    # Fallback if properties differ (which shouldn't usually happen but preserves safety)
     concatenated_audio = AudioSegment.empty()
     for audio in audios:
         concatenated_audio += audio


### PR DESCRIPTION
💡 What: Replaced iterative `+=` concatenation of `pydub.AudioSegment` objects with `b''.join(a.raw_data for a in audios)` when audio properties match.
🎯 Why: Iteratively appending segments via `+=` causes quadratic O(n^2) performance penalties due to continuous byte-copying. Joining the raw byte arrays upfront creates a single O(n) memory allocation.
📊 Impact: Expected to reduce execution time for concatenating thousands of audio segments from seconds to milliseconds.
🔬 Measurement: Verify by executing node workflows that generate and stitch together numerous small audio chunks. Performance will scale linearly rather than quadratically.

---
*PR created automatically by Jules for task [9276866430169190446](https://jules.google.com/task/9276866430169190446) started by @georgi*