### PR TITLE
⚡ Bolt: [performance improvement] Optimize Hugging Face fast cache with os.scandir

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,7 @@
 ## 2025-04-26 - Asyncio Directory Traversal Bottleneck
 **Learning:** Deep recursive directory traversal using individual `aiofiles` calls (like `aiofiles.os.listdir` or `aiofiles.os.path.is_file`) causes massive context-switching overhead in `asyncio` applications by dispatching thousands of tasks to the default thread pool.
 **Action:** Optimize deep recursive file system traversals by running a single synchronous C-optimized `os.walk` or `os.scandir` inside a back-referenced `loop.run_in_executor()`. This reduces the async task dispatch count from O(N) down to O(1) while keeping the event loop unblocked.
+
+## 2024-05-18 - [Optimize Hugging Face fast cache with os.scandir]
+**Learning:** [In asyncio apps, reading directories with `aiofiles.os.listdir` and then performing individual `aiofiles.os.stat` or `aiofiles.os.path.is_dir` checks for every entry causes massive context-switching overhead because it dispatches thousands of tiny I/O tasks to the default thread pool.]
+**Action:** [Use a single `await asyncio.get_running_loop().run_in_executor()` call wrapping a fast synchronous helper utilizing `os.scandir` to retrieve the directory entries and their stats in a single system call sequence.]

--- a/src/nodetool/integrations/huggingface/hf_fast_cache.py
+++ b/src/nodetool/integrations/huggingface/hf_fast_cache.py
@@ -307,19 +307,27 @@ class HfFastCache:
         type_prefix = f"{repo_type}s" if not repo_type.endswith("s") else repo_type
         repos: list[tuple[str, Path]] = []
 
-        try:
-            for name in await aiofiles.os.listdir(str(self.cache_dir)):
-                item = self.cache_dir / name
-                if not await _is_dir(item):
-                    continue
-                if not item.name.startswith(f"{type_prefix}--"):
-                    continue
+        # ⚡ Bolt Optimization: Use a single run_in_executor with os.scandir
+        # to find matching directories, avoiding N individual aiofiles.os.listdir
+        # and aiofiles.os.stat thread dispatches.
+        def _sync_discover() -> list[tuple[str, Path]]:
+            discovered = []
+            try:
+                for entry in os.scandir(str(self.cache_dir)):
+                    if not entry.is_dir():
+                        continue
+                    if not entry.name.startswith(f"{type_prefix}--"):
+                        continue
 
-                parts = item.name[len(f"{type_prefix}--") :].split("--")
-                repo_id = "/".join(parts) if len(parts) > 1 else parts[0]
-                repos.append((repo_id, item))
-        except OSError:
-            return []
+                    parts = entry.name[len(f"{type_prefix}--") :].split("--")
+                    repo_id = "/".join(parts) if len(parts) > 1 else parts[0]
+                    discovered.append((repo_id, self.cache_dir / entry.name))
+            except OSError:
+                pass
+            return discovered
+
+        loop = asyncio.get_running_loop()
+        repos = await loop.run_in_executor(None, _sync_discover)
 
         return repos
 
@@ -522,19 +530,33 @@ async def _read_current_ref_async(
     if await _exists(main):
         return await _mtime_or_none_async(main), await _read_first_line_async(main)
 
-    newest_mtime: Optional[float] = None
+    # ⚡ Bolt Optimization: Use a single run_in_executor with os.scandir
+    # to find the newest ref file, avoiding N individual aiofiles.os.listdir
+    # and aiofiles.os.stat thread dispatches.
+    def _sync_find_newest_ref() -> tuple[Optional[float], Optional[Path]]:
+        n_mtime: Optional[float] = None
+        n_path: Optional[Path] = None
+        try:
+            for entry in os.scandir(str(refs_dir)):
+                if not entry.is_file():
+                    continue
+                try:
+                    mt = entry.stat().st_mtime
+                    if n_mtime is None or mt > n_mtime:
+                        n_mtime = mt
+                        n_path = refs_dir / entry.name
+                except OSError:
+                    pass
+        except OSError:
+            pass
+        return n_mtime, n_path
+
+    loop = asyncio.get_running_loop()
+    newest_mtime, newest_path = await loop.run_in_executor(None, _sync_find_newest_ref)
+
     newest_commit: Optional[str] = None
-    try:
-        for name in await aiofiles.os.listdir(str(refs_dir)):
-            file = refs_dir / name
-            if not await _is_file(file):
-                continue
-            mt = await _mtime_or_none_async(file)
-            if newest_mtime is None or (mt is not None and mt > newest_mtime):
-                newest_mtime = mt
-                newest_commit = await _read_first_line_async(file)
-    except OSError:
-        return None, None
+    if newest_path is not None:
+        newest_commit = await _read_first_line_async(newest_path)
 
     return (
         (newest_mtime if newest_mtime is not None else await _mtime_or_none_async(refs_dir)),
@@ -555,20 +577,30 @@ async def _pick_latest_snapshot_async(repo_dir: Path) -> Optional[Path]:
     snapshots_dir = repo_dir / "snapshots"
     if not await _exists(snapshots_dir):
         return None
-    newest_path: Optional[Path] = None
-    newest_mtime: Optional[float] = None
-    try:
-        for name in await aiofiles.os.listdir(str(snapshots_dir)):
-            path = snapshots_dir / name
-            if not await _is_dir(path):
-                continue
-            mt = await _mtime_or_none_async(path)
-            if newest_mtime is None or (mt is not None and mt > newest_mtime):
-                newest_mtime = mt
-                newest_path = path
-    except OSError:
-        return None
-    return newest_path
+
+    # ⚡ Bolt Optimization: Use a single run_in_executor with os.scandir
+    # to find the newest snapshot directory, avoiding N individual aiofiles.os.listdir
+    # and aiofiles.os.stat thread dispatches.
+    def _sync_find_newest_snapshot() -> Optional[Path]:
+        n_path: Optional[Path] = None
+        n_mtime: Optional[float] = None
+        try:
+            for entry in os.scandir(str(snapshots_dir)):
+                if not entry.is_dir():
+                    continue
+                try:
+                    mt = entry.stat().st_mtime
+                    if n_mtime is None or mt > n_mtime:
+                        n_mtime = mt
+                        n_path = snapshots_dir / entry.name
+                except OSError:
+                    pass
+        except OSError:
+            pass
+        return n_path
+
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, _sync_find_newest_snapshot)
 
 
 async def _read_first_line_async(path: Path) -> Optional[str]:


### PR DESCRIPTION
💡 **What:** Replaced individual `aiofiles.os.listdir` and `aiofiles.os.stat`/`is_dir` checks with synchronous helpers utilizing `os.scandir` executed via a single `run_in_executor` dispatch in `discover_repos`, `_read_current_ref_async`, and `_pick_latest_snapshot_async`.

🎯 **Why:** Deep recursive or wide flat directory traversals using individual `aiofiles` calls cause massive context-switching overhead by dispatching thousands of tasks to the default async thread pool. 

📊 **Impact:** Reduces task dispatch count from O(N) to O(1) for directory listings, substantially minimizing event loop lag when scanning large locally cached repositories.

🔬 **Measurement:** Verify performance enhancement by executing cache-intensive workloads (like frequent startup discovery) or running the test suite (`uv run pytest tests/integrations/test_hf_fast_cache.py`) to confirm correctness and improved execution speed.

---
*PR created automatically by Jules for task [6407428142681273230](https://jules.google.com/task/6407428142681273230) started by @georgi*