### PR TITLE
Restore node_metadata + add nodetool.package_tools scanner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ dependencies = [
     "aiofiles>=24.1.0",
 ]
 
+[project.scripts]
+nodetool-pkg = "nodetool.package_tools.__main__:main"
+
 [project.optional-dependencies]
 # Vectorstore nodes (chromadb + langchain)
 vectorstore = [

--- a/src/nodetool/metadata/node_metadata.py
+++ b/src/nodetool/metadata/node_metadata.py
@@ -1,0 +1,194 @@
+"""Node and package metadata models.
+
+Restored from commit e1d10d3a (removed in the 2026-04-11 strip-down,
+commit 88b759f8) so `BaseNode.get_metadata()` keeps working and the
+package scanner under `nodetool.package_tools` has types to build.
+
+`AssetInfo` is defined here too — its previous home in
+`nodetool.packages.package_types` was deleted by the same strip.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import json
+import pkgutil
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from nodetool.config.logging_config import get_logger
+from nodetool.metadata.types import OutputSlot
+from nodetool.types.model import ModelPack, UnifiedModel
+from nodetool.workflows.base_node import BaseNode
+from nodetool.workflows.property import Property
+
+logger = get_logger(__name__)
+
+
+class AssetInfo(BaseModel):
+    """Asset information for files shipped by a node package."""
+
+    package_name: str = Field(description="Name of the package providing the asset")
+    name: str = Field(description="Asset file name")
+    path: str = Field(description="Full path to the asset file")
+
+
+class NodeMetadata(BaseModel):
+    """Metadata for a node."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "required": [
+                "title",
+                "description",
+                "namespace",
+                "node_type",
+                "outputs",
+                "properties",
+                "the_model_info",
+                "recommended_models",
+                "basic_fields",
+                "required_settings",
+            ]
+        }
+    )
+
+    title: str = Field(description="UI Title of the node")
+    description: str = Field(description="UI Description of the node")
+    namespace: str = Field(description="Namespace of the node")
+    node_type: str = Field(description="Fully qualified type of the node")
+    layout: str = Field(default="default", description="UI Layout of the node")
+    properties: list[Property] = Field(default_factory=list, description="Properties of the node")
+    outputs: list[OutputSlot] = Field(default_factory=list, description="Outputs of the node")
+    the_model_info: dict[str, Any] = Field(default_factory=dict, description="HF Model info for the node")
+    recommended_models: list[UnifiedModel] = Field(
+        default_factory=list, description="Recommended models for the node"
+    )
+    basic_fields: list[str] = Field(default_factory=list, description="Basic fields of the node")
+    required_settings: list[str] = Field(
+        default_factory=list,
+        description="Environment setting/secret keys required to run the node",
+    )
+    is_dynamic: bool = Field(default=False, description="Whether the node is dynamic")
+    is_streaming_output: bool = Field(default=False, description="Whether the node can stream output")
+    expose_as_tool: bool = Field(default=False, description="Whether the node is exposed as a tool")
+    supports_dynamic_outputs: bool = Field(
+        default=False,
+        description="Whether the node can declare outputs dynamically at runtime (only for dynamic nodes)",
+    )
+    model_packs: list[ModelPack] = Field(
+        default_factory=list, description="Model packs associated with this node"
+    )
+
+
+class ExampleMetadata(BaseModel):
+    """Metadata for an example workflow."""
+
+    id: str
+    name: str
+    description: str
+    tags: list[str]
+
+
+class PackageModel(BaseModel):
+    """Metadata model for a node package."""
+
+    name: str = Field(description="Unique name of the package")
+    description: str = Field(description="Description of the package and its functionality")
+    version: str = Field(description="Version of the package (semver format)")
+    authors: list[str] = Field(description="Authors of the package")
+    namespaces: list[str] = Field(default_factory=list, description="Namespaces provided by this package")
+    repo_id: str | None = Field(default=None, description="Repository ID in the format <owner>/<project>")
+    nodes: list[NodeMetadata] | None = Field(
+        default_factory=list, description="List of nodes provided by this package"
+    )
+    git_hash: str | None = Field(default=None, description="Git commit hash of the package")
+    assets: list[AssetInfo] | None = Field(
+        default_factory=list, description="List of assets provided by this package"
+    )
+    examples: list[ExampleMetadata] | None = Field(
+        default_factory=list, description="List of examples provided by this package"
+    )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Non-fatal issues encountered during scan (e.g. modules that failed to import).",
+    )
+    source_folder: str | None = Field(default=None, description="Source folder of the package")
+
+
+class EnumEncoder(json.JSONEncoder):
+    def default(self, o):
+        try:
+            if isinstance(o, Enum):
+                return o.value
+            if o == b"":
+                return ""
+            return super().default(o)
+        except TypeError as e:
+            raise TypeError(f"Error encoding {o}: {e}") from e
+
+
+def get_submodules(package_name: str, verbose: bool = False) -> list[str]:
+    """Get all submodules of a package recursively."""
+    try:
+        package = importlib.import_module(package_name)
+        if not hasattr(package, "__path__"):
+            return [package_name]
+
+        submodules = [package_name]
+        for _, name, is_pkg in pkgutil.iter_modules(package.__path__, package.__name__ + "."):
+            if verbose:
+                logger.debug(f"Found submodule: {name}")
+            if is_pkg:
+                submodules.extend(get_submodules(name, verbose))
+            else:
+                submodules.append(name)
+
+        return submodules
+    except ImportError as e:
+        logger.error(f"Error importing package {package_name}: {e}")
+        return []
+
+
+def get_node_classes_from_module(module_name: str, verbose: bool = False) -> list[type[BaseNode]]:
+    """Find all classes in the given module that derive from BaseNode."""
+    module = importlib.import_module(module_name)
+
+    node_classes = []
+    for _name, obj in inspect.getmembers(module):
+        if inspect.isclass(obj):
+            has_abstract_method = any(
+                getattr(member, "__isabstractmethod__", False)
+                for _, member in inspect.getmembers(obj)
+            )
+            if has_abstract_method:
+                continue
+        if (
+            inspect.isclass(obj)
+            and issubclass(obj, BaseNode)
+            and obj is not BaseNode
+            and obj.__module__ == module_name
+        ):
+            node_classes.append(obj)
+            if verbose:
+                logger.debug(f"Found node class: {obj.__name__} in {module_name}")
+
+    return node_classes
+
+
+def get_node_classes_from_namespace(namespace: str, verbose: bool = False) -> list[type[BaseNode]]:
+    """Find all BaseNode subclasses in the given namespace and its submodules."""
+    logger.info(f"Searching for submodules in namespace: {namespace}")
+    submodules = get_submodules(namespace, verbose)
+
+    all_node_classes = []
+    for submodule in submodules:
+        node_classes = get_node_classes_from_module(submodule, verbose)
+        all_node_classes.extend(node_classes)
+        if node_classes:
+            logger.info(f"Found {len(node_classes)} node classes in module {submodule}")
+
+    return all_node_classes

