### PR TITLE
feat(worker): add BRIDGE_PROTOCOL_VERSION and report it in discover

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,23 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npx tsx:*)",
+      "Bash(node --experimental-vm-modules node_modules/.bin/tsx packages/dsl/scripts/codegen.ts)",
+      "Bash(npm run:*)",
+      "Bash(xargs grep:*)",
+      "Bash(grep -l \"registerFalNodes\\\\|registerKieNodes\\\\|registerReplicateNodes\\\\|FAL_NODES\\\\|KIE_NODES\\\\|REPLICATE_NODES\" /m/P/NODETOOL/____REPOS____/nodetool/packages/websocket/src/*.ts)",
+      "Bash(python -m nodetool.worker --stdio)",
+      "Bash(conda run:*)",
+      "Bash(\"C:/Users/rkt/miniconda3/envs/nodetool/python.exe\" -m nodetool.worker --stdio)",
+      "Bash(echo \"EXIT: $?\")",
+      "Bash(\"C:/Users/rkt/miniconda3/envs/nodetool/python.exe\" -c \"import nodetool.worker; print\\('OK'\\)\")",
+      "Bash(npx tsc:*)",
+      "Bash(findstr /I \"transformPreview error TS\")",
+      "Bash(grep -n \"createRuntime\" \"m:/P/NODETOOL/____REPOS____/nodetool/web/src/components/sketch/rendering/\"*.ts)",
+      "Bash(grep -n \"handleStrokeStart\\\\|handleStrokeEnd\" \"m:/P/NODETOOL/____REPOS____/nodetool/web/src/components/sketch/hooks/\"*.ts)",
+      "Bash(grep -n \"handleLayerTransformChange\\\\|onLayerTransformChange\" \"m:/P/NODETOOL/____REPOS____/nodetool/web/src/components/sketch/hooks/\"*.ts)",
+      "Bash(grep -n \"handleCommitLayerTransform\\\\|commitLayerTransform\" \"m:/P/NODETOOL/____REPOS____/nodetool/web/src/components/sketch/hooks/\"*.ts)",
+      "Bash(grep -n \"commitLayerTransform\" \"m:/P/NODETOOL/____REPOS____/nodetool/web/src/components/sketch/state/\"*.ts)"
+    ]
+  }
+}

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,4 @@
+build/
+dist/
+node_modules/
+**/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ tmp/
 
 # Agent
 __plans__/
+.claude/
 
 # Node.js / TypeScript
 node_modules/

--- a/src/nodetool/worker/__init__.py
+++ b/src/nodetool/worker/__init__.py
@@ -1,1 +1,15 @@
 # src/nodetool/worker/__init__.py
+"""NodeTool worker package.
+
+Bridge protocol version: bumped only when the JS↔Python stdio protocol
+changes in a non-backward-compatible way. The Electron app declares the
+minimum version it can speak; if the Python worker reports a lower number
+the JS bridge refuses to use it and asks the user to reinstall the
+Python environment.
+
+History:
+  1 - Initial stdio protocol (msgpack length-prefixed framing,
+      discover/execute/result/error/chunk/progress + provider.* messages).
+"""
+
+BRIDGE_PROTOCOL_VERSION = 1

--- a/src/nodetool/worker/server.py
+++ b/src/nodetool/worker/server.py
@@ -5,6 +5,8 @@ from typing import Any, Callable, Awaitable
 import msgpack
 from websockets.asyncio.server import serve as ws_serve, ServerConnection
 
+from nodetool.worker import BRIDGE_PROTOCOL_VERSION
+
 
 class WorkerServer:
     def __init__(self):
@@ -34,7 +36,10 @@ class WorkerServer:
                 response = msgpack.packb({
                     "type": "discover",
                     "request_id": request_id,
-                    "data": {"nodes": self._nodes_metadata},
+                    "data": {
+                        "nodes": self._nodes_metadata,
+                        "protocol_version": BRIDGE_PROTOCOL_VERSION,
+                    },
                 })
                 await websocket.send(response)
 

--- a/src/nodetool/worker/stdio_server.py
+++ b/src/nodetool/worker/stdio_server.py
@@ -18,6 +18,8 @@ from typing import Any, Callable, Awaitable
 
 import msgpack
 
+from nodetool.worker import BRIDGE_PROTOCOL_VERSION
+
 
 class StdioTransport:
     """Async reader/writer for length-prefixed msgpack over stdin/stdout.
@@ -110,7 +112,10 @@ class StdioWorkerServer:
             await transport.send_msg({
                 "type": "discover",
                 "request_id": request_id,
-                "data": {"nodes": self._nodes_metadata},
+                "data": {
+                    "nodes": self._nodes_metadata,
+                    "protocol_version": BRIDGE_PROTOCOL_VERSION,
+                },
             })
 
         elif msg_type == "execute":

--- a/tests/test_stdio_worker.py
+++ b/tests/test_stdio_worker.py
@@ -57,7 +57,11 @@ async def main():
     assert resp["type"] == "discover"
     assert resp["request_id"] == "d1"
     nodes = resp["data"]["nodes"]
-    print(f"  OK: {len(nodes)} nodes discovered")
+    from nodetool.worker import BRIDGE_PROTOCOL_VERSION
+    assert resp["data"].get("protocol_version") == BRIDGE_PROTOCOL_VERSION, (
+        f"Expected protocol_version {BRIDGE_PROTOCOL_VERSION}, got {resp['data'].get('protocol_version')}"
+    )
+    print(f"  OK: {len(nodes)} nodes discovered (protocol v{resp['data']['protocol_version']})")
 
     print("\n--- Test 2: execute (valid node) ---")
     # Find a simple node that doesn't need external deps


### PR DESCRIPTION
The Electron app uses this to verify at runtime that the installed nodetool-core speaks the same stdio bridge protocol as the bundled JS runtime. Bumped only on breaking protocol changes — most core releases will not touch it, decoupling the core release cadence from the Electron app version.
- nodetool/worker/__init__.py: declare BRIDGE_PROTOCOL_VERSION = 1
- worker/stdio_server.py + worker/server.py: include protocol_version in the discover response payload
- tests/test_stdio_worker.py: assert the new field