### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in font downloading

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -36,7 +36,7 @@
 **Learning:** Combining a base `pathlib.Path` with an untrusted `key` without stripping leading slashes or resolving to absolute paths to verify boundaries permits out-of-bounds filesystem access. If the second operand of `/` is an absolute path, `pathlib` discards the first operand.
 **Prevention:** Always strip leading slashes from untrusted keys before concatenating them with a base path. Resolve both the base path and the final target path to their absolute representations and verify that the target path is a subpath of the base path (e.g. using `target.is_relative_to(base)`).
 
-## $(date +%Y-%m-%d) - [Replace insecure MD5 with SHA256 for non-cryptographic hashing]
+## 2026-05-18 - [Replace insecure MD5 with SHA256 for non-cryptographic hashing]
 **Vulnerability:** The `src/nodetool/media/image/web_font_utils.py` file was using `hashlib.md5()` to generate a cache filename from a URL.
 **Learning:** Even though the hash was used non-cryptographically (just for cache filenames) and truncated to 8 characters, automated security tools and linters universally flag MD5 usage as a vulnerability. The repository enforces a policy of using SHA-256 for all hashing operations to maintain a consistent security standard.
 **Prevention:** Always use `hashlib.sha256()` instead of `hashlib.md5()`, even for non-cryptographic purposes like caching, to prevent security linters from flagging the code and to adhere to modern cryptographic standards.
@@ -53,3 +53,7 @@
 **Vulnerability:** The `download_font_from_url` function was using `urlopen` directly on user-provided URLs without validating whether the hostname or its resolved IP address pointed to private, internal infrastructure, allowing for Server-Side Request Forgery (SSRF) attacks.
 **Learning:** Functions that download resources from URLs provided by the user must always validate the resolved IP against an allowlist/blocklist (e.g. `is_ip_private`). Wait, `urllib.request.urlopen` does not support custom DNS resolvers out of the box, which means it is susceptible to TOCTOU (DNS Rebinding) attacks. The safest method for external HTTP requests is `aiohttp` using `SSRFProtectResolver`.
 **Prevention:** Always use `is_ip_private` on both the explicit hostname and the IPs resolved by `socket.getaddrinfo` prior to a request. If possible, migrate from `urllib.request` to a library that supports custom connection pools and DNS resolvers (like `aiohttp`) to robustly mitigate DNS rebinding.
+## 2026-05-18 - [HIGH] Fix SSRF vulnerability in web_font_utils.py font downloading
+**Vulnerability:** The functions `download_google_font` and `download_font_from_url` in `src/nodetool/media/image/web_font_utils.py` used `urllib.request.urlopen` with DNS checking that was susceptible to DNS rebinding (TOCTOU), allowing for Server-Side Request Forgery (SSRF) vulnerabilities when accessing external font URLs.
+**Learning:** `urllib.request` does not allow custom DNS resolvers, making it inherently vulnerable to DNS rebinding bypass techniques even when pre-flight IP checks (like `is_ip_private`) are implemented.
+**Prevention:** Always replace `urllib.request` with `aiohttp` using a custom connector configured with `SSRFProtectResolver` (`aiohttp.TCPConnector(resolver=SSRFProtectResolver())`) to guarantee robust DNS rebinding SSRF protection when downloading user-provided external URLs.

--- a/src/nodetool/media/image/web_font_utils.py
+++ b/src/nodetool/media/image/web_font_utils.py
@@ -2,15 +2,17 @@
 Web font utilities for downloading and caching fonts from Google Fonts and custom URLs.
 """
 
+import asyncio
 import hashlib
 import os
 import re
 from pathlib import Path
 from typing import Optional
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+
+import aiohttp
 
 from nodetool.config.logging_config import get_logger
+from nodetool.utils.network import SSRFProtectResolver, is_ip_private
 
 log = get_logger(__name__)
 
@@ -181,6 +183,22 @@ def _get_cache_filename(font_name: str, weight: str, url: str = "") -> str:
         return f"google_{clean_name}_{weight}.ttf"
 
 
+async def _download_font_async(url: str, cache_path: Path) -> bytes:
+    """Asynchronously download font data with SSRF protection."""
+    connector = aiohttp.TCPConnector(resolver=SSRFProtectResolver())
+    async with aiohttp.ClientSession(connector=connector) as session:
+        try:
+            async with session.get(url, timeout=30, headers={"User-Agent": "NodeTool/1.0"}) as response:
+                if response.status == 404:
+                    raise FileNotFoundError(f"Font file not found at {url}")
+                response.raise_for_status()
+                return await response.read()
+        except aiohttp.ClientError as e:
+            raise ConnectionError(f"Failed to download font from {url}: {e}") from e
+        except TimeoutError as e:
+            raise ConnectionError(f"Timeout while downloading font from {url}") from e
+
+
 def download_google_font(font_name: str, weight: str = "regular") -> str:
     """Download a font from Google Fonts and cache it locally.
 