--- a/src/nodetool/package_tools/__init__.py
+++ b/src/nodetool/package_tools/__init__.py
@@ -1,0 +1,9 @@
+"""nodetool.package_tools — scan utilities for nodetool Python node packages.
+
+Invoked as a subprocess by the TS workspace to produce
+`src/nodetool/package_metadata/<name>.json` for each Python node package.
+"""
+
+from nodetool.package_tools.scanner import scan_package
+
+__all__ = ["scan_package"]

--- a/src/nodetool/package_tools/__main__.py
+++ b/src/nodetool/package_tools/__main__.py
@@ -1,0 +1,101 @@
+"""CLI for nodetool.package_tools.
+
+Usage:
+    python -m nodetool.package_tools <command> [options]
+    nodetool-pkg <command> [options]
+
+Commands:
+    scan       Scan a package directory and emit PackageModel JSON.
+    version    Print version.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+from pathlib import Path
+
+from nodetool.metadata.node_metadata import EnumEncoder
+from nodetool.package_tools.scanner import scan_package
+
+
+def _version() -> str:
+    for name in ("nodetool-core", "nodetool_core"):
+        try:
+            return _pkg_version(name)
+        except PackageNotFoundError:
+            continue
+    return "unknown"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="nodetool-pkg")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    scan = sub.add_parser("scan", help="Scan a package directory and emit JSON.")
+    scan.add_argument(
+        "--package-dir",
+        default=".",
+        help="Package root (must contain pyproject.toml). Default: cwd.",
+    )
+    out_group = scan.add_mutually_exclusive_group()
+    out_group.add_argument(
+        "--output",
+        default=None,
+        help="Write JSON to this path instead of stdout.",
+    )
+    out_group.add_argument(
+        "--write",
+        action="store_true",
+        help="Write JSON into <package-dir>/src/nodetool/package_metadata/<name>.json.",
+    )
+    scan.add_argument("--enrich", action="store_true", help="Fetch HF model metadata (slow).")
+    scan.add_argument("--verbose", action="store_true", help="Log scan progress to stderr.")
+
+    sub.add_parser("version", help="Print version.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "version":
+        print(_version())
+        return 0
+
+    if args.command == "scan":
+        try:
+            pkg = scan_package(
+                package_dir=args.package_dir,
+                enrich=args.enrich,
+                verbose=args.verbose,
+                write=args.write,
+                output=args.output,
+            )
+        except FileNotFoundError as e:
+            sys.stderr.write(f"SCAN error {e}\n")
+            return 1
+        except ValueError as e:
+            sys.stderr.write(f"SCAN error {e}\n")
+            return 1
+        except Exception as e:
+            sys.stderr.write(f"SCAN error unexpected {type(e).__name__}: {e}\n")
+            return 1
+
+        if not args.write and not args.output:
+            payload = pkg.model_dump(exclude_defaults=True)
+            json.dump(payload, sys.stdout, indent=2, cls=EnumEncoder, sort_keys=True)
+            sys.stdout.write("\n")
+        elif args.output:
+            print(str(Path(args.output).resolve()))
+        return 0
+
+    parser.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/nodetool/package_tools/enrich.py
+++ b/src/nodetool/package_tools/enrich.py
@@ -1,0 +1,135 @@
+"""HuggingFace model-info enrichment for recommended models on scanned nodes.
+
+Restored from commit e1d10d3a of nodetool-core
+(`src/nodetool/packages/registry.py:_enrich_nodes_with_model_info`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from typing import Any
+
+from nodetool.config.logging_config import get_logger
+from nodetool.metadata.node_metadata import NodeMetadata
+
+log = get_logger(__name__)
+
+
+def _model_size_from_info(model: Any, model_info: Any) -> int | None:
+    """Calculate model size using HF metadata, respecting optional path filters."""
+    from nodetool.integrations.huggingface.huggingface_models import size_on_disk
+
+    if model_info is None:
+        return None
+
+    if getattr(model, "path", None):
+        return next(
+            (
+                getattr(sibling, "size", None)
+                for sibling in (model_info.siblings or [])
+                if getattr(sibling, "rfilename", None) == model.path
+            ),
+            None,
+        )
+
+    return size_on_disk(
+        model_info,
+        allow_patterns=getattr(model, "allow_patterns", None),
+        ignore_patterns=getattr(model, "ignore_patterns", None),
+    )
+
+
+async def enrich_nodes_with_model_info(
+    nodes: list[NodeMetadata], verbose: bool = False
+) -> tuple[int, int]:
+    """Fetch HF model metadata to populate recommended model details.
+
+    Returns (ok, failed) — counts of repo fetches that succeeded/failed.
+    """
+    from nodetool.integrations.huggingface.huggingface_models import (
+        fetch_model_info,
+        has_model_index,
+        model_type_from_model_info,
+    )
+
+    repo_to_models: dict[str, list[Any]] = defaultdict(list)
+    for node in nodes:
+        for model in node.recommended_models or []:
+            if getattr(model, "repo_id", None):
+                repo_to_models[model.repo_id].append(model)
+
+    if not repo_to_models:
+        return 0, 0
+
+    repo_ids = list(repo_to_models.keys())
+    results = await asyncio.gather(
+        *(fetch_model_info(repo_id) for repo_id in repo_ids),
+        return_exceptions=True,
+    )
+
+    model_info_map: dict[str, Any] = {}
+    failed = 0
+    for repo_id, info in zip(repo_ids, results, strict=False):
+        if isinstance(info, Exception):
+            failed += 1
+            if verbose:
+                log.warning("Failed to fetch model info for %s: %s", repo_id, info)
+            continue
+        if info:
+            model_info_map[repo_id] = info
+
+    ok = len(model_info_map)
+    if not model_info_map:
+        return ok, failed
+
+    for node in nodes:
+        if not node.recommended_models:
+            continue
+
+        updated_models: list[Any] = []
+        for model in node.recommended_models:
+            if not getattr(model, "repo_id", None):
+                updated_models.append(model)
+                continue
+
+            info = model_info_map.get(model.repo_id)
+            if not info:
+                updated_models.append(model)
+                continue
+
+            updates: dict[str, Any] = {}
+            if getattr(model, "size_on_disk", None) is None:
+                size = _model_size_from_info(model, info)
+                if size is not None:
+                    updates["size_on_disk"] = size
+
+            if getattr(model, "type", None) is None:
+                inferred_type = model_type_from_model_info(repo_to_models, model.repo_id, info)
+                if inferred_type:
+                    updates["type"] = inferred_type
+
+            if getattr(model, "pipeline_tag", None) is None and getattr(info, "pipeline_tag", None):
+                updates["pipeline_tag"] = info.pipeline_tag
+            if getattr(model, "tags", None) is None and getattr(info, "tags", None):
+                updates["tags"] = info.tags
+            if getattr(model, "has_model_index", None) is None:
+                updates["has_model_index"] = has_model_index(info)
+            if getattr(model, "downloads", None) is None and getattr(info, "downloads", None) is not None:
+                updates["downloads"] = info.downloads
+            if getattr(model, "likes", None) is None and getattr(info, "likes", None) is not None:
+                updates["likes"] = info.likes
+            if (
+                getattr(model, "trending_score", None) is None
+                and getattr(info, "trending_score", None) is not None
+            ):
+                updates["trending_score"] = info.trending_score
+
+            if updates:
+                updated_models.append(model.model_copy(update=updates))
+            else:
+                updated_models.append(model)
+
+        node.recommended_models = updated_models
+
+    return ok, failed

--- a/src/nodetool/package_tools/scanner.py
+++ b/src/nodetool/package_tools/scanner.py
@@ -1,0 +1,294 @@
+"""Scan a nodetool Python node package and build a `PackageModel`.
+
+Restored from commit e1d10d3a of nodetool-core (`src/nodetool/packages/
+registry.py:scan_for_package_nodes`), adapted to emit machine-parseable
+progress on stderr instead of a click progressbar so TS callers can stream
+status lines.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from nodetool.metadata.node_metadata import (
+    AssetInfo,
+    EnumEncoder,
+    ExampleMetadata,
+    NodeMetadata,
+    PackageModel,
+    get_node_classes_from_module,
+)
+
+
+def _stderr(msg: str) -> None:
+    sys.stderr.write(msg + "\n")
+    sys.stderr.flush()
+
+
+def _extend_namespace_path(module_name: str, new_path: Path) -> None:
+    """If `module_name` is already imported, prepend `new_path` to its __path__.
+
+    Needed because `nodetool` and `nodetool.nodes` are PEP 420 namespace
+    packages: their `__path__` is frozen at import time. When we add the
+    target package's `src/` to `sys.path` after-the-fact, we also need to
+    teach the already-imported `nodetool.nodes` about the new source tree.
+    """
+    mod = sys.modules.get(module_name)
+    if mod is None or not hasattr(mod, "__path__") or not new_path.exists():
+        return
+    path_list = list(mod.__path__)  # type: ignore[attr-defined]
+    new_str = str(new_path)
+    if new_str not in path_list:
+        path_list.insert(0, new_str)
+        try:
+            mod.__path__ = path_list  # type: ignore[attr-defined]
+        except Exception:
+            pass
+
+
+def _to_repo_id(url: str | None) -> str | None:
+    if not url or not isinstance(url, str):
+        return None
+    try:
+        parsed = urlparse(url)
+        path = parsed.path.strip("/")
+        if not path:
+            return None
+        if path.endswith(".git"):
+            path = path[:-4]
+        owner_repo = "/".join(path.split("/")[:2])
+        return owner_repo or None
+    except Exception:
+        return None
+
+
+def _read_pyproject(package_dir: Path) -> dict[str, Any]:
+    pyproject = package_dir / "pyproject.toml"
+    if not pyproject.exists():
+        raise FileNotFoundError(f"No pyproject.toml in {package_dir}")
+    with open(pyproject, "rb") as f:
+        return tomllib.load(f)
+
+
+def _parse_authors(raw_authors: Any) -> list[str]:
+    authors: list[str] = []
+    if isinstance(raw_authors, list) and raw_authors and isinstance(raw_authors[0], dict):
+        for a in raw_authors:
+            name = a.get("name")
+            email = a.get("email")
+            if name and email:
+                authors.append(f"{name} <{email}>")
+            elif name:
+                authors.append(str(name))
+            elif email:
+                authors.append(str(email))
+    elif isinstance(raw_authors, list):
+        authors = [str(a) for a in raw_authors]
+    return authors
+
+
+def _load_examples_from_dir(directory: Path, package_name: str) -> list[ExampleMetadata]:
+    """Load example workflow metadata from `<directory>/<package_name>/*.json`."""
+    if not directory.exists():
+        return []
+    pkg_dir = directory / package_name
+    if not pkg_dir.exists():
+        return []
+
+    examples: list[ExampleMetadata] = []
+    for entry in sorted(pkg_dir.iterdir()):
+        if entry.name.startswith("_") or entry.suffix != ".json":
+            continue
+        try:
+            with open(entry, encoding="utf-8") as f:
+                data = json.load(f)
+        except Exception as e:
+            _stderr(f"SCAN warn example_load_failed file={entry} error={e}")
+            continue
+        examples.append(
+            ExampleMetadata(
+                id=str(data.get("id", "")),
+                name=str(data.get("name", entry.stem)),
+                description=str(data.get("description", "")),
+                tags=list(data.get("tags") or []),
+            )
+        )
+    return examples
+
+
+def _load_assets_from_dir(directory: Path, package_name: str) -> list[AssetInfo]:
+    """Load asset info from `<directory>/<package_name>/*` (files only)."""
+    if not directory.exists():
+        return []
+    pkg_dir = directory / package_name
+    if not pkg_dir.exists():
+        return []
+
+    assets: list[AssetInfo] = []
+    for entry in sorted(pkg_dir.iterdir()):
+        if entry.name.startswith("_"):
+            continue
+        assets.append(AssetInfo(package_name=package_name, name=entry.name, path=""))
+    return assets
+
+
+def _collect_node_modules(nodes_dir: Path) -> list[str]:
+    """Walk nodes_dir for *.py and return dotted module names relative to `nodetool.nodes.`."""
+    modules: list[str] = []
+    for root, _, files in os.walk(nodes_dir):
+        for file in files:
+            if not file.endswith(".py") or file == "__init__.py":
+                continue
+            module_path = Path(root) / file
+            rel = module_path.relative_to(nodes_dir)
+            dotted = str(rel.with_suffix("")).replace(os.sep, ".")
+            modules.append(dotted)
+    return sorted(modules)
+
+
+def scan_package(
+    package_dir: str | Path = ".",
+    *,
+    enrich: bool = False,
+    verbose: bool = False,
+    write: bool = False,
+    output: str | Path | None = None,
+) -> PackageModel:
+    """Scan a nodetool Python package and return its `PackageModel`.
+
+    Args:
+        package_dir: Package root (must contain pyproject.toml). Default: cwd.
+        enrich: Fetch HF model metadata for recommended models. Slow.
+        verbose: Emit extra progress lines to stderr.
+        write: Write JSON to `<package_dir>/src/nodetool/package_metadata/<name>.json`.
+        output: Write JSON to this path instead. Mutually exclusive with `write`.
+    """
+    if write and output:
+        raise ValueError("Cannot combine write=True with output=...")
+
+    pkg_dir = Path(package_dir).resolve()
+    data = _read_pyproject(pkg_dir)
+
+    project = data.get("project") or {}
+    if not project:
+        raise ValueError(f"No [project] metadata in {pkg_dir / 'pyproject.toml'}")
+
+    name = project.get("name") or ""
+    version = project.get("version") or "0.1.0"
+    description = project.get("description") or ""
+    authors = _parse_authors(project.get("authors") or [])
+
+    urls = project.get("urls") if isinstance(project, dict) else None
+    repo_url = None
+    if isinstance(urls, dict):
+        repo_url = urls.get("Repository") or urls.get("Source") or urls.get("Homepage")
+    repo_id = _to_repo_id(repo_url) or ""
+
+    _stderr(f"SCAN begin name={name}")
+
+    src_dir = pkg_dir / "src"
+    if src_dir.exists():
+        src_str = str(src_dir)
+        if src_str not in sys.path:
+            sys.path.insert(0, src_str)
+        _extend_namespace_path("nodetool", src_dir / "nodetool")
+        _extend_namespace_path("nodetool.nodes", src_dir / "nodetool" / "nodes")
+
+    examples = _load_examples_from_dir(src_dir / "nodetool" / "examples", name)
+    assets = _load_assets_from_dir(src_dir / "nodetool" / "assets", name)
+
+    package = PackageModel(
+        name=name,
+        description=description,
+        version=version,
+        authors=authors,
+        repo_id=repo_id,
+        nodes=[],
+        examples=examples,
+        assets=assets,
+    )
+
+    nodes_dir = src_dir / "nodetool" / "nodes"
+    if not nodes_dir.exists():
+        _stderr(f"SCAN warn no_nodes_dir path={nodes_dir}")
+    else:
+        module_names = _collect_node_modules(nodes_dir)
+        _stderr(f"SCAN modules total={len(module_names)}")
+
+        for i, rel_mod in enumerate(module_names, 1):
+            full = f"nodetool.nodes.{rel_mod}"
+            if verbose:
+                _stderr(f"SCAN module {i}/{len(module_names)} {full}")
+
+            try:
+                node_classes = get_node_classes_from_module(full, verbose)
+            except Exception as e:
+                msg = f"import_failed module={full} error={e}"
+                package.warnings.append(msg)
+                _stderr(f"SCAN warn {msg}")
+                continue
+
+            for node_class in node_classes:
+                try:
+                    is_visible = node_class.is_visible()
+                except Exception:
+                    is_visible = True
+                if not is_visible:
+                    continue
+                try:
+                    meta = node_class.get_metadata(include_model_info=False)
+                except Exception as e:
+                    msg = f"metadata_failed class={node_class.__name__} module={full} error={e}"
+                    package.warnings.append(msg)
+                    _stderr(f"SCAN warn {msg}")
+                    continue
+                assert package.nodes is not None
+                package.nodes.append(meta)
+
+        _stderr(f"SCAN nodes found={len(package.nodes or [])}")
+
+    if enrich and package.nodes:
+        _stderr("SCAN enrich begin")
+        try:
+            ok, failed = asyncio.run(_run_enrich(package.nodes, verbose=verbose))
+            _stderr(f"SCAN enrich done ok={ok} failed={failed}")
+        except Exception as e:
+            _stderr(f"SCAN warn enrich_failed error={e}")
+
+    target: Path | None = None
+    if write:
+        target = pkg_dir / "src" / "nodetool" / "package_metadata" / f"{name}.json"
+    elif output:
+        target = Path(output).resolve()
+
+    if target is not None:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with open(target, "w", encoding="utf-8") as f:
+            json.dump(
+                package.model_dump(exclude_defaults=True),
+                f,
+                indent=2,
+                cls=EnumEncoder,
+                sort_keys=True,
+            )
+            f.write("\n")
+        _stderr(f"SCAN write path={target}")
+
+    _stderr(
+        f"SCAN end status=ok nodes={len(package.nodes or [])} "
+        f"examples={len(package.examples or [])} assets={len(package.assets or [])}"
+    )
+    return package
+
+
+async def _run_enrich(nodes: list[NodeMetadata], verbose: bool) -> tuple[int, int]:
+    from nodetool.package_tools.enrich import enrich_nodes_with_model_info
+
+    return await enrich_nodes_with_model_info(nodes, verbose=verbose)

--- a/src/nodetool/workflows/base_node.py
+++ b/src/nodetool/workflows/base_node.py
@@ -1017,11 +1017,8 @@ class BaseNode(BaseModel):
             NodeMetadata: An object containing all metadata about the node,
             including its properties, outputs, and other relevant information.
         """
-        try:
-            # avoid circular import
-            from nodetool.metadata.node_metadata import NodeMetadata
-        except ImportError:
-            raise ImportError("node_metadata module not available — use node_loader.node_to_metadata() instead")
+        # avoid circular import
+        from nodetool.metadata.node_metadata import NodeMetadata
 
         try:
             return NodeMetadata(

--- a/tests/package_tools/fixtures/sample_pkg/pyproject.toml
+++ b/tests/package_tools/fixtures/sample_pkg/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "nodetool-sample"
+version = "0.0.1"
+description = "Sample package fixture"
+authors = [{ name = "Test", email = "test@example.com" }]
+requires-python = ">=3.11"
+
+[project.urls]
+Repository = "https://github.com/nodetool-ai/nodetool-sample"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/nodetool"]

--- a/tests/package_tools/fixtures/sample_pkg/src/nodetool/examples/nodetool-sample/echo.json
+++ b/tests/package_tools/fixtures/sample_pkg/src/nodetool/examples/nodetool-sample/echo.json
@@ -1,0 +1,6 @@
+{
+  "id": "echo-example",
+  "name": "Echo Example",
+  "description": "A tiny workflow that uses EchoNode.",
+  "tags": ["demo"]
+}

--- a/tests/package_tools/fixtures/sample_pkg/src/nodetool/nodes/demo.py
+++ b/tests/package_tools/fixtures/sample_pkg/src/nodetool/nodes/demo.py
@@ -1,0 +1,16 @@
+"""Demo node module used by scanner tests."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from nodetool.workflows.base_node import BaseNode
+
+
+class EchoNode(BaseNode):
+    """Echo the input string back."""
+
+    text: str = Field(default="", description="Text to echo")
+
+    async def process(self, context) -> str:  # type: ignore[override]
+        return self.text

--- a/tests/package_tools/test_enrich.py
+++ b/tests/package_tools/test_enrich.py
@@ -1,0 +1,83 @@
+"""Enrich tests (mocked HF fetch)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from nodetool.metadata.node_metadata import NodeMetadata
+from nodetool.package_tools.enrich import enrich_nodes_with_model_info
+
+
+class _FakeModelInfo:
+    def __init__(self) -> None:
+        self.pipeline_tag = "text-generation"
+        self.tags = ["foo", "bar"]
+        self.downloads = 123
+        self.likes = 45
+        self.trending_score = 7.2
+        self.siblings = []
+        self.cardData = None
+
+
+def _make_node_with_repo(repo_id: str) -> NodeMetadata:
+    from nodetool.types.model import UnifiedModel
+
+    model = UnifiedModel(
+        id=repo_id,
+        repo_id=repo_id,
+        type=None,
+        name=repo_id,
+        path=None,
+        downloaded=False,
+    )
+    return NodeMetadata(
+        title="T",
+        description="D",
+        namespace="ns",
+        node_type="ns.T",
+        recommended_models=[model],
+    )
+
+
+@pytest.mark.asyncio
+async def test_enrich_populates_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch(_model_id: str) -> Any:
+        return _FakeModelInfo()
+
+    def fake_has_model_index(_info: Any) -> bool:
+        return False
+
+    def fake_type(_repo_map: Any, _repo_id: str, _info: Any) -> str | None:
+        return "language_model"
+
+    import nodetool.integrations.huggingface.huggingface_models as hm
+
+    monkeypatch.setattr(hm, "fetch_model_info", fake_fetch)
+    monkeypatch.setattr(hm, "has_model_index", fake_has_model_index)
+    monkeypatch.setattr(hm, "model_type_from_model_info", fake_type)
+
+    node = _make_node_with_repo("owner/repo")
+    ok, failed = await enrich_nodes_with_model_info([node])
+    assert (ok, failed) == (1, 0)
+
+    m = node.recommended_models[0]
+    assert m.pipeline_tag == "text-generation"
+    assert m.tags == ["foo", "bar"]
+    assert m.downloads == 123
+    assert m.likes == 45
+
+
+@pytest.mark.asyncio
+async def test_enrich_no_models_is_noop() -> None:
+    node = NodeMetadata(title="T", description="D", namespace="ns", node_type="ns.T")
+    ok, failed = await enrich_nodes_with_model_info([node])
+    assert (ok, failed) == (0, 0)
+
+
+def test_enrich_sync_wrapper() -> None:
+    node = NodeMetadata(title="T", description="D", namespace="ns", node_type="ns.T")
+    ok, failed = asyncio.run(enrich_nodes_with_model_info([node]))
+    assert (ok, failed) == (0, 0)

--- a/tests/package_tools/test_scanner.py
+++ b/tests/package_tools/test_scanner.py
@@ -1,0 +1,74 @@
+"""Scanner tests."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from nodetool.metadata.node_metadata import PackageModel
+from nodetool.package_tools import scan_package
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sample_pkg"
+
+
+def test_scan_sample_package() -> None:
+    pkg = scan_package(FIXTURE, enrich=False, verbose=False)
+
+    assert isinstance(pkg, PackageModel)
+    assert pkg.name == "nodetool-sample"
+    assert pkg.version == "0.0.1"
+    assert pkg.description == "Sample package fixture"
+    assert "Test <test@example.com>" in pkg.authors
+    assert pkg.repo_id == "nodetool-ai/nodetool-sample"
+
+    assert pkg.nodes is not None and len(pkg.nodes) == 1
+    node = pkg.nodes[0]
+    assert "Echo" in node.node_type
+    assert "demo" in node.namespace
+
+    assert pkg.examples is not None and len(pkg.examples) == 1
+    assert pkg.examples[0].name == "Echo Example"
+    assert pkg.assets == []
+
+
+def test_scan_missing_pyproject(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        scan_package(tmp_path)
+
+
+def test_scan_write_idempotent(tmp_path: Path) -> None:
+    import shutil
+
+    dest = tmp_path / "pkg"
+    shutil.copytree(FIXTURE, dest)
+
+    pkg1 = scan_package(dest, write=True)
+    meta_path = dest / "src" / "nodetool" / "package_metadata" / "nodetool-sample.json"
+    assert meta_path.exists()
+    content1 = meta_path.read_text()
+
+    pkg2 = scan_package(dest, write=True)
+    content2 = meta_path.read_text()
+
+    assert content1 == content2, "scan --write must be idempotent"
+    assert pkg1.model_dump() == pkg2.model_dump()
+
+
+def test_cli_scan_stdout() -> None:
+    """Run the CLI as a subprocess and parse stdout JSON."""
+    result = subprocess.run(
+        [sys.executable, "-m", "nodetool.package_tools", "scan", "--package-dir", str(FIXTURE)],
+        capture_output=True,
+        text=True,
+        env=os.environ.copy(),
+    )
+    assert result.returncode == 0, f"CLI failed: {result.stderr}"
+    data = json.loads(result.stdout)
+    assert data["name"] == "nodetool-sample"
+    assert "SCAN begin" in result.stderr
+    assert "SCAN end" in result.stderr


### PR DESCRIPTION
## Summary
- Restores `nodetool/metadata/node_metadata.py` at its original location (deleted by the 2026-04-11 strip, commit 88b759f8)
- Adds `nodetool.package_tools` — scan utilities invoked as a subprocess by the TS workspace to rebuild `package_metadata/<name>.json` for any Python node package
- Fixes `BaseNode.get_metadata()` which had been pointing at a non-existent replacement

## Why
Python node packages (`nodetool-huggingface`, `nodetool-mlx`, `nodetool-apple`, etc.) have no way to regenerate their `package_metadata/<name>.json` since the scan code was removed. The TS loader depends on those files. This restores the ability inside `nodetool-core` so TS can shell out to `python -m nodetool.package_tools scan`.

## What's here
- `src/nodetool/metadata/node_metadata.py` — `NodeMetadata`, `PackageModel`, `ExampleMetadata`, `AssetInfo`, `EnumEncoder`, `get_submodules`, `get_node_classes_from_module`/`_namespace`
- `src/nodetool/package_tools/scanner.py` — `scan_package()` with PEP 420 namespace handling
- `src/nodetool/package_tools/enrich.py` — optional HF model-info enrichment behind `--enrich`
- `src/nodetool/package_tools/__main__.py` — `nodetool-pkg scan [--package-dir] [--output|--write] [--enrich] [--verbose]`
- `tests/package_tools/` — 7 tests, all pass

## Dependencies
None new. Uses stdlib `tomllib` (3.11+).

## Test plan
- [x] `pytest tests/package_tools` — 7/7 pass
- [x] `python -m nodetool.package_tools scan --package-dir /Users/mg/workspace/nodetool-huggingface` — 85 nodes / 7 examples / 11 assets / 0 warnings, ~9s
- [x] `--write` is idempotent (md5 stable across runs)
- [x] Companion TS wrapper at https://github.com/nodetool-ai/nodetool/pull/2763 calls this and returns the parsed result in ~7s end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)