### PR TITLE
fix(worker): stream Python node outputs + surface recommended models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nodetool-core"
-version = "0.6.3-rc.48"
+version = "0.7.0-rc.8"
 description = "Nodetool Core is the core library for Nodetool, providing the necessary functionality for building and running AI workflows."
 readme = "README.md"
 authors = [{ name = "Matthias Georgi", email = "matti.georgi@gmail.com" }]

--- a/src/nodetool/worker/executor.py
+++ b/src/nodetool/worker/executor.py
@@ -3,7 +3,9 @@ Instantiate a Python BaseNode, execute it, and collect final outputs.
 """
 import asyncio
 import os
+import shutil
 import tempfile
+from collections.abc import AsyncGenerator
 from types import UnionType
 from typing import Any, Union, get_args, get_origin
 
@@ -52,6 +54,66 @@ def _get_asset_ref_type(annotation: Any) -> str:
     return REF_TYPE_BY_CLASS_NAME.get(type_name, "asset")
 
 
+async def _prepare_node(
+    node_class: type[BaseNode],
+    fields: dict[str, Any],
+    input_blobs: dict[str, bytes | list[bytes]],
+    temp_dir: str,
+    ctx: WorkerContext,
+) -> BaseNode:
+    """Instantiate a node, assign fields/blobs, and run its preprocessing lifecycle.
+
+    Shared by both the unary (`execute_node`) and streaming (`execute_node_stream`)
+    entry points so they resolve inputs identically.
+    """
+    # Write input blobs to temp files for URI resolution
+    input_ref_uris: dict[str, str | list[str]] = {}
+    for name, data in input_blobs.items():
+        if isinstance(data, list):
+            uris: list[str] = []
+            for index, item in enumerate(data):
+                path = os.path.join(temp_dir, f"input_{name}_{index}")
+                with open(path, "wb") as f:
+                    f.write(item)
+                uris.append(f"file://{path}")
+            input_ref_uris[name] = uris
+        else:
+            path = os.path.join(temp_dir, f"input_{name}")
+            with open(path, "wb") as f:
+                f.write(data)
+            input_ref_uris[name] = f"file://{path}"
+
+    # Instantiate node
+    node = node_class()
+
+    # Set fields — convert blob references for asset fields
+    resolved_fields = dict(fields)
+    for field_name, field_info in node.__class__.model_fields.items():
+        if field_name in input_blobs:
+            uri = input_ref_uris.get(field_name, f"blob://{field_name}")
+            ref_type = _get_asset_ref_type(field_info.annotation)
+            if isinstance(uri, list):
+                resolved_fields[field_name] = [
+                    {"uri": item, "type": ref_type} for item in uri
+                ]
+            else:
+                resolved_fields[field_name] = {
+                    "uri": uri,
+                    "type": ref_type,
+                }
+
+    for key, value in resolved_fields.items():
+        error = node.assign_property(key, value)
+        if error:
+            raise ValueError(error)
+
+    # Lifecycle: pre_process -> preload_model -> move_to_device
+    await node.pre_process(ctx)
+    await node.preload_model(ctx)
+    await node.move_to_device(ctx.device)
+    return node
+
+
 async def execute_node(
     node_type: str,
     fields: dict[str, Any],
@@ -70,53 +132,9 @@ async def execute_node(
             cancel_event=cancel_event,
         )
 
-        # Write input blobs to temp files for URI resolution
         temp_dir = tempfile.mkdtemp(prefix="nodetool_worker_")
-        input_ref_uris: dict[str, str | list[str]] = {}
         try:
-            for name, data in input_blobs.items():
-                if isinstance(data, list):
-                    uris: list[str] = []
-                    for index, item in enumerate(data):
-                        path = os.path.join(temp_dir, f"input_{name}_{index}")
-                        with open(path, "wb") as f:
-                            f.write(item)
-                        uris.append(f"file://{path}")
-                    input_ref_uris[name] = uris
-                else:
-                    path = os.path.join(temp_dir, f"input_{name}")
-                    with open(path, "wb") as f:
-                        f.write(data)
-                    input_ref_uris[name] = f"file://{path}"
-
-            # Instantiate node
-            node = node_class()
-
-            # Set fields — convert blob references for asset fields
-            resolved_fields = dict(fields)
-            for field_name, field_info in node.__class__.model_fields.items():
-                if field_name in input_blobs:
-                    uri = input_ref_uris.get(field_name, f"blob://{field_name}")
-                    ref_type = _get_asset_ref_type(field_info.annotation)
-                    if isinstance(uri, list):
-                        resolved_fields[field_name] = [
-                            {"uri": item, "type": ref_type} for item in uri
-                        ]
-                    else:
-                        resolved_fields[field_name] = {
-                            "uri": uri,
-                            "type": ref_type,
-                        }
-
-            for key, value in resolved_fields.items():
-                error = node.assign_property(key, value)
-                if error:
-                    raise ValueError(error)
-
-            # Lifecycle: pre_process -> preload_model -> move_to_device -> execute
-            await node.pre_process(ctx)
-            await node.preload_model(ctx)
-            await node.move_to_device(ctx.device)
+            node = await _prepare_node(node_class, fields, input_blobs, temp_dir, ctx)
             if node.is_streaming_output():
                 result = await _collect_streaming_outputs(node, ctx)
                 outputs, blobs = _extract_named_outputs(result, ctx)
@@ -125,7 +143,43 @@ async def execute_node(
                 outputs, blobs = _extract_outputs(result, ctx)
             return {"outputs": outputs, "blobs": blobs}
         finally:
-            import shutil
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+async def execute_node_stream(
+    node_type: str,
+    fields: dict[str, Any],
+    secrets: dict[str, str],
+    input_blobs: dict[str, bytes | list[bytes]],
+    cancel_event: asyncio.Event | None = None,
+) -> AsyncGenerator[dict[str, Any], None]:
+    """Execute a streaming node, yielding {"outputs", "blobs"} for each emitted item.
+
+    Drives the node's ``gen_process`` and serializes every yielded mapping the same
+    way a unary streaming collect would, but emits each one incrementally so the
+    caller can forward it as a `chunk` frame over the stdio bridge.
+    """
+    node_class = NODE_BY_TYPE.get(node_type)
+    if node_class is None:
+        raise ValueError(f"Unknown node type: {node_type}")
+
+    async with ResourceScope():
+        ctx = WorkerContext(
+            secrets=secrets,
+            cancel_event=cancel_event,
+        )
+
+        temp_dir = tempfile.mkdtemp(prefix="nodetool_worker_")
+        try:
+            node = await _prepare_node(node_class, fields, input_blobs, temp_dir, ctx)
+            async for item in node.gen_process(ctx):
+                if not isinstance(item, dict):
+                    raise TypeError(
+                        "Streaming worker nodes must yield dictionaries mapping output names to values."
+                    )
+                outputs, blobs = _extract_named_outputs(item, ctx)
+                yield {"outputs": outputs, "blobs": blobs}
+        finally:
             shutil.rmtree(temp_dir, ignore_errors=True)
 
 

--- a/src/nodetool/worker/node_loader.py
+++ b/src/nodetool/worker/node_loader.py
@@ -92,10 +92,46 @@ def node_to_metadata(node_class: type[BaseNode]) -> dict[str, Any]:
         "properties": properties,
         "outputs": outputs,
         "required_settings": list(required_settings),
+        "recommended_models": _recommended_models(node_class),
         "is_streaming_output": _call_or_get(node_class, "is_streaming_output"),
         "is_streaming_input": _call_or_get(node_class, "is_streaming_input"),
         "is_dynamic": _call_or_get(node_class, "is_dynamic"),
     }
+
+
+def _recommended_models(node_class: type[BaseNode]) -> list[dict]:
+    """Serialize a node's recommended models for the discover payload.
+
+    Mirrors ``unified_model(model, model_info=None)`` synchronously — no
+    network, no event loop — so startup discovery is fast. The static
+    package_metadata JSON carries the HF-enriched variant when available;
+    this is the fallback that lets bridge-only nodes (no JSON) still expose
+    recommendations.
+    """
+    from nodetool.types.model import UnifiedModel
+
+    try:
+        models = node_class.get_recommended_models() or []
+    except Exception:
+        return []
+
+    result: list[dict] = []
+    for model in models:
+        model_id = (
+            f"{model.repo_id}:{model.path}" if model.path is not None else model.repo_id
+        )
+        result.append(
+            UnifiedModel(
+                id=model_id,
+                repo_id=model.repo_id,
+                path=model.path,
+                type=model.type,
+                name=model.repo_id,
+                allow_patterns=model.allow_patterns,
+                ignore_patterns=model.ignore_patterns,
+            ).model_dump()
+        )
+    return result
 
 
 def _call_or_get(cls: type, name: str) -> bool:

--- a/src/nodetool/worker/stdio_server.py
+++ b/src/nodetool/worker/stdio_server.py
@@ -14,7 +14,8 @@ import asyncio
 import struct
 import sys
 import traceback
-from typing import Any, Callable, Awaitable
+from collections.abc import AsyncIterator
+from typing import Any, Awaitable, Callable
 
 import msgpack
 
@@ -67,6 +68,7 @@ class StdioWorkerServer:
         self._nodes_metadata: list[dict] = []
         self._cancel_flags: dict[str, asyncio.Event] = {}
         self._execute_handler: Callable | None = None
+        self._stream_handler: Callable | None = None
         self._transport: StdioTransport | None = None
 
     def set_nodes_metadata(self, metadata: list[dict]) -> None:
@@ -77,6 +79,12 @@ class StdioWorkerServer:
         handler: Callable[[dict, asyncio.Event], Awaitable[dict]],
     ) -> None:
         self._execute_handler = handler
+
+    def set_stream_handler(
+        self,
+        handler: Callable[[dict, asyncio.Event], AsyncIterator[dict]],
+    ) -> None:
+        self._stream_handler = handler
 
     async def run(self) -> None:
         """Main loop: read from stdin, dispatch, write to stdout."""
@@ -143,6 +151,37 @@ class StdioWorkerServer:
             finally:
                 self._cancel_flags.pop(request_id, None)
 
+        elif msg_type == "execute.stream":
+            cancel_event = asyncio.Event()
+            if request_id:
+                self._cancel_flags[request_id] = cancel_event
+            try:
+                if self._stream_handler is None:
+                    raise RuntimeError("No stream handler registered")
+                async for chunk in self._stream_handler(msg["data"], cancel_event):
+                    await transport.send_msg({
+                        "type": "chunk",
+                        "request_id": request_id,
+                        "data": chunk,
+                    })
+                # Final frame closes the stream on the TS side.
+                await transport.send_msg({
+                    "type": "result",
+                    "request_id": request_id,
+                    "data": {"outputs": {}, "blobs": {}},
+                })
+            except Exception as e:
+                await transport.send_msg({
+                    "type": "error",
+                    "request_id": request_id,
+                    "data": {
+                        "error": str(e),
+                        "traceback": traceback.format_exc(),
+                    },
+                })
+            finally:
+                self._cancel_flags.pop(request_id, None)
+
         elif msg_type == "cancel":
             cancel_event = self._cancel_flags.get(request_id)
             if cancel_event:
@@ -161,8 +200,8 @@ class StdioWorkerServer:
 
 async def run_stdio_worker(namespaces: list[str] | None = None) -> None:
     """Entry point for the stdio worker."""
+    from nodetool.worker.executor import execute_node, execute_node_stream
     from nodetool.worker.node_loader import load_nodes
-    from nodetool.worker.executor import execute_node
 
     print("Loading node packages...", file=sys.stderr)
     nodes_metadata = load_nodes(namespaces=namespaces)
@@ -181,6 +220,18 @@ async def run_stdio_worker(namespaces: list[str] | None = None) -> None:
         )
 
     server.set_execute_handler(handle_execute)
+
+    async def handle_execute_stream(data: dict, cancel_event: asyncio.Event):
+        async for chunk in execute_node_stream(
+            node_type=data["node_type"],
+            fields=data.get("fields", {}),
+            secrets=data.get("secrets", {}),
+            input_blobs=data.get("blobs", {}),
+            cancel_event=cancel_event,
+        ):
+            yield chunk
+
+    server.set_stream_handler(handle_execute_stream)
 
     # Signal readiness on stderr (stdout is for protocol only)
     print("NODETOOL_STDIO_READY", file=sys.stderr, flush=True)

--- a/tests/worker/test_executor.py
+++ b/tests/worker/test_executor.py
@@ -4,9 +4,8 @@ import numpy as np
 import pytest
 from pydantic import Field
 
-from nodetool.metadata.types import AudioRef, Chunk
-from nodetool.metadata.types import ImageRef
-from nodetool.worker.executor import execute_node
+from nodetool.metadata.types import AudioRef, Chunk, ImageRef
+from nodetool.worker.executor import execute_node, execute_node_stream
 from nodetool.workflows.base_node import NODE_BY_TYPE, BaseNode
 from nodetool.workflows.processing_context import ProcessingContext
 
@@ -82,17 +81,44 @@ class StreamingAudioNode(BaseNode):
         }
 
 
+class MultiChunkStreamingNode(BaseNode):
+    @classmethod
+    def get_node_type(cls) -> str:
+        return "test.MultiChunkStreamingNode"
+
+    async def process(self, context: ProcessingContext) -> str:
+        raise AssertionError("execute_node should use gen_process for streaming nodes")
+
+    async def gen_process(
+        self, context: ProcessingContext
+    ) -> AsyncGenerator[dict[str, str | None | Chunk], None]:
+        accumulated = ""
+        for index in range(3):
+            token = f"tok{index}"
+            accumulated += token
+            yield {
+                "text": None,
+                "chunk": Chunk(content=token, done=False, content_type="text"),
+            }
+        yield {
+            "text": accumulated,
+            "chunk": Chunk(content="", done=True, content_type="text"),
+        }
+
+
 @pytest.fixture(autouse=True)
 def register_echo():
     NODE_BY_TYPE["test.EchoNode"] = EchoNode
     NODE_BY_TYPE["test.ImageListNode"] = ImageListNode
     NODE_BY_TYPE["test.StreamingOnlyNode"] = StreamingOnlyNode
     NODE_BY_TYPE["test.StreamingAudioNode"] = StreamingAudioNode
+    NODE_BY_TYPE["test.MultiChunkStreamingNode"] = MultiChunkStreamingNode
     yield
     NODE_BY_TYPE.pop("test.EchoNode", None)
     NODE_BY_TYPE.pop("test.ImageListNode", None)
     NODE_BY_TYPE.pop("test.StreamingOnlyNode", None)
     NODE_BY_TYPE.pop("test.StreamingAudioNode", None)
+    NODE_BY_TYPE.pop("test.MultiChunkStreamingNode", None)
 
 
 @pytest.mark.asyncio
@@ -181,3 +207,43 @@ async def test_execute_serializes_streaming_audio_refs_with_protocol_type():
     assert result["blobs"]["audio"].startswith(b"RIFF")
     assert result["outputs"]["chunk"]["content_type"] == "audio"
     assert result["outputs"].get("chunk", {}).get("done") is True
+
+
+@pytest.mark.asyncio
+async def test_execute_node_stream_yields_each_chunk():
+    items = [
+        item
+        async for item in execute_node_stream(
+            node_type="test.MultiChunkStreamingNode",
+            fields={},
+            secrets={},
+            input_blobs={},
+        )
+    ]
+
+    # 3 token chunks + 1 final aggregate chunk
+    assert len(items) == 4
+    assert all(item["blobs"] == {} for item in items)
+    assert items[0]["outputs"]["chunk"]["content"] == "tok0"
+    assert items[0]["outputs"]["chunk"]["done"] is False
+    assert items[0]["outputs"]["text"] is None
+    assert items[-1]["outputs"]["text"] == "tok0tok1tok2"
+    assert items[-1]["outputs"]["chunk"]["done"] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_node_stream_extracts_blobs_per_chunk():
+    items = [
+        item
+        async for item in execute_node_stream(
+            node_type="test.StreamingAudioNode",
+            fields={},
+            secrets={},
+            input_blobs={},
+        )
+    ]
+
+    assert len(items) == 1
+    assert "audio" not in items[0]["outputs"]
+    assert items[0]["blobs"]["audio"].startswith(b"RIFF")
+    assert items[0]["outputs"]["chunk"]["content_type"] == "audio"

--- a/tests/worker/test_node_loader.py
+++ b/tests/worker/test_node_loader.py
@@ -1,12 +1,14 @@
 import pytest
+
 from nodetool.worker.node_loader import _discover_namespaces, load_nodes, node_to_metadata
 
 
 def test_node_to_metadata_from_mock_node():
     """Test that we can extract metadata from a BaseNode subclass."""
-    from nodetool.workflows.base_node import BaseNode, NODE_BY_TYPE
-    from nodetool.workflows.processing_context import ProcessingContext
     from pydantic import Field
+
+    from nodetool.workflows.base_node import NODE_BY_TYPE, BaseNode
+    from nodetool.workflows.processing_context import ProcessingContext
 
     class MockTestNode(BaseNode):
         """A test node for unit testing."""
@@ -33,7 +35,7 @@ def test_node_to_metadata_uses_streaming_output_type():
     from typing import AsyncGenerator, TypedDict
 
     from nodetool.metadata.types import AudioRef, Chunk
-    from nodetool.workflows.base_node import BaseNode, NODE_BY_TYPE
+    from nodetool.workflows.base_node import NODE_BY_TYPE, BaseNode
     from nodetool.workflows.processing_context import ProcessingContext
 
     class StreamingAudioNode(BaseNode):
@@ -109,3 +111,51 @@ def test_discover_namespaces_falls_back_to_namespace_paths(tmp_path, monkeypatch
 
     assert "huggingface" in namespaces
     assert "mlx" in namespaces
+
+
+def test_node_to_metadata_includes_recommended_models():
+    """Recommended models must flow through discover metadata (bridge-only fallback)."""
+    from nodetool.metadata.types import HuggingFaceModel
+    from nodetool.workflows.base_node import NODE_BY_TYPE, BaseNode
+    from nodetool.workflows.processing_context import ProcessingContext
+
+    class RecModelNode(BaseNode):
+        @classmethod
+        def get_node_type(cls) -> str:
+            return "test_ns.RecModelNode"
+
+        @classmethod
+        def get_recommended_models(cls) -> list[HuggingFaceModel]:
+            return [HuggingFaceModel(repo_id="mlx-community/Qwen3-0.5B-4bit")]
+
+        async def process(self, context: ProcessingContext) -> str:
+            return ""
+
+    NODE_BY_TYPE["test_ns.RecModelNode"] = RecModelNode
+    try:
+        meta = node_to_metadata(RecModelNode)
+        rm = meta["recommended_models"]
+        assert len(rm) == 1
+        assert rm[0]["repo_id"] == "mlx-community/Qwen3-0.5B-4bit"
+        assert rm[0]["id"] == "mlx-community/Qwen3-0.5B-4bit"
+    finally:
+        del NODE_BY_TYPE["test_ns.RecModelNode"]
+
+
+def test_node_to_metadata_recommended_models_empty_for_plain_node():
+    from nodetool.workflows.base_node import NODE_BY_TYPE, BaseNode
+    from nodetool.workflows.processing_context import ProcessingContext
+
+    class PlainNode(BaseNode):
+        @classmethod
+        def get_node_type(cls) -> str:
+            return "test_ns.PlainNode"
+
+        async def process(self, context: ProcessingContext) -> str:
+            return ""
+
+    NODE_BY_TYPE["test_ns.PlainNode"] = PlainNode
+    try:
+        assert node_to_metadata(PlainNode)["recommended_models"] == []
+    finally:
+        del NODE_BY_TYPE["test_ns.PlainNode"]


### PR DESCRIPTION
## Summary

Fixes two issues in the Python worker's stdio bridge, found while debugging a hang on `mlx.text_generation.TextGeneration`.

### 1. Streaming nodes hung (`execute.stream` unhandled)
The TS bridge sends `execute.stream` for streaming nodes, but the worker's dispatch had no handler — the frame was silently dropped, the worker never replied, and the TS pending-stream promise awaited forever.

- Add `execute_node_stream()` — drives `gen_process` and yields `{outputs, blobs}` per item.
- Add an `execute.stream` dispatch branch that emits a `chunk` frame per item, then a closing `result` frame.
- Extract shared node setup into `_prepare_node()` so unary and streaming paths resolve inputs identically.

### 2. No recommended models for bridge-only nodes
Bridge-registered Python nodes (no static `package_metadata` JSON) reported no recommended models because `node_to_metadata()` omitted the field. Emit `recommended_models` in the discover payload, serialized as `UnifiedModel` dicts via a synchronous, no-network mapping (mirrors `unified_model(model, model_info=None)`).

### 3. Version bump
`0.6.3-rc.48` → `0.7.0-rc.8` to satisfy the TS server's `MIN_NODETOOL_CORE_VERSION` pin (`>=0.7.0rc8`).

## Pairs with
nodetool PR: `feat/python-recommended-models` (TS side carries `recommended_models` through the bridge type and uses it when registering bridge-only nodes).

## Testing
- 23 worker tests pass (incl. new streaming + recommended-models tests); ruff clean.
- Worker imports and reaches `NODETOOL_STDIO_READY`.
- Verified `execute_node_stream` yields per-chunk and extracts blobs.

## Notes
- Built on `origin/main` (a stale local `main` carried a broken, never-pushed `protocol.py` experiment — not used here).
- Latent bug spotted (not fixed here): `BaseNode.unified_recommended_models(include_model_info=False)` returns un-awaited coroutines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)