### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure deserialization in joblib load

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,8 @@
 **Vulnerability:** The `src/nodetool/media/image/web_font_utils.py` file was using `hashlib.md5()` to generate a cache filename from a URL.
 **Learning:** Even though the hash was used non-cryptographically (just for cache filenames) and truncated to 8 characters, automated security tools and linters universally flag MD5 usage as a vulnerability. The repository enforces a policy of using SHA-256 for all hashing operations to maintain a consistent security standard.
 **Prevention:** Always use `hashlib.sha256()` instead of `hashlib.md5()`, even for non-cryptographic purposes like caching, to prevent security linters from flagging the code and to adhere to modern cryptographic standards.
+
+## 2024-05-12 - [CRITICAL] Fix insecure deserialization in joblib load
+**Vulnerability:** In `src/nodetool/workflows/processing_offload.py`, the function `_joblib_load_from_io` verified the data stream using a restricted `SafeUnpickler` but then immediately discarded its result. It subsequently read from the exact same stream using the unsafe default `joblib.load()`, rendering the safety check useless and allowing arbitrary code execution during pickling.
+**Learning:** Security checks that parse data but discard their safe results in favor of re-evaluating the raw data with unsafe functions create a false sense of security (a form of TOCTOU or check-bypass vulnerability).
+**Prevention:** Always directly return or use the object resulting from the safe parser or unpickler instead of relying on a secondary, un-restricted loading mechanism.

--- a/src/nodetool/workflows/processing_offload.py
+++ b/src/nodetool/workflows/processing_offload.py
@@ -214,7 +214,7 @@ def _audio_segment_to_numpy(
 
 
 def _joblib_load_from_io(buffer: IO[bytes]) -> Any:
-    joblib = _ensure_joblib()
+    _ensure_joblib()
     from joblib.numpy_pickle import NumpyUnpickler
     from joblib.numpy_pickle_utils import _validate_fileobject_and_memmap
 
@@ -266,13 +266,9 @@ def _joblib_load_from_io(buffer: IO[bytes]) -> Any:
             # Signature: (filename, file_handle, ensure_native_byte_order, mmap_mode=None)
             # Pass empty string as filename if reading from buffer (similar to joblib.load)
             unpickler = SafeUnpickler("", fobj, ensure_native_byte_order=True)
-            unpickler.load()
+            return unpickler.load()
     except Exception as e:
         raise ValueError(f"Unsafe or invalid model data: {e}") from e
-
-    with suppress(Exception):
-        buffer.seek(0)
-    return joblib.load(buffer)
 
 
 def _joblib_dump_to_bytes(estimator: Any) -> bytes:


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The function `_joblib_load_from_io` in `src/nodetool/workflows/processing_offload.py` used a safe unpickler to validate the payload but discarded its result and subsequently executed a default `joblib.load()` on the same input. This created a TOCTOU-like vulnerability that bypasses the security check and allows arbitrary code execution via insecure deserialization.
🎯 **Impact:** An attacker could craft a malicious pickle payload that passes the `SafeUnpickler` initial test (if it is structure-compliant or using bypassing techniques on the initial read context) or simply rely on the function re-reading the stream using the unsafe, unrestricted default unpickler, leading to full Remote Code Execution (RCE) on the server.
🔧 **Fix:** Replaced the discarded result with a direct return of `unpickler.load()` and removed the unsafe `joblib.load(buffer)` fallback, ensuring the restricted sandbox applies to the final loaded object. Updated `.jules/sentinel.md` with findings.
✅ **Verification:** Verified by running `uv run pytest tests/workflows/` and `uv run pytest tests/worker/`. All tests pass. Verified correct return value from secure unpickler.

---
*PR created automatically by Jules for task [11704247249290178177](https://jules.google.com/task/11704247249290178177) started by @georgi*