### PR TITLE
feat(providers): text-to-audio capability + video/audio worker dispatch

### DIFF
--- a/src/nodetool/integrations/huggingface/huggingface_models.py
+++ b/src/nodetool/integrations/huggingface/huggingface_models.py
@@ -45,10 +45,12 @@ from nodetool.integrations.huggingface.async_downloader import async_hf_download
 from nodetool.integrations.huggingface.hf_fast_cache import HfFastCache
 from nodetool.metadata.types import (
     CLASSNAME_TO_MODEL_TYPE,
+    AudioModel,
     HuggingFaceModel,
     ImageModel,
     LanguageModel,
     Provider,
+    VideoModel,
 )
 from nodetool.security.secret_helper import get_secret
 from nodetool.types.model import UnifiedModel
@@ -325,10 +327,14 @@ def size_on_disk(
         if not sib.rfilename:
             continue
 
-        if allow_patterns is not None and not any(fnmatch(sib.rfilename, pattern) for pattern in allow_patterns):
+        if allow_patterns is not None and not any(
+            fnmatch(sib.rfilename, pattern) for pattern in allow_patterns
+        ):
             continue
 
-        if ignore_patterns is not None and any(fnmatch(sib.rfilename, pattern) for pattern in ignore_patterns):
+        if ignore_patterns is not None and any(
+            fnmatch(sib.rfilename, pattern) for pattern in ignore_patterns
+        ):
             continue
 
         total_size += sib.size
@@ -401,7 +407,9 @@ def detect_repo_packaging(
     we see multiple quantizations or adapter-style weights that likely represent
     independent choices for the user.
     """
-    weight_entries = [(name, size) for name, size in file_entries if _is_weight_file(name)]
+    weight_entries = [
+        (name, size) for name, size in file_entries if _is_weight_file(name)
+    ]
     weight_files = [name for name, _ in weight_entries]
     lower_weight_files = [name.lower() for name in weight_files]
 
@@ -437,7 +445,9 @@ def _has_bundle_metadata(model_info: ModelInfo | None) -> bool:
     if has_model_index(model_info):
         return True
     library_name = getattr(model_info, "library_name", None)
-    return bool(library_name and str(library_name).lower() in ("diffusers", "transformers"))
+    return bool(
+        library_name and str(library_name).lower() in ("diffusers", "transformers")
+    )
 
 
 def _has_sharded_weights(weight_files: Sequence[str]) -> bool:
@@ -474,7 +484,12 @@ def _has_adapter_candidates(weight_entries: Sequence[tuple[str, int]]) -> bool:
         if any(marker in lower for marker in _ADAPTER_MARKERS):
             adapter_like.append((name, size))
             continue
-        if lower.endswith(".safetensors") and size and size < _SMALL_ADAPTER_MAX_BYTES and len(weight_entries) > 1:
+        if (
+            lower.endswith(".safetensors")
+            and size
+            and size < _SMALL_ADAPTER_MAX_BYTES
+            and len(weight_entries) > 1
+        ):
             adapter_like.append((name, size))
     return len(adapter_like) >= 1
 
@@ -599,13 +614,19 @@ async def unified_model(
     otherwise we return a minimal record so callers can still render choices.
     """
 
-    model_id = f"{model.repo_id}:{model.path}" if model.path is not None else model.repo_id
+    model_id = (
+        f"{model.repo_id}:{model.path}" if model.path is not None else model.repo_id
+    )
 
     # Without hub lookups, size and metadata may be missing; rely on provided info only.
     if model_info is not None and size is None:
         if model.path:
             size = next(
-                (sib.size for sib in (model_info.siblings or []) if sib.rfilename == model.path),
+                (
+                    sib.size
+                    for sib in (model_info.siblings or [])
+                    if sib.rfilename == model.path
+                ),
                 None,
             )
         else:
@@ -694,7 +715,9 @@ class _RecursiveNamespace:
             val = self._data[key]
         except KeyError:
             # Mirror standard object behavior for missing attributes
-            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{key}'") from None
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{key}'"
+            ) from None
 
         if isinstance(val, dict):
             return _RecursiveNamespace(val)
@@ -748,7 +771,11 @@ def model_type_from_model_info(
         return recommended[0].type
     if model_info is None:
         return None
-    if model_info.config and "diffusers" in model_info.config and "_class_name" in model_info.config["diffusers"]:
+    if (
+        model_info.config
+        and "diffusers" in model_info.config
+        and "_class_name" in model_info.config["diffusers"]
+    ):
         return CLASSNAME_TO_MODEL_TYPE.get(
             model_info.config["diffusers"]["_class_name"],
             None,  # type: ignore[no-any-return]
@@ -823,12 +850,16 @@ def _infer_model_type_from_local_configs(
         return None
 
     config_candidates = [
-        rel_path for rel_path, _ in file_entries if rel_path.lower().endswith(("model_index.json", "config.json"))
+        rel_path
+        for rel_path, _ in file_entries
+        if rel_path.lower().endswith(("model_index.json", "config.json"))
     ]
     if not config_candidates:
         return None
 
-    for rel_path in sorted(config_candidates, key=lambda value: (value.count("/"), len(value))):
+    for rel_path in sorted(
+        config_candidates, key=lambda value: (value.count("/"), len(value))
+    ):
         config_path = snapshot_dir / rel_path
         data = _safe_load_json(config_path)
         if not data:
@@ -840,7 +871,9 @@ def _infer_model_type_from_local_configs(
             if mapped:
                 return mapped
 
-        model_type = str(data.get("model_type", "")).lower() if isinstance(data, dict) else ""
+        model_type = (
+            str(data.get("model_type", "")).lower() if isinstance(data, dict) else ""
+        )
         if model_type:
             mapped = _CONFIG_MODEL_TYPE_MAPPING.get(model_type)
             if mapped:
@@ -871,7 +904,9 @@ async def _build_cached_repo_entry(
     size_on_disk = 0
     snapshot_path: Path | None = snapshot_dir
     if snapshot_path is None:
-        resolved_snapshot = await HF_FAST_CACHE.active_snapshot_dir(repo_id, repo_type="model")
+        resolved_snapshot = await HF_FAST_CACHE.active_snapshot_dir(
+            repo_id, repo_type="model"
+        )
         snapshot_path = Path(resolved_snapshot) if resolved_snapshot else None
 
     if snapshot_path:
@@ -879,14 +914,17 @@ async def _build_cached_repo_entry(
             file_list = await HF_FAST_CACHE.list_files(repo_id, repo_type="model")
 
         # Offload blocking IO loop to thread
-        size_on_disk, file_entries = await asyncio.to_thread(_calculate_repo_stats, snapshot_path, file_list)
+        size_on_disk, file_entries = await asyncio.to_thread(
+            _calculate_repo_stats, snapshot_path, file_list
+        )
 
     if repo_id in recommended_models:
         model = recommended_models[repo_id][0].model_copy(
             update={
                 "downloaded": repo_root is not None or repo_dir.exists(),
                 "cache_path": str(repo_root) if repo_root else str(repo_dir),
-                "size_on_disk": size_on_disk or recommended_models[repo_id][0].size_on_disk,
+                "size_on_disk": size_on_disk
+                or recommended_models[repo_id][0].size_on_disk,
             }
         )
         return model, file_entries
@@ -895,7 +933,9 @@ async def _build_cached_repo_entry(
     if file_entries and snapshot_path:
         artifact_paths = [str(snapshot_path / name) for name, _ in file_entries]
         try:
-            from nodetool.integrations.huggingface.artifact_inspector import inspect_paths
+            from nodetool.integrations.huggingface.artifact_inspector import (
+                inspect_paths,
+            )
 
             artifact_detection = await asyncio.to_thread(inspect_paths, artifact_paths)
 
@@ -922,7 +962,9 @@ async def _build_cached_repo_entry(
         size_on_disk=size_on_disk,
         artifact_family=artifact_detection.family if artifact_detection else None,
         artifact_component=artifact_detection.component if artifact_detection else None,
-        artifact_confidence=(artifact_detection.confidence if artifact_detection else None),
+        artifact_confidence=(
+            artifact_detection.confidence if artifact_detection else None
+        ),
         artifact_evidence=artifact_detection.evidence if artifact_detection else None,
     )
 
@@ -1106,7 +1148,9 @@ HF_SEARCH_TYPE_CONFIG: dict[str, dict[str, list[str] | str]] = {
 for _base, _ckpt in _CHECKPOINT_BASES.items():
     if _base in HF_SEARCH_TYPE_CONFIG and _ckpt not in HF_SEARCH_TYPE_CONFIG:
         _base_cfg = HF_SEARCH_TYPE_CONFIG[_base]
-        HF_SEARCH_TYPE_CONFIG[_ckpt] = {k: (list(v) if isinstance(v, list) else v) for k, v in _base_cfg.items()}
+        HF_SEARCH_TYPE_CONFIG[_ckpt] = {
+            k: (list(v) if isinstance(v, list) else v) for k, v in _base_cfg.items()
+        }
 
 HF_TYPE_STRUCTURAL_RULES: dict[str, dict[str, bool]] = {
     "hf.unet": {"file_only": True},
@@ -1204,14 +1248,19 @@ def _derive_pipeline_tag(normalized_type: str, task: str | None = None) -> str |
     return slug.replace("_", "-")
 
 
-def _matches_repo_for_type(normalized_type: str, repo_id: str, repo_id_from_id: str) -> bool:
+def _matches_repo_for_type(
+    normalized_type: str, repo_id: str, repo_id_from_id: str
+) -> bool:
     """Check if a repo id matches any hard-coded comfy-type mappings for a model type."""
     matchers = KNOWN_TYPE_REPO_MATCHERS.get(normalized_type)
     if not matchers:
         return False
     repo_lower = repo_id.lower()
     repo_from_id_lower = repo_id_from_id.lower()
-    return any(repo_lower == candidate.lower() or repo_from_id_lower == candidate.lower() for candidate in matchers)
+    return any(
+        repo_lower == candidate.lower() or repo_from_id_lower == candidate.lower()
+        for candidate in matchers
+    )
 
 
 def _matches_artifact_detection(
@@ -1236,7 +1285,9 @@ def _matches_artifact_detection(
     }:
         return "flux" in fam
     if normalized_type == "hf.stable_diffusion":
-        return fam.startswith("sd1") or fam.startswith("sd2") or "stable-diffusion" in fam
+        return (
+            fam.startswith("sd1") or fam.startswith("sd2") or "stable-diffusion" in fam
+        )
     if normalized_type == "hf.stable_diffusion_xl":
         return "sdxl" in fam
     if normalized_type == "hf.stable_diffusion_xl_refiner":
@@ -1264,7 +1315,9 @@ def _matches_model_type(model: UnifiedModel, model_type: str) -> bool:
     def _is_qwen_text_encoder(path: str | None) -> bool:
         if not path:
             return False
-        return "text_encoders" in path or "text_encoder" in path or "qwen_2.5_vl" in path
+        return (
+            "text_encoders" in path or "text_encoder" in path or "qwen_2.5_vl" in path
+        )
 
     def _is_qwen_vae(path: str | None) -> bool:
         if not path:
@@ -1277,7 +1330,9 @@ def _matches_model_type(model: UnifiedModel, model_type: str) -> bool:
 
     if model_type_lower:
         model_type_base = (
-            model_type_lower[: -len("_checkpoint")] if model_type_lower.endswith("_checkpoint") else model_type_lower
+            model_type_lower[: -len("_checkpoint")]
+            if model_type_lower.endswith("_checkpoint")
+            else model_type_lower
         )
         if model_type_lower in target_types or model_type_base == normalized_type:
             return not (
@@ -1308,13 +1363,18 @@ def _matches_model_type(model: UnifiedModel, model_type: str) -> bool:
     artifact_family = (getattr(model, "artifact_family", None) or "").lower()
     artifact_component = (getattr(model, "artifact_component", None) or "").lower()
     if artifact_family or artifact_component:
-        if _matches_artifact_detection(normalized_type, artifact_family, artifact_component):
+        if _matches_artifact_detection(
+            normalized_type, artifact_family, artifact_component
+        ):
             return True
 
     tags = [(tag or "").lower() for tag in (model.tags or [])]
     keywords = HF_TYPE_KEYWORD_MATCHERS.get(normalized_type, [])
     if keywords:
-        if any(keyword in repo_id or any(keyword in tag for tag in tags) for keyword in keywords):
+        if any(
+            keyword in repo_id or any(keyword in tag for tag in tags)
+            for keyword in keywords
+        ):
             return True
         if path_lower and any(keyword in path_lower for keyword in keywords):
             return True
@@ -1340,7 +1400,9 @@ async def get_models_by_hf_type(
         """Apply type-specific structural rules then semantic matching."""
         rules = HF_TYPE_STRUCTURAL_RULES.get(model_type, {})
         file_only = rules.get("file_only", False)
-        checkpoint = rules.get("checkpoint", False) or model_type in set(_CHECKPOINT_BASES.values())
+        checkpoint = rules.get("checkpoint", False) or model_type in set(
+            _CHECKPOINT_BASES.values()
+        )
         nested_checkpoint = rules.get("nested_checkpoint", False)
         single_file_repo = rules.get("single_file_repo", False)
 
@@ -1362,7 +1424,9 @@ async def get_models_by_hf_type(
                     continue
                 if path_value:
                     path_lower = path_value.lower()
-                    if not _is_single_file_diffusion_weight(path_value) and not path_lower.endswith(".gguf"):
+                    if not _is_single_file_diffusion_weight(
+                        path_value
+                    ) and not path_lower.endswith(".gguf"):
                         continue
 
             if checkpoint:
@@ -1419,17 +1483,23 @@ async def iter_cached_model_files(
     or whose files cannot be listed are skipped.
     """
     repo_list = (
-        list(pre_resolved_repos) if pre_resolved_repos is not None else await HF_FAST_CACHE.discover_repos("model")
+        list(pre_resolved_repos)
+        if pre_resolved_repos is not None
+        else await HF_FAST_CACHE.discover_repos("model")
     )
 
     for repo_id, repo_dir in repo_list:
-        snapshot_dir = await HF_FAST_CACHE.active_snapshot_dir(repo_id, repo_type="model")
+        snapshot_dir = await HF_FAST_CACHE.active_snapshot_dir(
+            repo_id, repo_type="model"
+        )
         if not snapshot_dir:
             continue
         try:
             file_list = await HF_FAST_CACHE.list_files(repo_id, repo_type="model")
         except Exception as exc:  # pragma: no cover - defensive guard
-            log.debug("iter_cached_model_files: list_files failed for %s: %s", repo_id, exc)
+            log.debug(
+                "iter_cached_model_files: list_files failed for %s: %s", repo_id, exc
+            )
             continue
 
         yield repo_id, Path(repo_dir), Path(snapshot_dir), file_list
@@ -1674,7 +1744,9 @@ async def get_llama_cpp_models_from_cache() -> list[UnifiedModel]:
     Returns:
         List[UnifiedModel]: Models with type='llama_cpp_model' found in the cache.
     """
-    from nodetool.integrations.huggingface.llama_cpp_download import get_llama_cpp_cache_dir
+    from nodetool.integrations.huggingface.llama_cpp_download import (
+        get_llama_cpp_cache_dir,
+    )
 
     cache_dir = get_llama_cpp_cache_dir()
     if not os.path.isdir(cache_dir):
@@ -1705,7 +1777,11 @@ async def get_llama_cpp_models_from_cache() -> list[UnifiedModel]:
             UnifiedModel(
                 id=f"{repo_id}:{filename}" if repo_id else filename,
                 type="llama_cpp_model",
-                name=f"{repo.replace('-', ' ').title()} • {filename}" if repo_id else filename,
+                name=(
+                    f"{repo.replace('-', ' ').title()} • {filename}"
+                    if repo_id
+                    else filename
+                ),
                 repo_id=repo_id,
                 path=filename,
                 cache_path=entry.path,
@@ -1731,7 +1807,9 @@ async def get_llamacpp_language_models_from_llama_cache() -> list[LanguageModel]
     Returns:
         List[LanguageModel]: Llama.cpp-compatible models discovered in the native cache.
     """
-    from nodetool.integrations.huggingface.llama_cpp_download import get_llama_cpp_cache_dir
+    from nodetool.integrations.huggingface.llama_cpp_download import (
+        get_llama_cpp_cache_dir,
+    )
 
     cache_dir = get_llama_cpp_cache_dir()
     if not os.path.isdir(cache_dir):
@@ -1757,7 +1835,9 @@ async def get_llamacpp_language_models_from_llama_cache() -> list[LanguageModel]
         # absolute cache path as the model id so llama-server can load it
         # reliably via `-m <path>` regardless of current working directory.
         model_id = f"{repo_id}:{filename}" if repo_id else entry.path
-        display = f"{repo.replace('-', ' ').title()} • {filename}" if repo_id else filename
+        display = (
+            f"{repo.replace('-', ' ').title()} • {filename}" if repo_id else filename
+        )
 
         results.append(
             LanguageModel(
@@ -1858,7 +1938,9 @@ async def _get_diffusion_models_from_hf_cache(task: str) -> list[ImageModel]:
             continue
         # Check if this is a component-only repo (e.g., Nunchaku transformers)
         is_component_only = _is_component_only_repo(repo_id)
-        has_diffusion_artifacts = await _repo_has_diffusion_artifacts(repo_id, snapshot_dir, file_list)
+        has_diffusion_artifacts = await _repo_has_diffusion_artifacts(
+            repo_id, snapshot_dir, file_list
+        )
 
         # Skip non-component repos that don't have diffusion artifacts
         if not is_component_only and not has_diffusion_artifacts:
@@ -1913,6 +1995,95 @@ async def get_image_to_image_models_from_hf_cache() -> list[ImageModel]:
     return await _get_diffusion_models_from_hf_cache("image_to_image")
 
 
+# diffusers `_class_name` values that identify text-to-video / text-to-audio repos.
+_VIDEO_PIPELINE_CLASS_NAMES = {
+    "WanPipeline",
+    "WanImageToVideoPipeline",
+    "CogVideoXPipeline",
+    "LTXPipeline",
+    "LTXImageToVideoPipeline",
+    "LTX2Pipeline",
+    "LTX2ImageToVideoPipeline",
+    "Kandinsky5T2VPipeline",
+    "Kandinsky5I2VPipeline",
+    "HunyuanVideoPipeline",
+    "MochiPipeline",
+    "StableVideoDiffusionPipeline",
+}
+_AUDIO_PIPELINE_CLASS_NAMES = {
+    "AceStepPipeline",
+    "LongCatAudioDiTPipeline",
+    "StableAudioPipeline",
+    "MusicLDMPipeline",
+    "AudioLDMPipeline",
+    "AudioLDM2Pipeline",
+}
+
+
+def _read_model_index_class_name(snapshot_dir: str | Path | None) -> str | None:
+    """Read the diffusers ``_class_name`` from a cached repo's model_index.json."""
+    if not snapshot_dir:
+        return None
+    try:
+        path = os.path.join(str(snapshot_dir), "model_index.json")
+        if not os.path.exists(path):
+            return None
+        with open(path) as f:
+            return json.load(f).get("_class_name")
+    except Exception:
+        return None
+
+
+async def get_text_to_video_models_from_hf_cache() -> list[VideoModel]:
+    """Return VideoModel entries for cached text-to-video diffusers repos.
+
+    Classifies repos by the diffusers ``_class_name`` in model_index.json so video
+    models (Wan, LTX, CogVideoX, Kandinsky 5, ...) don't get mixed in with images.
+    """
+    result: dict[str, VideoModel] = {}
+    async for repo_id, _repo_dir, snapshot_dir, file_list in iter_cached_model_files():
+        if not file_list:
+            continue
+        if (
+            _read_model_index_class_name(snapshot_dir)
+            not in _VIDEO_PIPELINE_CLASS_NAMES
+        ):
+            continue
+        result.setdefault(
+            repo_id,
+            VideoModel(
+                id=repo_id,
+                name=repo_id.split("/")[-1],
+                provider=Provider.HuggingFace,
+                supported_tasks=["text_to_video"],
+            ),
+        )
+    return list(result.values())
+
+
+async def get_text_to_audio_models_from_hf_cache() -> list[AudioModel]:
+    """Return AudioModel entries for cached text-to-audio diffusers repos (ACE-Step, ...)."""
+    result: dict[str, AudioModel] = {}
+    async for repo_id, _repo_dir, snapshot_dir, file_list in iter_cached_model_files():
+        if not file_list:
+            continue
+        if (
+            _read_model_index_class_name(snapshot_dir)
+            not in _AUDIO_PIPELINE_CLASS_NAMES
+        ):
+            continue
+        result.setdefault(
+            repo_id,
+            AudioModel(
+                id=repo_id,
+                name=repo_id.split("/")[-1],
+                provider=Provider.HuggingFace,
+                supported_tasks=["text_to_audio"],
+            ),
+        )
+    return list(result.values())
+
+
 async def get_mlx_image_models_from_hf_cache() -> list[ImageModel]:
     """
     Return ImageModel entries for cached Hugging Face repos that are mflux models
@@ -1941,7 +2112,9 @@ async def get_mlx_image_models_from_hf_cache() -> list[ImageModel]:
     return list(result.values())
 
 
-async def _fetch_models_by_author(user_id: str | None = None, **kwargs) -> list[ModelInfo]:
+async def _fetch_models_by_author(
+    user_id: str | None = None, **kwargs
+) -> list[ModelInfo]:
     """Fetch models list from HF API for a given author using HFAPI.
 
     Returns raw model dicts from the public API.
@@ -1964,7 +2137,9 @@ async def _fetch_models_by_author(user_id: str | None = None, **kwargs) -> list[
 
         api = HfApi()
     # Run the blocking call in a thread executor
-    models = await asyncio.get_running_loop().run_in_executor(None, lambda: api.list_models(**kwargs))
+    models = await asyncio.get_running_loop().run_in_executor(
+        None, lambda: api.list_models(**kwargs)
+    )
     return list(models)
 
 
@@ -2030,7 +2205,9 @@ async def get_gguf_language_models_from_authors(
             )
 
     # Execute all unified_model calls in parallel
-    entries = await asyncio.gather(*[unified_model(model, info, size) for model, info, size in tasks])
+    entries = await asyncio.gather(
+        *[unified_model(model, info, size) for model, info, size in tasks]
+    )
 
     # Sort for stability: repo then filename
     entries = [entry for entry in entries if entry is not None]
@@ -2061,13 +2238,21 @@ async def get_mlx_language_models_from_authors(
     # Fetch authors concurrently
     # Note: user_id would need to be passed from caller context
     results = await asyncio.gather(
-        *(_fetch_models_by_author(user_id=None, author=a, limit=limit, sort=sort, tags=tags) for a in authors)
+        *(
+            _fetch_models_by_author(
+                user_id=None, author=a, limit=limit, sort=sort, tags=tags
+            )
+            for a in authors
+        )
     )
     model_infos = [item for sublist in results for item in sublist]
 
     # Execute all unified_model calls in parallel
     entries = await asyncio.gather(
-        *[unified_model(HuggingFaceModel(type="mlx", repo_id=info.id), info) for info in model_infos]
+        *[
+            unified_model(HuggingFaceModel(type="mlx", repo_id=info.id), info)
+            for info in model_infos
+        ]
     )
 
     # Stable order

--- a/src/nodetool/metadata/types.py
+++ b/src/nodetool/metadata/types.py
@@ -101,8 +101,11 @@ class BaseType(BaseModel):
         if type_name is None:
             raise ValueError("Type name is missing. Types must derive from BaseType")
         if type_name not in NameToType:
-            raise ValueError(f"Unknown type name: {type_name}. Types must derive from BaseType. Data: {data}")
+            raise ValueError(
+                f"Unknown type name: {type_name}. Types must derive from BaseType. Data: {data}"
+            )
         return NameToType[type_name](**data)
+
 
 class ImageSize(BaseType):
     """
@@ -113,13 +116,14 @@ class ImageSize(BaseType):
     type: Literal["image_size"] = "image_size"
     width: int = Field(default=1024, description="Image width")
     height: int = Field(default=1024, description="Image height")
-    preset: Optional[str] = Field(None, description="Aspect ratio preset name (e.g. 'square_hd')")
+    preset: Optional[str] = Field(
+        None, description="Aspect ratio preset name (e.g. 'square_hd')"
+    )
 
     def __str__(self):
         if self.preset:
             return f"{self.preset} ({self.width}x{self.height})"
         return f"{self.width}x{self.height}"
-
 
 
 class Collection(BaseType):
@@ -177,7 +181,11 @@ class Datetime(BaseType):
             minute=self.minute,
             second=self.second,
             microsecond=self.microsecond,
-            tzinfo=(timezone(timedelta(seconds=self.utc_offset), self.tzinfo) if self.utc_offset else UTC),
+            tzinfo=(
+                timezone(timedelta(seconds=self.utc_offset), self.tzinfo)
+                if self.utc_offset
+                else UTC
+            ),
         )
 
     @staticmethod
@@ -407,7 +415,12 @@ class AudioStream(BaseType):
 
     def duration_seconds(self) -> float:
         """Calculate duration in seconds based on data length and format."""
-        if not self.data or self.sample_rate == 0 or self.channels == 0 or self.sample_width == 0:
+        if (
+            not self.data
+            or self.sample_rate == 0
+            or self.channels == 0
+            or self.sample_width == 0
+        ):
             return 0.0
         num_samples = len(self.data) // (self.sample_width * self.channels)
         return num_samples / self.sample_rate
@@ -440,9 +453,13 @@ class Model3DRef(AssetRef):
     """
 
     type: Literal["model_3d"] = "model_3d"
-    format: Optional[str] = None  # The 3D format (glb, gltf, obj, mtl, fbx, stl, ply, usdz)
+    format: Optional[str] = (
+        None  # The 3D format (glb, gltf, obj, mtl, fbx, stl, ply, usdz)
+    )
     material_file: Optional["AssetRef"] = None  # Material file (e.g., MTL for OBJ)
-    texture_files: list["ImageRef"] = Field(default_factory=list)  # Associated texture images
+    texture_files: list["ImageRef"] = Field(
+        default_factory=list
+    )  # Associated texture images
 
 
 class RSSEntry(BaseType):
@@ -570,7 +587,9 @@ class InferenceProvider(enum.StrEnum):
 
 
 class InferenceProviderAudioClassificationModel(BaseType):
-    type: Literal["inference_provider_audio_classification_model"] = "inference_provider_audio_classification_model"
+    type: Literal["inference_provider_audio_classification_model"] = (
+        "inference_provider_audio_classification_model"
+    )
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
@@ -584,67 +603,89 @@ class InferenceProviderAutomaticSpeechRecognitionModel(BaseType):
 
 
 class InferenceProviderImageClassificationModel(BaseType):
-    type: Literal["inference_provider_image_classification_model"] = "inference_provider_image_classification_model"
+    type: Literal["inference_provider_image_classification_model"] = (
+        "inference_provider_image_classification_model"
+    )
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderImageToImageModel(BaseType):
-    type: Literal["inference_provider_image_to_image_model"] = "inference_provider_image_to_image_model"
+    type: Literal["inference_provider_image_to_image_model"] = (
+        "inference_provider_image_to_image_model"
+    )
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderImageSegmentationModel(BaseType):
-    type: Literal["inference_provider_image_segmentation_model"] = "inference_provider_image_segmentation_model"
+    type: Literal["inference_provider_image_segmentation_model"] = (
+        "inference_provider_image_segmentation_model"
+    )
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderTextClassificationModel(BaseType):
-    type: Literal["inference_provider_text_classification_model"] = "inference_provider_text_classification_model"
+    type: Literal["inference_provider_text_classification_model"] = (
+        "inference_provider_text_classification_model"
+    )
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderSummarizationModel(BaseType):
-    type: Literal["inference_provider_summarization_model"] = "inference_provider_summarization_model"
+    type: Literal["inference_provider_summarization_model"] = (
+        "inference_provider_summarization_model"
+    )
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderTextToImageModel(BaseType):
-    type: Literal["inference_provider_text_to_image_model"] = "inference_provider_text_to_image_model"
+    type: Literal["inference_provider_text_to_image_model"] = (
+        "inference_provider_text_to_image_model"
+    )
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderTranslationModel(BaseType):
-    type: Literal["inference_provider_translation_model"] = "inference_provider_translation_model"
+    type: Literal["inference_provider_translation_model"] = (
+        "inference_provider_translation_model"
+    )
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderTextToTextModel(BaseType):
-    type: Literal["inference_provider_text_to_text_model"] = "inference_provider_text_to_text_model"
+    type: Literal["inference_provider_text_to_text_model"] = (
+        "inference_provider_text_to_text_model"
+    )
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderTextToSpeechModel(BaseType):
-    type: Literal["inference_provider_text_to_speech_model"] = "inference_provider_text_to_speech_model"
+    type: Literal["inference_provider_text_to_speech_model"] = (
+        "inference_provider_text_to_speech_model"
+    )
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderTextToAudioModel(BaseType):
-    type: Literal["inference_provider_text_to_audio_model"] = "inference_provider_text_to_audio_model"
+    type: Literal["inference_provider_text_to_audio_model"] = (
+        "inference_provider_text_to_audio_model"
+    )
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderTextGenerationModel(BaseType):
-    type: Literal["inference_provider_text_generation_model"] = "inference_provider_text_generation_model"
+    type: Literal["inference_provider_text_generation_model"] = (
+        "inference_provider_text_generation_model"
+    )
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
@@ -693,6 +734,17 @@ class ASRModel(BaseType):
 
 class VideoModel(BaseType):
     type: Literal["video_model"] = "video_model"
+    provider: Provider = Provider.Empty
+    id: str = ""
+    name: str = ""
+    path: str | None = None
+    supported_tasks: list[str] = Field(default_factory=list)
+
+
+class AudioModel(BaseType):
+    """A model for audio/music generation (text-to-audio)."""
+
+    type: Literal["audio_model"] = "audio_model"
     provider: Provider = Provider.Empty
     id: str = ""
     name: str = ""
@@ -841,7 +893,9 @@ class HFStableDiffusionXL(HuggingFaceModel):
 
 
 class HFStableDiffusionXLCheckpoint(HuggingFaceModel):
-    type: Literal["hf.stable_diffusion_xl_checkpoint"] = "hf.stable_diffusion_xl_checkpoint"
+    type: Literal["hf.stable_diffusion_xl_checkpoint"] = (
+        "hf.stable_diffusion_xl_checkpoint"
+    )
 
 
 class HFStableDiffusion3(HuggingFaceModel):
@@ -849,7 +903,9 @@ class HFStableDiffusion3(HuggingFaceModel):
 
 
 class HFStableDiffusion3Checkpoint(HuggingFaceModel):
-    type: Literal["hf.stable_diffusion_3_checkpoint"] = "hf.stable_diffusion_3_checkpoint"
+    type: Literal["hf.stable_diffusion_3_checkpoint"] = (
+        "hf.stable_diffusion_3_checkpoint"
+    )
 
 
 class HFStableDiffusionXLRefiner(HuggingFaceModel):
@@ -857,7 +913,9 @@ class HFStableDiffusionXLRefiner(HuggingFaceModel):
 
 
 class HFStableDiffusionXLRefinerCheckpoint(HuggingFaceModel):
-    type: Literal["hf.stable_diffusion_xl_refiner_checkpoint"] = "hf.stable_diffusion_xl_refiner_checkpoint"
+    type: Literal["hf.stable_diffusion_xl_refiner_checkpoint"] = (
+        "hf.stable_diffusion_xl_refiner_checkpoint"
+    )
 
 
 class HFFlux(HuggingFaceModel):
@@ -977,7 +1035,9 @@ class HFImageToVideo(HuggingFaceModel):
 
 
 class HFUnconditionalImageGeneration(HuggingFaceModel):
-    type: Literal["hf.unconditional_image_generation"] = "hf.unconditional_image_generation"
+    type: Literal["hf.unconditional_image_generation"] = (
+        "hf.unconditional_image_generation"
+    )
 
 
 class HFUnet(HuggingFaceModel):
@@ -1013,7 +1073,9 @@ class HFTextToVideo(HuggingFaceModel):
 
 
 class HFZeroShotImageClassification(HuggingFaceModel):
-    type: Literal["hf.zero_shot_image_classification"] = "hf.zero_shot_image_classification"
+    type: Literal["hf.zero_shot_image_classification"] = (
+        "hf.zero_shot_image_classification"
+    )
 
 
 class HFMaskGeneration(HuggingFaceModel):
@@ -1113,7 +1175,9 @@ class HFAudioClassification(HuggingFaceModel):
 
 
 class HFZeroShotAudioClassification(HuggingFaceModel):
-    type: Literal["hf.zero_shot_audio_classification"] = "hf.zero_shot_audio_classification"
+    type: Literal["hf.zero_shot_audio_classification"] = (
+        "hf.zero_shot_audio_classification"
+    )
 
 
 class HFRealESRGAN(HuggingFaceModel):
@@ -1437,7 +1501,9 @@ class Step(BaseType):
     completed: bool = Field(default=False, description="Whether the step is completed")
     start_time: int = Field(default=0, description="The start time of the step")
     end_time: int = Field(default=0, description="The end time of the step")
-    depends_on: list[str] = Field(default=[], description="The IDs of steps this step depends on")
+    depends_on: list[str] = Field(
+        default=[], description="The IDs of steps this step depends on"
+    )
     tools: list[str] | None = Field(
         default=None,
         description="Optional list of allowed tool names for this step (None = no restriction).",
@@ -1454,8 +1520,12 @@ class Step(BaseType):
     def to_markdown(self) -> str:
         """Convert the step to markdown format."""
         checkbox = "[x]" if self.completed else "[*]" if self.is_running() else "[ ]"
-        deps_str = f" (depends on {', '.join(self.depends_on)})" if self.depends_on else ""
-        output_schema_str = f" (output schema: {self.output_schema})" if self.output_schema else ""
+        deps_str = (
+            f" (depends on {', '.join(self.depends_on)})" if self.depends_on else ""
+        )
+        output_schema_str = (
+            f" (output schema: {self.output_schema})" if self.output_schema else ""
+        )
         return f"- {checkbox} {self.instructions}{deps_str}{output_schema_str}"
 
     def is_running(self) -> bool:
@@ -1484,8 +1554,12 @@ class Task(BaseType):
     type: Literal["task"] = "task"
 
     title: str = Field(default="", description="The title of the task")
-    description: str = Field(default="", description="A description of the task, not used for execution")
-    steps: list[Step] = Field(default=[], description="The steps of the task, a list of step IDs")
+    description: str = Field(
+        default="", description="A description of the task, not used for execution"
+    )
+    steps: list[Step] = Field(
+        default=[], description="The steps of the task, a list of step IDs"
+    )
 
     def is_completed(self) -> bool:
         """Returns True if all steps are marked as completed."""
@@ -1536,6 +1610,7 @@ class TorchTensor(BaseType):
 
     def _validate_nbytes(self) -> None:
         import numpy as np
+
         assert self.value is not None, "No bytes stored"
         itemsize = np.dtype(self.dtype).itemsize
         expected = int(np.prod(self.shape)) * itemsize
@@ -1597,6 +1672,7 @@ class TorchTensor(BaseType):
     @staticmethod
     def from_list(arr: list, **kwargs) -> "TorchTensor":
         import numpy as np
+
         np_arr = np.array(arr)
         return TorchTensor.from_numpy(np_arr, **kwargs)
 
@@ -1615,6 +1691,7 @@ class NPArray(BaseType):
 
     def to_numpy(self) -> "np.ndarray":
         import numpy as np
+
         assert self.value is not None
         return np.frombuffer(self.value, dtype=np.dtype(self.dtype)).reshape(self.shape)
 
@@ -1623,17 +1700,21 @@ class NPArray(BaseType):
 
     @staticmethod
     def from_numpy(arr: "np.ndarray", **kwargs):
-        return NPArray(value=arr.tobytes(), dtype=arr.dtype.str, shape=arr.shape, **kwargs)
+        return NPArray(
+            value=arr.tobytes(), dtype=arr.dtype.str, shape=arr.shape, **kwargs
+        )
 
     @staticmethod
     def from_list(arr: list, **_kwargs):
         import numpy as np
+
         return NPArray.from_numpy(np.array(arr))
 
 
 def to_numpy(num: float | int | NPArray) -> "np.ndarray":
     if type(num) in (float, int, list):
         import numpy as np
+
         return np.array(num)
     elif type(num) is NPArray:
         return num.to_numpy()
@@ -1641,7 +1722,13 @@ def to_numpy(num: float | int | NPArray) -> "np.ndarray":
         raise ValueError()
 
 
-ColumnType = Literal["int"] | Literal["float"] | Literal["datetime"] | Literal["string"] | Literal["object"]
+ColumnType = (
+    Literal["int"]
+    | Literal["float"]
+    | Literal["datetime"]
+    | Literal["string"]
+    | Literal["object"]
+)
 
 
 class ColumnDef(BaseModel):
@@ -2256,11 +2343,19 @@ class PlotlySeries(BaseType):
         default=None,
         description="Column name for y-axis (optional for some charts like histogram)",
     )
-    color: str | None = Field(default=None, description="Column name for color encoding")
+    color: str | None = Field(
+        default=None, description="Column name for color encoding"
+    )
     size: str | None = Field(default=None, description="Column name for size encoding")
-    symbol: str | None = Field(default=None, description="Column name for symbol encoding")
-    line_dash: str | None = Field(default=None, description="Column name for line dash pattern encoding")
-    chart_type: str = Field(description="The type of chart to create (scatter, line, bar, histogram, box, violin)")
+    symbol: str | None = Field(
+        default=None, description="Column name for symbol encoding"
+    )
+    line_dash: str | None = Field(
+        default=None, description="Column name for line dash pattern encoding"
+    )
+    chart_type: str = Field(
+        description="The type of chart to create (scatter, line, bar, histogram, box, violin)"
+    )
 
 
 class PlotlyConfig(BaseType):
@@ -2451,6 +2546,7 @@ class EmailSearchCriteria(BaseType):
         folder: IMAP folder to search in (defaults to INBOX)
         text: Full-text search across all email fields
     """
+
     type: Literal["email_search_criteria"] = "email_search_criteria"
     from_address: Optional[str] = None
     to_address: Optional[str] = None
@@ -2459,7 +2555,9 @@ class EmailSearchCriteria(BaseType):
     cc: Optional[str] = None
     label: Optional[str] = None
     date_query: Optional[DateSearchCondition] = None
-    date_condition: Optional[DateSearchCondition] = None  # Alias for date_query for backwards compatibility
+    date_condition: Optional[DateSearchCondition] = (
+        None  # Alias for date_query for backwards compatibility
+    )
     flags: list[EmailFlag] = Field(default_factory=list)
     keywords: list[str] = Field(default_factory=list)
     folder: Optional[str] = None

--- a/src/nodetool/providers/base.py
+++ b/src/nodetool/providers/base.py
@@ -23,6 +23,8 @@ import numpy as np
 from nodetool.config.logging_config import get_logger
 from nodetool.metadata.types import (
     ASRModel,
+    AudioModel,
+    AudioRef,
     EmbeddingModel,
     ImageModel,
     LanguageModel,
@@ -58,7 +60,10 @@ class ProviderCapability(StrEnum):
     TEXT_TO_IMAGE = "text_to_image"  # Text → Image generation
     IMAGE_TO_IMAGE = "image_to_image"  # Image transformation
     TEXT_TO_SPEECH = "text_to_speech"  # Text → Speech/Audio generation
-    AUTOMATIC_SPEECH_RECOGNITION = "automatic_speech_recognition"  # Speech → Text transcription
+    TEXT_TO_AUDIO = "text_to_audio"  # Text → Music/audio generation
+    AUTOMATIC_SPEECH_RECOGNITION = (
+        "automatic_speech_recognition"  # Speech → Text transcription
+    )
     TEXT_TO_VIDEO = "text_to_video"  # Text → Video generation
     IMAGE_TO_VIDEO = "image_to_video"  # Image → Video generation
     TEXT_TO_3D = "text_to_3d"  # Text → 3D model generation
@@ -142,6 +147,7 @@ class BaseProvider:
         ProviderCapability.TEXT_TO_IMAGE: "text_to_image",
         ProviderCapability.IMAGE_TO_IMAGE: "image_to_image",
         ProviderCapability.TEXT_TO_SPEECH: "text_to_speech",
+        ProviderCapability.TEXT_TO_AUDIO: "text_to_audio",
         ProviderCapability.AUTOMATIC_SPEECH_RECOGNITION: "automatic_speech_recognition",
         ProviderCapability.TEXT_TO_VIDEO: "text_to_video",
         ProviderCapability.IMAGE_TO_VIDEO: "image_to_video",
@@ -344,6 +350,21 @@ class BaseProvider:
         """
         return []
 
+    async def get_available_audio_models(self) -> list[AudioModel]:
+        """Get a list of available audio/music generation models for this provider.
+
+        Distinct from TTS (speech): these generate music or sound effects from a
+        text prompt. The implementation may check local cache or other requirements.
+
+        Returns:
+            List of AudioModel instances available for this provider.
+            Returns empty list if provider doesn't support audio generation.
+
+        Raises:
+            Exception: If model discovery fails (should be caught and return empty list)
+        """
+        return []
+
     async def get_available_embedding_models(self) -> list[EmbeddingModel]:
         """Get a list of available embedding models for this provider.
         The implementation may check for API keys, local cache, or other requirements.
@@ -374,7 +395,15 @@ class BaseProvider:
 
     async def get_available_models(
         self,
-    ) -> list[LanguageModel | ImageModel | TTSModel | ASRModel | VideoModel | EmbeddingModel | Model3DModel]:
+    ) -> list[
+        LanguageModel
+        | ImageModel
+        | TTSModel
+        | ASRModel
+        | VideoModel
+        | EmbeddingModel
+        | Model3DModel
+    ]:
         """Get a list of all available models for this provider.
 
         Returns language, image, TTS, ASR, video, embedding, and 3D models combined. Use get_available_language_models(),
@@ -585,7 +614,9 @@ class BaseProvider:
         Raises:
             NotImplementedError: If provider doesn't support GENERATE_MESSAGE capability
         """
-        raise NotImplementedError(f"{self.__class__.__name__} does not support GENERATE_MESSAGE capability")
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support GENERATE_MESSAGE capability"
+        )
 
     def generate_messages(
         self,
@@ -615,7 +646,9 @@ class BaseProvider:
         Raises:
             NotImplementedError: If provider doesn't support GENERATE_MESSAGES capability
         """
-        raise NotImplementedError(f"{self.__class__.__name__} does not support GENERATE_MESSAGES capability")
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support GENERATE_MESSAGES capability"
+        )
 
     async def text_to_image(
         self,
@@ -641,7 +674,9 @@ class BaseProvider:
             ValueError: If required parameters are missing or invalid
             RuntimeError: If generation fails
         """
-        raise NotImplementedError(f"{self.__class__.__name__} does not support TEXT_TO_IMAGE capability")
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support TEXT_TO_IMAGE capability"
+        )
 
     async def image_to_image(  # type: ignore[override]
         self,
@@ -669,7 +704,9 @@ class BaseProvider:
             ValueError: If required parameters are missing or invalid
             RuntimeError: If generation fails
         """
-        raise NotImplementedError(f"{self.__class__.__name__} does not support IMAGE_TO_IMAGE capability")
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support IMAGE_TO_IMAGE capability"
+        )
 
     def text_to_speech(
         self,
@@ -706,7 +743,54 @@ class BaseProvider:
             ValueError: If required parameters are missing or invalid
             RuntimeError: If generation fails
         """
-        raise NotImplementedError(f"{self.__class__.__name__} does not support TEXT_TO_SPEECH capability")
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support TEXT_TO_SPEECH capability"
+        )
+
+    async def text_to_audio(
+        self,
+        prompt: str,
+        model: str,
+        lyrics: str = "",
+        audio_duration: float = 30.0,
+        guidance_scale: float = 7.0,
+        num_inference_steps: int = 8,
+        seed: int | None = None,
+        timeout_s: int | None = None,
+        context: Any = None,  # ProcessingContext, but imported later
+        node_id: str | None = None,
+        **kwargs: Any,
+    ) -> "AudioRef":
+        """Generate music/audio from a text prompt (and optional lyrics).
+
+        Only implemented by providers with TEXT_TO_AUDIO capability. Unlike
+        text_to_speech (which streams spoken audio), this generates full musical
+        or sound-effect tracks and returns them as a single AudioRef.
+
+        Args:
+            prompt: Description of the desired audio (style, instruments, mood, tempo)
+            model: Model identifier for audio generation
+            lyrics: Optional structured lyrics (e.g. with [verse]/[chorus] tags)
+            audio_duration: Duration of the generated audio in seconds
+            guidance_scale: Classifier-free guidance scale
+            num_inference_steps: Number of denoising steps
+            seed: Optional random seed for reproducibility
+            timeout_s: Optional timeout in seconds
+            context: Optional processing context
+            node_id: Optional node id for progress reporting
+            **kwargs: Additional provider-specific parameters
+
+        Returns:
+            AudioRef: Reference to the generated audio track.
+
+        Raises:
+            NotImplementedError: If provider doesn't support TEXT_TO_AUDIO capability
+            ValueError: If required parameters are missing or invalid
+            RuntimeError: If generation fails
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support TEXT_TO_AUDIO capability"
+        )
 
     async def automatic_speech_recognition(
         self,
@@ -744,7 +828,9 @@ class BaseProvider:
             ValueError: If required parameters are missing or invalid
             RuntimeError: If transcription fails
         """
-        raise NotImplementedError(f"{self.__class__.__name__} does not support AUTOMATIC_SPEECH_RECOGNITION capability")
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support AUTOMATIC_SPEECH_RECOGNITION capability"
+        )
 
     async def text_to_video(
         self,
@@ -777,7 +863,9 @@ class BaseProvider:
             ValueError: If required parameters are missing or invalid
             RuntimeError: If generation fails
         """
-        raise NotImplementedError(f"{self.__class__.__name__} does not support TEXT_TO_VIDEO capability")
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support TEXT_TO_VIDEO capability"
+        )
 
     async def image_to_video(  # type: ignore[override]
         self,
@@ -813,7 +901,9 @@ class BaseProvider:
             ValueError: If required parameters are missing or invalid
             RuntimeError: If generation fails
         """
-        raise NotImplementedError(f"{self.__class__.__name__} does not support IMAGE_TO_VIDEO capability")
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support IMAGE_TO_VIDEO capability"
+        )
 
     async def generate_embedding(
         self,
@@ -839,7 +929,9 @@ class BaseProvider:
             ValueError: If required parameters are missing or invalid
             RuntimeError: If embedding generation fails
         """
-        raise NotImplementedError(f"{self.__class__.__name__} does not support GENERATE_EMBEDDING capability")
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support GENERATE_EMBEDDING capability"
+        )
 
     async def text_to_3d(
         self,
@@ -870,7 +962,9 @@ class BaseProvider:
             ValueError: If required parameters are missing or invalid
             RuntimeError: If generation fails
         """
-        raise NotImplementedError(f"{self.__class__.__name__} does not support TEXT_TO_3D capability")
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support TEXT_TO_3D capability"
+        )
 
     async def image_to_3d(
         self,
@@ -902,7 +996,9 @@ class BaseProvider:
             ValueError: If required parameters are missing or invalid
             RuntimeError: If generation fails
         """
-        raise NotImplementedError(f"{self.__class__.__name__} does not support IMAGE_TO_3D capability")
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support IMAGE_TO_3D capability"
+        )
 
 
 class MockProvider(BaseProvider):
@@ -955,7 +1051,9 @@ class MockProvider(BaseProvider):
 
         Logs the call and returns the next predefined response.
         """
-        self._log_api_request("generate_message", messages=messages, model=model, tools=tools, **kwargs)
+        self._log_api_request(
+            "generate_message", messages=messages, model=model, tools=tools, **kwargs
+        )
         self.call_log.append(
             {
                 "method": "generate_message",
@@ -985,7 +1083,9 @@ class MockProvider(BaseProvider):
         Currently yields the entire next predefined response. Can be adapted
         to yield individual chunks/tool calls if needed for more granular testing.
         """
-        self._log_api_request("generate_messages", messages=messages, model=model, tools=tools, **kwargs)
+        self._log_api_request(
+            "generate_messages", messages=messages, model=model, tools=tools, **kwargs
+        )
         self.call_log.append(
             {
                 "method": "generate_messages",
@@ -996,7 +1096,9 @@ class MockProvider(BaseProvider):
             }
         )
         response = self._get_next_response()
-        self._log_api_response("generate_messages", response=response)  # Log the full conceptual response
+        self._log_api_response(
+            "generate_messages", response=response
+        )  # Log the full conceptual response
 
         # Simulate streaming behavior
         if response.tool_calls:

--- a/src/nodetool/worker/provider_handler.py
+++ b/src/nodetool/worker/provider_handler.py
@@ -10,9 +10,8 @@ import sys
 import traceback
 from typing import Any, AsyncIterator
 
-from websockets.asyncio.server import ServerConnection
 import msgpack
-
+from websockets.asyncio.server import ServerConnection
 
 # Cached provider instances
 _provider_cache: dict[str, Any] = {}
@@ -73,24 +72,38 @@ def get_available_providers() -> list[dict[str, Any]]:
             # Detect capabilities from implemented methods
             capabilities = []
             base_methods = {
-                "generate_message", "generate_messages", "text_to_image",
-                "image_to_image", "text_to_speech", "automatic_speech_recognition",
-                "text_to_video", "image_to_video", "generate_embedding",
+                "generate_message",
+                "generate_messages",
+                "text_to_image",
+                "image_to_image",
+                "text_to_speech",
+                "text_to_audio",
+                "automatic_speech_recognition",
+                "text_to_video",
+                "image_to_video",
+                "generate_embedding",
             }
             for method_name in base_methods:
                 method = getattr(cls, method_name, None)
                 if method is not None:
                     # Check if it's overridden from BaseProvider
                     from nodetool.providers.base import BaseProvider
+
                     base_method = getattr(BaseProvider, method_name, None)
                     if method is not base_method:
                         capabilities.append(method_name)
 
-            result.append({
-                "id": pid,
-                "capabilities": capabilities,
-                "required_secrets": cls.required_secrets() if hasattr(cls, "required_secrets") else [],
-            })
+            result.append(
+                {
+                    "id": pid,
+                    "capabilities": capabilities,
+                    "required_secrets": (
+                        cls.required_secrets()
+                        if hasattr(cls, "required_secrets")
+                        else []
+                    ),
+                }
+            )
     return result
 
 
@@ -133,6 +146,14 @@ async def handle_provider_message(
             result = await _handle_image_to_image(data)
             await _send_result(websocket, request_id, result)
 
+        elif msg_type == "provider.text_to_video":
+            result = await _handle_text_to_video(data)
+            await _send_result(websocket, request_id, result)
+
+        elif msg_type == "provider.text_to_audio":
+            result = await _handle_text_to_audio(data)
+            await _send_result(websocket, request_id, result)
+
         elif msg_type == "provider.tts":
             cancel_event = asyncio.Event()
             if request_id:
@@ -152,7 +173,9 @@ async def handle_provider_message(
             await _send_result(websocket, request_id, result)
 
         else:
-            await _send_error(websocket, request_id, f"Unknown provider message type: {msg_type}")
+            await _send_error(
+                websocket, request_id, f"Unknown provider message type: {msg_type}"
+            )
 
     except Exception as e:
         await _send_error(websocket, request_id, str(e), traceback.format_exc())
@@ -161,28 +184,44 @@ async def handle_provider_message(
 # ── Message helpers ──────────────────────────────────────────────────────
 
 
-async def _send_result(ws: ServerConnection, request_id: str | None, data: dict) -> None:
-    await ws.send(msgpack.packb({
-        "type": "result",
-        "request_id": request_id,
-        "data": data,
-    }))
+async def _send_result(
+    ws: ServerConnection, request_id: str | None, data: dict
+) -> None:
+    await ws.send(
+        msgpack.packb(
+            {
+                "type": "result",
+                "request_id": request_id,
+                "data": data,
+            }
+        )
+    )
 
 
-async def _send_error(ws: ServerConnection, request_id: str | None, error: str, tb: str | None = None) -> None:
-    await ws.send(msgpack.packb({
-        "type": "error",
-        "request_id": request_id,
-        "data": {"error": error, "traceback": tb},
-    }))
+async def _send_error(
+    ws: ServerConnection, request_id: str | None, error: str, tb: str | None = None
+) -> None:
+    await ws.send(
+        msgpack.packb(
+            {
+                "type": "error",
+                "request_id": request_id,
+                "data": {"error": error, "traceback": tb},
+            }
+        )
+    )
 
 
 async def _send_chunk(ws: ServerConnection, request_id: str | None, data: dict) -> None:
-    await ws.send(msgpack.packb({
-        "type": "chunk",
-        "request_id": request_id,
-        "data": data,
-    }))
+    await ws.send(
+        msgpack.packb(
+            {
+                "type": "chunk",
+                "request_id": request_id,
+                "data": data,
+            }
+        )
+    )
 
 
 # ── Handler implementations ─────────────────────────────────────────────
@@ -198,10 +237,11 @@ def _deserialize_messages(raw_messages: list[dict]) -> list[Any]:
         # content can be string, list of content parts, or None
         if isinstance(content, list):
             from nodetool.metadata.types import (
-                MessageTextContent,
-                MessageImageContent,
                 MessageAudioContent,
+                MessageImageContent,
+                MessageTextContent,
             )
+
             parts = []
             for part in content:
                 if part.get("type") == "text":
@@ -218,6 +258,7 @@ def _deserialize_messages(raw_messages: list[dict]) -> list[Any]:
         )
         if m.get("tool_calls"):
             from nodetool.metadata.types import ToolCall
+
             msg.tool_calls = [
                 ToolCall(id=tc["id"], name=tc["name"], args=tc.get("args", {}))
                 for tc in m["tool_calls"]
@@ -241,8 +282,7 @@ def _serialize_message(msg: Any) -> dict:
 
     if msg.tool_calls:
         result["tool_calls"] = [
-            {"id": tc.id, "name": tc.name, "args": tc.args}
-            for tc in msg.tool_calls
+            {"id": tc.id, "name": tc.name, "args": tc.args} for tc in msg.tool_calls
         ]
     return result
 
@@ -284,8 +324,7 @@ async def _handle_models(data: dict) -> dict:
     models = await getter()
     return {
         "models": [
-            m.model_dump() if hasattr(m, "model_dump") else m.__dict__
-            for m in models
+            m.model_dump() if hasattr(m, "model_dump") else m.__dict__ for m in models
         ]
     }
 
@@ -344,12 +383,16 @@ async def _handle_stream(
             break
 
         if isinstance(item, ToolCall):
-            await _send_chunk(websocket, request_id, {
-                "type": "tool_call",
-                "id": item.id,
-                "name": item.name,
-                "args": item.args,
-            })
+            await _send_chunk(
+                websocket,
+                request_id,
+                {
+                    "type": "tool_call",
+                    "id": item.id,
+                    "name": item.name,
+                    "args": item.args,
+                },
+            )
         else:
             # Chunk object
             chunk_data: dict[str, Any] = {
@@ -382,6 +425,73 @@ async def _handle_image_to_image(data: dict) -> dict:
     return {"blobs": {"image": result_bytes}}
 
 
+async def _extract_media_bytes(ctx: Any, ref: Any) -> bytes:
+    """Pull encoded bytes out of a worker context after media generation.
+
+    Audio/image are captured into the WorkerContext's output blobs; file-based
+    refs (e.g. video) are resolved directly via the context.
+    """
+    get_blobs = getattr(ctx, "get_output_blobs", None)
+    blobs = get_blobs() if callable(get_blobs) else {}
+    if blobs:
+        return next(iter(blobs.values()))
+    return await ctx.asset_to_bytes(ref)
+
+
+async def _handle_text_to_video(data: dict) -> dict:
+    """Handle provider.text_to_video."""
+    from nodetool.worker.context_stub import WorkerContext
+
+    provider = _get_provider(data["provider"], data.get("secrets", {}))
+    ctx = WorkerContext(secrets=data.get("secrets", {}))
+    kwargs: dict[str, Any] = {
+        "prompt": data["prompt"],
+        "model": data["model"],
+        "context": ctx,
+    }
+    for key in (
+        "negative_prompt",
+        "num_frames",
+        "guidance_scale",
+        "num_inference_steps",
+        "height",
+        "width",
+        "fps",
+        "seed",
+        "max_sequence_length",
+    ):
+        if key in data:
+            kwargs[key] = data[key]
+
+    video_ref = await provider.text_to_video(**kwargs)
+    return {"blobs": {"video": await _extract_media_bytes(ctx, video_ref)}}
+
+
+async def _handle_text_to_audio(data: dict) -> dict:
+    """Handle provider.text_to_audio."""
+    from nodetool.worker.context_stub import WorkerContext
+
+    provider = _get_provider(data["provider"], data.get("secrets", {}))
+    ctx = WorkerContext(secrets=data.get("secrets", {}))
+    kwargs: dict[str, Any] = {
+        "prompt": data["prompt"],
+        "model": data["model"],
+        "context": ctx,
+    }
+    for key in (
+        "lyrics",
+        "audio_duration",
+        "guidance_scale",
+        "num_inference_steps",
+        "seed",
+    ):
+        if key in data:
+            kwargs[key] = data[key]
+
+    audio_ref = await provider.text_to_audio(**kwargs)
+    return {"blobs": {"audio": await _extract_media_bytes(ctx, audio_ref)}}
+
+
 async def _handle_tts(
     data: dict,
     request_id: str | None,
@@ -403,11 +513,15 @@ async def _handle_tts(
         if cancel_event.is_set():
             break
         # audio_chunk is numpy int16 array
-        await websocket.send(msgpack.packb({
-            "type": "chunk",
-            "request_id": request_id,
-            "data": {"blobs": {"audio": audio_chunk.tobytes()}},
-        }))
+        await websocket.send(
+            msgpack.packb(
+                {
+                    "type": "chunk",
+                    "request_id": request_id,
+                    "data": {"blobs": {"audio": audio_chunk.tobytes()}},
+                }
+            )
+        )
 
     await _send_result(websocket, request_id, {"done": True})
 
@@ -459,7 +573,13 @@ async def handle_provider_message_stdio(
         await transport.send_msg({"type": "result", "request_id": rid, "data": d})
 
     async def send_error(rid: str | None, error: str, tb: str | None = None) -> None:
-        await transport.send_msg({"type": "error", "request_id": rid, "data": {"error": error, "traceback": tb}})
+        await transport.send_msg(
+            {
+                "type": "error",
+                "request_id": rid,
+                "data": {"error": error, "traceback": tb},
+            }
+        )
 
     async def send_chunk(rid: str | None, d: dict) -> None:
         await transport.send_msg({"type": "chunk", "request_id": rid, "data": d})
@@ -494,13 +614,31 @@ async def handle_provider_message_stdio(
                     kwargs["tools"] = tools
 
                 from nodetool.metadata.types import ToolCall
-                async for item in provider.generate_messages(messages=messages, model=model, **kwargs):
+
+                async for item in provider.generate_messages(
+                    messages=messages, model=model, **kwargs
+                ):
                     if cancel_event.is_set():
                         break
                     if isinstance(item, ToolCall):
-                        await send_chunk(request_id, {"type": "tool_call", "id": item.id, "name": item.name, "args": item.args})
+                        await send_chunk(
+                            request_id,
+                            {
+                                "type": "tool_call",
+                                "id": item.id,
+                                "name": item.name,
+                                "args": item.args,
+                            },
+                        )
                     else:
-                        await send_chunk(request_id, {"type": "chunk", "content": getattr(item, "content", str(item)), "done": getattr(item, "done", False)})
+                        await send_chunk(
+                            request_id,
+                            {
+                                "type": "chunk",
+                                "content": getattr(item, "content", str(item)),
+                                "done": getattr(item, "done", False),
+                            },
+                        )
                 await send_result(request_id, {"done": True})
             finally:
                 if request_id:
@@ -514,20 +652,33 @@ async def handle_provider_message_stdio(
             result = await _handle_image_to_image(data)
             await send_result(request_id, result)
 
+        elif msg_type == "provider.text_to_video":
+            result = await _handle_text_to_video(data)
+            await send_result(request_id, result)
+
+        elif msg_type == "provider.text_to_audio":
+            result = await _handle_text_to_audio(data)
+            await send_result(request_id, result)
+
         elif msg_type == "provider.tts":
             cancel_event = asyncio.Event()
             if request_id:
                 cancel_flags[request_id] = cancel_event
             try:
                 provider = _get_provider(data["provider"], data.get("secrets", {}))
-                kwargs_tts: dict[str, Any] = {"text": data["text"], "model": data["model"]}
+                kwargs_tts: dict[str, Any] = {
+                    "text": data["text"],
+                    "model": data["model"],
+                }
                 for key in ("voice", "speed"):
                     if key in data:
                         kwargs_tts[key] = data[key]
                 async for audio_chunk in provider.text_to_speech(**kwargs_tts):
                     if cancel_event.is_set():
                         break
-                    await send_chunk(request_id, {"blobs": {"audio": audio_chunk.tobytes()}})
+                    await send_chunk(
+                        request_id, {"blobs": {"audio": audio_chunk.tobytes()}}
+                    )
                 await send_result(request_id, {"done": True})
             finally:
                 if request_id:


### PR DESCRIPTION
## Summary

Adds first-class audio generation plus video/audio worker dispatch to the provider
abstraction, consumed by the nodetool-huggingface local provider.

- `ProviderCapability.TEXT_TO_AUDIO` + base `text_to_audio()` (capability-gated, returns `AudioRef`)
- New `AudioModel` type + `get_available_audio_models()` base method
- Worker `provider.text_to_video` / `provider.text_to_audio` dispatch (websocket + stdio),
  creating a `WorkerContext` and converting the returned ref to bytes
- `get_text_to_video_models_from_hf_cache` / `get_text_to_audio_models_from_hf_cache`
  classify cached diffusers repos by `_class_name` (so video/audio models aren't
  mislabeled as images)

All changes are additive — existing providers are unaffected (base methods raise
`NotImplementedError`, capabilities are auto-detected by method override).

## Companion
Required by the nodetool-huggingface PR (new diffusers pipeline nodes + provider integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