@@ -267,22 +285,18 @@ def download_google_font(font_name: str, weight: str = "regular") -> str:
         log.debug(f"Trying to download font from: {url}")
 
         try:
-            request = Request(url, headers={"User-Agent": "NodeTool/1.0"})
-            with urlopen(request, timeout=30) as response:
-                font_data = response.read()
+            font_data = asyncio.run(_download_font_async(url, cache_path))
 
             # Save to cache
             cache_path.write_bytes(font_data)
             log.info(f"Downloaded and cached Google Font: {font_name} ({weight}) -> {cache_path}")
             return str(cache_path)
 
-        except HTTPError as e:
-            if e.code == 404:
-                log.debug(f"Font file not found at {url}, trying next pattern...")
-                continue
-            raise ConnectionError(f"Failed to download font from {url}: HTTP {e.code}") from e
-        except URLError as e:
-            raise ConnectionError(f"Failed to connect to download font: {e.reason}") from e
+        except FileNotFoundError:
+            log.debug(f"Font file not found at {url}, trying next pattern...")
+            continue
+        except ConnectionError as e:
+            raise e
 
     raise ValueError(
         f"Could not find font file for '{font_name}' weight '{weight}' in Google Fonts. "
@@ -306,25 +320,12 @@ def download_font_from_url(url: str) -> str:
     if not url.startswith(("http://", "https://")):
         raise ValueError(f"Invalid font URL: {url}. Must be http:// or https://")
 
-    import socket
     from urllib.parse import urlparse
-
-    from nodetool.utils.network import is_ip_private
 
     parsed_url = urlparse(url)
     hostname = parsed_url.hostname
-    if hostname:
-        if is_ip_private(hostname):
-            raise ValueError(f"Access to private/restricted IP blocked: {hostname}")
-        try:
-            for res in socket.getaddrinfo(hostname, None):
-                ip = res[4][0]
-                if is_ip_private(ip):
-                    raise ValueError(
-                        f"Access to host '{hostname}' blocked because it resolved to a private/restricted IP."
-                    )
-        except socket.gaierror:
-            pass
+    if hostname and is_ip_private(hostname):
+        raise ValueError(f"Access to private/restricted IP blocked: {hostname}")
 
     cache_dir = get_font_cache_dir()
     cache_filename = _get_cache_filename("", "", url)
@@ -337,35 +338,27 @@ def download_font_from_url(url: str) -> str:
 
     log.info(f"Downloading font from URL: {url}")
 
-    try:
-        request = Request(url, headers={"User-Agent": "NodeTool/1.0"})
-        with urlopen(request, timeout=30) as response:
-            font_data = response.read()
+    font_data = asyncio.run(_download_font_async(url, cache_path))
 
-        # Basic validation - check for TTF/OTF magic bytes
-        if len(font_data) < 4:
-            raise ValueError("Downloaded file is too small to be a valid font")
+    # Basic validation - check for TTF/OTF magic bytes
+    if len(font_data) < 4:
+        raise ValueError("Downloaded file is too small to be a valid font")
 
-        # TTF starts with 0x00010000 or 'OTTO' (for OTF) or 'true' or 'typ1'
-        magic = font_data[:4]
-        valid_signatures = [
-            b"\x00\x01\x00\x00",  # TTF
-            b"OTTO",  # OTF
-            b"true",  # TrueType
-            b"typ1",  # Type1
-        ]
-        if magic not in valid_signatures:
-            log.warning(f"Downloaded file may not be a valid font (magic bytes: {magic.hex()})")
+    # TTF starts with 0x00010000 or 'OTTO' (for OTF) or 'true' or 'typ1'
+    magic = font_data[:4]
+    valid_signatures = [
+        b"\x00\x01\x00\x00",  # TTF
+        b"OTTO",  # OTF
+        b"true",  # TrueType
+        b"typ1",  # Type1
+    ]
+    if magic not in valid_signatures:
+        log.warning(f"Downloaded file may not be a valid font (magic bytes: {magic.hex()})")
 
-        # Save to cache
-        cache_path.write_bytes(font_data)
-        log.info(f"Downloaded and cached font from URL: {cache_path}")
-        return str(cache_path)
-
-    except HTTPError as e:
-        raise ConnectionError(f"Failed to download font from {url}: HTTP {e.code}") from e
-    except URLError as e:
-        raise ConnectionError(f"Failed to connect to download font: {e.reason}") from e
+    # Save to cache
+    cache_path.write_bytes(font_data)
+    log.info(f"Downloaded and cached font from URL: {cache_path}")
+    return str(cache_path)
 
 
 def get_web_font_path(

--- a/tests/common/test_web_font_utils.py
+++ b/tests/common/test_web_font_utils.py
@@ -101,27 +101,26 @@ class TestDownloadGoogleFont:
         with pytest.raises(ValueError, match="not found in Google Fonts catalog"):
             download_google_font("NonExistentFontXYZ", "regular")
 
-    @patch("nodetool.media.image.web_font_utils.urlopen")
-    def test_download_font_caches_result(self, mock_urlopen):
+    @patch("nodetool.media.image.web_font_utils._download_font_async")
+    def test_download_font_caches_result(self, mock_download):
         """Test that downloaded fonts are cached."""
-        # Setup mock response
-        mock_response = MagicMock()
-        mock_response.read.return_value = b"\x00\x01\x00\x00" + b"\x00" * 100  # TTF header
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-        mock_urlopen.return_value = mock_response
+        # Setup mock response to return TTF header bytes
+        mock_download.return_value = b"\x00\x01\x00\x00" + b"\x00" * 100  # TTF header
 
-        # First download
-        cache_dir = get_font_cache_dir()
-        test_cache_file = cache_dir / "google_roboto_regular.ttf"
+        # Override asyncio.run behavior to bypass coroutines for the mock
+        import asyncio
 
-        # Clean up if exists from previous test
-        if test_cache_file.exists():
-            test_cache_file.unlink()
+        with patch("asyncio.run", side_effect=lambda x: mock_download.return_value):
+            # First download
+            cache_dir = get_font_cache_dir()
+            test_cache_file = cache_dir / "google_roboto_regular.ttf"
 
-        # This would normally download, but we're mocking
-        # Just verify the function signature works
-        assert "roboto" in GOOGLE_FONTS_CATALOG
+            # Clean up if exists from previous test
+            if test_cache_file.exists():
+                test_cache_file.unlink()
+
+            download_google_font("Roboto", "regular")
+            assert test_cache_file.exists()
 
 
 class TestDownloadFontFromUrl:


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `download_font_from_url` and `download_google_font` functions in `src/nodetool/media/image/web_font_utils.py` used `urllib.request.urlopen`. Although they performed an `is_ip_private` check on the resolved IP, `urllib.request` does not support custom DNS resolvers. This made the application vulnerable to DNS Rebinding (TOCTOU) attacks, leading to Server-Side Request Forgery (SSRF).
🎯 Impact: An attacker could bypass the initial IP check and force the server to download fonts from restricted, internal, or private network addresses, potentially leaking internal infrastructure details or interacting with unauthorized internal services.
🔧 Fix: Replaced `urllib.request` with `aiohttp` using a custom connector configured with `SSRFProtectResolver`. This ensures that DNS rebinding is prevented during actual HTTP connection resolution. Since the original functions were synchronous, an internal async wrapper (`_download_font_async`) was added and called via `asyncio.run()`.
✅ Verification: Ran `uv run pytest tests/common/test_web_font_utils.py` and `uv run pytest` to verify the new fetching mechanism works correctly and securely without causing codebase regressions.

---
*PR created automatically by Jules for task [11050786842905118880](https://jules.google.com/task/11050786842905118880) started by @georgi*