### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in FileStorage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,7 @@
 **Vulnerability:** The `read_file_uri` function naively opened arbitrary user-supplied file paths derived from `file://` URIs without validating them against the designated workspace boundary, risking Local File Inclusion (LFI).
 **Learning:** Even internal mechanisms like asset auto-saving can become attack vectors if they resolve user-supplied `file://` URIs without path sanitization.
 **Prevention:** Always pipe file paths derived from user inputs or untrusted URIs through the standard workspace resolution utility (e.g., `resolve_workspace_path`) before accessing the disk.
+## 2024-05-08 - Fix path traversal in FileStorage
+**Vulnerability:** The `FileStorage` class in `src/nodetool/storage/file_storage.py` allowed path traversal via `self.base_path / key`. Using absolute paths (e.g. `/etc/passwd`) or directory traversal (e.g. `../../../file`) allowed unauthorized reads/writes outside the `base_path`.
+**Learning:** Combining a base `pathlib.Path` with an untrusted `key` without stripping leading slashes or resolving to absolute paths to verify boundaries permits out-of-bounds filesystem access. If the second operand of `/` is an absolute path, `pathlib` discards the first operand.
+**Prevention:** Always strip leading slashes from untrusted keys before concatenating them with a base path. Resolve both the base path and the final target path to their absolute representations and verify that the target path is a subpath of the base path (e.g. using `target.is_relative_to(base)`).

--- a/src/nodetool/storage/file_storage.py
+++ b/src/nodetool/storage/file_storage.py
@@ -10,7 +10,18 @@ class FileStorage(AbstractStorage):
         self.base_path.mkdir(parents=True, exist_ok=True)
 
     def _path(self, key: str) -> Path:
-        return self.base_path / key
+        # Prevent absolute path injection by stripping leading slash
+        clean_key = key.lstrip("/")
+
+        # Resolve to absolute paths
+        abs_base_path = self.base_path.resolve()
+        abs_target_path = (abs_base_path / clean_key).resolve()
+
+        # Verify the target path is inside the base path
+        if not abs_target_path.is_relative_to(abs_base_path):
+            raise ValueError("Path traversal attempt detected")
+
+        return abs_target_path
 
     async def upload(self, key: str, data: IO) -> None:
         path = self._path(key)

--- a/tests/storage/test_file_storage.py
+++ b/tests/storage/test_file_storage.py
@@ -1,0 +1,11 @@
+import pytest
+import os
+from pathlib import Path
+from io import BytesIO
+from nodetool.storage.file_storage import FileStorage
+
+@pytest.mark.asyncio
+async def test_file_storage_path_traversal(tmp_path):
+    storage = FileStorage(str(tmp_path))
+    with pytest.raises(ValueError, match="Path traversal attempt detected"):
+        await storage.upload("../evil.txt", BytesIO(b"evil"))


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The `FileStorage` class (`src/nodetool/storage/file_storage.py`) was susceptible to absolute path injection and path traversal. Because it resolved paths via `self.base_path / key`, an attacker could supply `key="/etc/passwd"` to overwrite/read system files, or `key="../../../secrets.txt"` to escape the base storage directory.
🎯 **Impact**: Allowed arbitrary file read, write, and delete operations across the local filesystem in contexts where `FileStorage` handles untrusted inputs.
🔧 **Fix**: Stripped leading slashes from `key` before path concatenation. Resolved both the base path and the combined path to their absolute representations and strictly verified that the combined path remains a subpath of the base directory via `pathlib.Path.is_relative_to()`.
✅ **Verification**: Run `uv run pytest tests/storage/test_file_storage.py` to verify the new boundary-check test effectively catches and blocks traversal payloads.

---
*PR created automatically by Jules for task [5853005050221811068](https://jules.google.com/task/5853005050221811068) started by @georgi*