### PR TITLE
🛡️ Sentinel: [HIGH] Fix symlink traversal in resolve_workspace_path

### DIFF
--- a/src/nodetool/io/path_utils.py
+++ b/src/nodetool/io/path_utils.py
@@ -67,12 +67,14 @@ def resolve_workspace_path(workspace_dir: str | None, path: str) -> str:
 
     # Prevent path traversal attempts (e.g., ../../etc/passwd)
     # Join the workspace directory with the potentially cleaned relative path
-    abs_path = os.path.abspath(os.path.join(workspace_dir, relative_path))
+    # 🛡️ Sentinel Security Fix: Use realpath to resolve symlinks and prevent symlink traversal
+    abs_path = os.path.realpath(os.path.join(workspace_dir, relative_path))
 
     # Final check: ensure the resolved path is still within the workspace directory
     # Use commonpath for robustness across OS (prevents partial path traversal)
-    common_path = os.path.commonpath([os.path.abspath(workspace_dir), abs_path])
-    if os.path.abspath(workspace_dir) != common_path:
+    workspace_real_path = os.path.realpath(workspace_dir)
+    common_path = os.path.commonpath([workspace_real_path, abs_path])
+    if workspace_real_path != common_path:
         log.error(
             f"Resolved path '{abs_path}' is outside the workspace directory '{workspace_dir}'. Original path: '{path}'"
         )


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `resolve_workspace_path` used `os.path.abspath` before checking path boundaries with `os.path.commonpath`. Because `os.path.abspath` normalizes paths but does not resolve symbolic links, an attacker could create a symlink inside the workspace pointing to an external directory (like `/etc/`), append to it, and successfully bypass the boundary check.
🎯 Impact: Arbitrary read/write access to the filesystem outside the restricted workspace via symlink traversal, potentially leading to disclosure or modification of sensitive data or code execution.
🔧 Fix: Replaced `os.path.abspath` with `os.path.realpath` to ensure that both the resolved file path and the base workspace path have all symlinks fully resolved before validating their boundary using `os.path.commonpath`.
✅ Verification: Tested against a local symlink payload pointing out of bounds, confirming it now correctly raises a ValueError. Lint checks pass.

---
*PR created automatically by Jules for task [4455582272022169731](https://jules.google.com/task/4455582272022169731) started by @georgi*