### PR TITLE
feat(worker): WebSocket worker protocol parity with stdio

### DIFF
--- a/src/nodetool/worker/__main__.py
+++ b/src/nodetool/worker/__main__.py
@@ -1,11 +1,11 @@
 import argparse
 import asyncio
-import os
 import sys
+from typing import Any, Awaitable, Callable
 
-from nodetool.worker.server import WorkerServer, start_server
-from nodetool.worker.node_loader import load_nodes
 from nodetool.worker.executor import execute_node
+from nodetool.worker.node_loader import load_nodes, resolve_namespaces
+from nodetool.worker.server import WorkerServer, start_server
 
 
 def main():
@@ -30,23 +30,32 @@ def main():
 
 async def run(args):
     namespaces = args.namespaces.split(",") if args.namespaces else None
+    resolved_namespaces = resolve_namespaces(namespaces)
 
     # Load node metadata
     print("Loading node packages...", file=sys.stderr)
-    nodes_metadata = load_nodes(namespaces=namespaces)
+    nodes_metadata = load_nodes(resolved_namespaces)
     print(f"Loaded {len(nodes_metadata)} nodes", file=sys.stderr)
 
     # Set up server
     worker = WorkerServer()
     worker.set_nodes_metadata(nodes_metadata)
+    worker.set_namespaces(resolved_namespaces)
 
-    async def handle_execute(data: dict, cancel_event: asyncio.Event) -> dict:
+    async def handle_execute(
+        data: dict,
+        cancel_event: asyncio.Event,
+        emit_progress: Callable[[dict[str, Any]], Awaitable[None]],
+        emit_chunk: Callable[[dict[str, Any]], Awaitable[None]] | None,
+    ) -> dict:
         return await execute_node(
             node_type=data["node_type"],
             fields=data.get("fields", {}),
             secrets=data.get("secrets", {}),
             input_blobs=data.get("blobs", {}),
             cancel_event=cancel_event,
+            emit_progress=emit_progress,
+            emit_chunk=emit_chunk,
         )
 
     worker.set_execute_handler(handle_execute)

--- a/src/nodetool/worker/protocol.py
+++ b/src/nodetool/worker/protocol.py
@@ -168,9 +168,9 @@ class WorkerProtocolServer:
             return
 
         if msg_type and str(msg_type).startswith("provider."):
-            from nodetool.worker.provider_handler import handle_provider_message_stdio
+            from nodetool.worker.provider_handler import handle_provider_message
 
-            await handle_provider_message_stdio(
+            await handle_provider_message(
                 msg_type=str(msg_type),
                 request_id=request_id,
                 data=msg.get("data", {}),

--- a/src/nodetool/worker/provider_handler.py
+++ b/src/nodetool/worker/provider_handler.py
@@ -2,16 +2,15 @@
 Provider bridge handler for the worker server.
 
 Loads Python-only providers (HuggingFace Local, MLX) and handles
-provider operations dispatched from the TS backend via the WebSocket protocol.
+provider operations dispatched from the TS backend. The handler is
+transport-agnostic — it only needs a transport exposing ``send_msg`` —
+so the same code path serves both the WebSocket and stdio workers.
 """
 
 import asyncio
 import sys
 import traceback
-from typing import Any, AsyncIterator
-
-import msgpack
-from websockets.asyncio.server import ServerConnection
+from typing import Any
 
 # Cached provider instances
 _provider_cache: dict[str, Any] = {}
@@ -105,123 +104,6 @@ def get_available_providers() -> list[dict[str, Any]]:
                 }
             )
     return result
-
-
-async def handle_provider_message(
-    msg_type: str,
-    request_id: str | None,
-    data: dict[str, Any],
-    websocket: ServerConnection,
-    cancel_flags: dict[str, asyncio.Event],
-) -> None:
-    """Handle a provider.* message type."""
-    try:
-        if msg_type == "provider.list":
-            providers = get_available_providers()
-            await _send_result(websocket, request_id, {"providers": providers})
-
-        elif msg_type == "provider.models":
-            result = await _handle_models(data)
-            await _send_result(websocket, request_id, result)
-
-        elif msg_type == "provider.generate":
-            result = await _handle_generate(data)
-            await _send_result(websocket, request_id, result)
-
-        elif msg_type == "provider.stream":
-            cancel_event = asyncio.Event()
-            if request_id:
-                cancel_flags[request_id] = cancel_event
-            try:
-                await _handle_stream(data, request_id, websocket, cancel_event)
-            finally:
-                if request_id:
-                    cancel_flags.pop(request_id, None)
-
-        elif msg_type == "provider.text_to_image":
-            result = await _handle_text_to_image(data)
-            await _send_result(websocket, request_id, result)
-
-        elif msg_type == "provider.image_to_image":
-            result = await _handle_image_to_image(data)
-            await _send_result(websocket, request_id, result)
-
-        elif msg_type == "provider.text_to_video":
-            result = await _handle_text_to_video(data)
-            await _send_result(websocket, request_id, result)
-
-        elif msg_type == "provider.text_to_audio":
-            result = await _handle_text_to_audio(data)
-            await _send_result(websocket, request_id, result)
-
-        elif msg_type == "provider.tts":
-            cancel_event = asyncio.Event()
-            if request_id:
-                cancel_flags[request_id] = cancel_event
-            try:
-                await _handle_tts(data, request_id, websocket, cancel_event)
-            finally:
-                if request_id:
-                    cancel_flags.pop(request_id, None)
-
-        elif msg_type == "provider.asr":
-            result = await _handle_asr(data)
-            await _send_result(websocket, request_id, result)
-
-        elif msg_type == "provider.embedding":
-            result = await _handle_embedding(data)
-            await _send_result(websocket, request_id, result)
-
-        else:
-            await _send_error(
-                websocket, request_id, f"Unknown provider message type: {msg_type}"
-            )
-
-    except Exception as e:
-        await _send_error(websocket, request_id, str(e), traceback.format_exc())
-
-
-# ── Message helpers ──────────────────────────────────────────────────────
-
-
-async def _send_result(
-    ws: ServerConnection, request_id: str | None, data: dict
-) -> None:
-    await ws.send(
-        msgpack.packb(
-            {
-                "type": "result",
-                "request_id": request_id,
-                "data": data,
-            }
-        )
-    )
-
-
-async def _send_error(
-    ws: ServerConnection, request_id: str | None, error: str, tb: str | None = None
-) -> None:
-    await ws.send(
-        msgpack.packb(
-            {
-                "type": "error",
-                "request_id": request_id,
-                "data": {"error": error, "traceback": tb},
-            }
-        )
-    )
-
-
-async def _send_chunk(ws: ServerConnection, request_id: str | None, data: dict) -> None:
-    await ws.send(
-        msgpack.packb(
-            {
-                "type": "chunk",
-                "request_id": request_id,
-                "data": data,
-            }
-        )
-    )
 
 
 # ── Handler implementations ─────────────────────────────────────────────
@@ -352,60 +234,6 @@ async def _handle_generate(data: dict) -> dict:
     return {"message": _serialize_message(result_msg)}
 
 
-async def _handle_stream(
-    data: dict,
-    request_id: str | None,
-    websocket: ServerConnection,
-    cancel_event: asyncio.Event,
-) -> None:
-    """Handle provider.stream — streaming message generation."""
-    provider = _get_provider(data["provider"], data.get("secrets", {}))
-    messages = _deserialize_messages(data["messages"])
-    model = data["model"]
-
-    kwargs: dict[str, Any] = {}
-    for key in ("max_tokens", "temperature", "top_p", "response_format"):
-        if key in data:
-            kwargs[key] = data[key]
-
-    tools = data.get("tools")
-    if tools:
-        kwargs["tools"] = tools
-
-    from nodetool.metadata.types import ToolCall
-
-    async for item in provider.generate_messages(
-        messages=messages,
-        model=model,
-        **kwargs,
-    ):
-        if cancel_event.is_set():
-            break
-
-        if isinstance(item, ToolCall):
-            await _send_chunk(
-                websocket,
-                request_id,
-                {
-                    "type": "tool_call",
-                    "id": item.id,
-                    "name": item.name,
-                    "args": item.args,
-                },
-            )
-        else:
-            # Chunk object
-            chunk_data: dict[str, Any] = {
-                "type": "chunk",
-                "content": getattr(item, "content", str(item)),
-                "done": getattr(item, "done", False),
-            }
-            await _send_chunk(websocket, request_id, chunk_data)
-
-    # Signal stream end
-    await _send_result(websocket, request_id, {"done": True})
-
-
 async def _handle_text_to_image(data: dict) -> dict:
     """Handle provider.text_to_image."""
     provider = _get_provider(data["provider"], data.get("secrets", {}))
@@ -492,40 +320,6 @@ async def _handle_text_to_audio(data: dict) -> dict:
     return {"blobs": {"audio": await _extract_media_bytes(ctx, audio_ref)}}
 
 
-async def _handle_tts(
-    data: dict,
-    request_id: str | None,
-    websocket: ServerConnection,
-    cancel_event: asyncio.Event,
-) -> None:
-    """Handle provider.tts — streaming text-to-speech."""
-    provider = _get_provider(data["provider"], data.get("secrets", {}))
-
-    kwargs: dict[str, Any] = {
-        "text": data["text"],
-        "model": data["model"],
-    }
-    for key in ("voice", "speed"):
-        if key in data:
-            kwargs[key] = data[key]
-
-    async for audio_chunk in provider.text_to_speech(**kwargs):
-        if cancel_event.is_set():
-            break
-        # audio_chunk is numpy int16 array
-        await websocket.send(
-            msgpack.packb(
-                {
-                    "type": "chunk",
-                    "request_id": request_id,
-                    "data": {"blobs": {"audio": audio_chunk.tobytes()}},
-                }
-            )
-        )
-
-    await _send_result(websocket, request_id, {"done": True})
-
-
 async def _handle_asr(data: dict) -> dict:
     """Handle provider.asr — automatic speech recognition."""
     provider = _get_provider(data["provider"], data.get("secrets", {}))
@@ -557,17 +351,17 @@ async def _handle_embedding(data: dict) -> dict:
     return {"embeddings": result}
 
 
-# ── Stdio transport adapter ──────────────────────────────────────────────
+# ── Provider message dispatch ─────────────────────────────────────────────
 
 
-async def handle_provider_message_stdio(
+async def handle_provider_message(
     msg_type: str,
     request_id: str | None,
     data: dict[str, Any],
-    transport: Any,  # StdioTransport
+    transport: Any,  # WorkerTransport (exposes async send_msg)
     cancel_flags: dict[str, asyncio.Event],
 ) -> None:
-    """Handle a provider.* message via stdio transport (same logic, different send)."""
+    """Handle a provider.* message via any transport exposing ``send_msg``."""
 
     async def send_result(rid: str | None, d: dict) -> None:
         await transport.send_msg({"type": "result", "request_id": rid, "data": d})

--- a/src/nodetool/worker/server.py
+++ b/src/nodetool/worker/server.py
@@ -1,89 +1,77 @@
 import asyncio
-import traceback
-from typing import Any, Callable, Awaitable
+from typing import Any, Awaitable, Callable, cast
 
 import msgpack
-from websockets.asyncio.server import serve as ws_serve, ServerConnection
+from websockets.asyncio.server import ServerConnection
+from websockets.asyncio.server import serve as ws_serve
+from websockets.exceptions import ConnectionClosed
 
-from nodetool.worker import BRIDGE_PROTOCOL_VERSION
+from nodetool.worker.protocol import WorkerProtocolServer
+
+
+class WebSocketTransport:
+    """WorkerTransport implementation over a websockets ServerConnection.
+
+    Writes are serialized with a lock so concurrent dispatch tasks cannot
+    interleave their frames (parity with StdioTransport).
+    """
+
+    def __init__(self, websocket: ServerConnection) -> None:
+        self._ws = websocket
+        self._write_lock = asyncio.Lock()
+
+    async def send_msg(self, msg: dict[str, Any]) -> None:
+        """Encode and send a dict as msgpack (thread-safe)."""
+        data = cast("bytes", msgpack.packb(msg))
+        async with self._write_lock:
+            await self._ws.send(data)
 
 
 class WorkerServer:
-    def __init__(self):
-        self._nodes_metadata: list[dict] = []
-        self._cancel_flags: dict[str, asyncio.Event] = {}
-        self._execute_handler: Callable | None = None
+    """WebSocket worker server that delegates to the shared protocol server."""
 
-    def set_nodes_metadata(self, metadata: list[dict]):
-        self._nodes_metadata = metadata
+    def __init__(self) -> None:
+        self._protocol = WorkerProtocolServer(transport_name="websocket")
+
+    def set_nodes_metadata(self, metadata: list[dict]) -> None:
+        self._protocol.set_nodes_metadata(metadata)
+
+    def set_load_errors(self, errors: list[dict[str, Any]]) -> None:
+        self._protocol.set_load_errors(errors)
+
+    def set_namespaces(self, namespaces: list[str]) -> None:
+        self._protocol.set_namespaces(namespaces)
 
     def set_execute_handler(
         self,
         handler: Callable[
-            [dict, asyncio.Event],
+            [
+                dict,
+                asyncio.Event,
+                Callable[[dict[str, Any]], Awaitable[None]],
+                Callable[[dict[str, Any]], Awaitable[None]] | None,
+            ],
             Awaitable[dict],
         ],
-    ):
-        self._execute_handler = handler
+    ) -> None:
+        self._protocol.set_execute_handler(handler)
 
-    async def handle_connection(self, websocket: ServerConnection):
-        async for raw_message in websocket:
-            msg = msgpack.unpackb(raw_message, raw=False)
-            msg_type = msg.get("type")
-            request_id = msg.get("request_id")
+    async def handle_connection(self, websocket: ServerConnection) -> None:
+        transport = WebSocketTransport(websocket)
+        tasks: set[asyncio.Task] = set()
 
-            if msg_type == "discover":
-                response = msgpack.packb({
-                    "type": "discover",
-                    "request_id": request_id,
-                    "data": {
-                        "nodes": self._nodes_metadata,
-                        "protocol_version": BRIDGE_PROTOCOL_VERSION,
-                    },
-                })
-                await websocket.send(response)
-
-            elif msg_type == "execute":
-                cancel_event = asyncio.Event()
-                if request_id:
-                    self._cancel_flags[request_id] = cancel_event
-                try:
-                    if self._execute_handler is None:
-                        raise RuntimeError("No execute handler registered")
-                    result = await self._execute_handler(msg["data"], cancel_event)
-                    response = msgpack.packb({
-                        "type": "result",
-                        "request_id": request_id,
-                        "data": result,
-                    })
-                    await websocket.send(response)
-                except Exception as e:
-                    response = msgpack.packb({
-                        "type": "error",
-                        "request_id": request_id,
-                        "data": {
-                            "error": str(e),
-                            "traceback": traceback.format_exc(),
-                        },
-                    })
-                    await websocket.send(response)
-                finally:
-                    self._cancel_flags.pop(request_id, None)
-
-            elif msg_type == "cancel":
-                cancel_event = self._cancel_flags.get(request_id)
-                if cancel_event:
-                    cancel_event.set()
-
-            elif msg_type and msg_type.startswith("provider."):
-                from nodetool.worker.provider_handler import handle_provider_message
-                await handle_provider_message(
-                    msg_type=msg_type,
-                    request_id=request_id,
-                    data=msg.get("data", {}),
-                    websocket=websocket,
-                    cancel_flags=self._cancel_flags,
-                )
+        try:
+            async for raw_message in websocket:
+                msg = msgpack.unpackb(raw_message, raw=False)
+                task = asyncio.create_task(self._protocol.dispatch(msg, transport))
+                tasks.add(task)
+                task.add_done_callback(tasks.discard)
+        except ConnectionClosed:
+            pass
+        finally:
+            # Wait for in-flight tasks to finish
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
 
 
 async def start_server(

--- a/tests/worker/test_server.py
+++ b/tests/worker/test_server.py
@@ -81,13 +81,15 @@ async def test_full_execute_with_echo_node():
         worker = WorkerServer()
         worker.set_nodes_metadata(load_nodes(namespaces=["testns"]))
 
-        async def handle(data, cancel):
+        async def handle(data, cancel, emit_progress, emit_chunk):
             return await execute_node(
                 node_type=data["node_type"],
                 fields=data.get("fields", {}),
                 secrets=data.get("secrets", {}),
                 input_blobs=data.get("blobs", {}),
                 cancel_event=cancel,
+                emit_progress=emit_progress,
+                emit_chunk=emit_chunk,
             )
 
         worker.set_execute_handler(handle)
@@ -126,7 +128,7 @@ async def test_execute_accepts_large_blob_payload():
 
     worker = WorkerServer()
 
-    async def handle(data, cancel):
+    async def handle(data, cancel, emit_progress, emit_chunk):
         blobs = data.get("blobs", {})
         image_blob = blobs.get("image", b"")
         return {

--- a/tests/worker/test_websocket_server.py
+++ b/tests/worker/test_websocket_server.py
@@ -1,0 +1,264 @@
+"""Tests for the WebSocket worker server protocol parity.
+
+These exercise the WebSocket transport end-to-end against a real
+``websockets`` client, asserting the server delegates to the shared
+``WorkerProtocolServer`` (discover / worker.status / execute /
+execute.stream / unknown-type).
+"""
+
+import asyncio
+from typing import Any, Awaitable, Callable, cast
+
+import msgpack
+import pytest
+import pytest_asyncio
+import websockets
+
+from nodetool.worker import BRIDGE_PROTOCOL_VERSION
+from nodetool.worker.server import WorkerServer, start_server
+
+
+def _pack(msg: dict[str, Any]) -> bytes:
+    return cast("bytes", msgpack.packb(msg))
+
+
+async def _recv(ws) -> dict:
+    raw = await asyncio.wait_for(ws.recv(), timeout=5)
+    return msgpack.unpackb(raw, raw=False)
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def configured_server():
+    """Start a fully-configured server with fake metadata and a streaming
+    execute handler. Yields (host, port)."""
+    worker = WorkerServer()
+    worker.set_nodes_metadata([{"node_type": "fake.Node", "properties": []}])
+    worker.set_namespaces(["fake"])
+    worker.set_load_errors([])
+
+    async def handle_execute(
+        data: dict,
+        _cancel_event: asyncio.Event,
+        _emit_progress: Callable[[dict[str, Any]], Awaitable[None]],
+        emit_chunk: Callable[[dict[str, Any]], Awaitable[None]] | None,
+    ) -> dict:
+        if data.get("node_type") != "fake.Echo":
+            raise ValueError(f"Unknown node type: {data.get('node_type')}")
+        # Emit a couple of chunks when streaming is requested.
+        if emit_chunk is not None:
+            await emit_chunk({"outputs": {"output": "a"}, "blobs": {}})
+            await emit_chunk({"outputs": {"output": "b"}, "blobs": {}})
+        return {"outputs": {"output": data.get("fields", {}).get("text", "")}, "blobs": {}}
+
+    worker.set_execute_handler(handle_execute)
+
+    host, port, stop_event, task = await start_server(
+        host="127.0.0.1", port=0, worker=worker,
+    )
+    yield host, port
+    stop_event.set()
+    await task
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def cancellable_server():
+    """Start a server whose streaming execute handler loops emitting chunks
+    until ``cancel_event`` is set. Yields (host, port)."""
+    worker = WorkerServer()
+    worker.set_nodes_metadata([{"node_type": "fake.Stream", "properties": []}])
+    worker.set_namespaces(["fake"])
+    worker.set_load_errors([])
+
+    async def handle_execute(
+        data: dict[str, Any],
+        cancel_event: asyncio.Event,
+        emit_progress: Callable[[dict[str, Any]], Awaitable[None]],
+        emit_chunk: Callable[[dict[str, Any]], Awaitable[None]] | None,
+    ) -> dict[str, Any]:
+        _ = data, emit_progress
+        assert emit_chunk is not None
+        i = 0
+        while not cancel_event.is_set():
+            await emit_chunk({"outputs": {"output": i}, "blobs": {}})
+            i += 1
+            # Yield control so the cancel message can be dispatched between
+            # chunk emissions.
+            await asyncio.sleep(0.01)
+        return {"outputs": {"output": "done"}, "blobs": {}}
+
+    worker.set_execute_handler(handle_execute)
+
+    host, port, stop_event, task = await start_server(
+        host="127.0.0.1", port=0, worker=worker,
+    )
+    yield host, port
+    stop_event.set()
+    await task
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_discover_returns_protocol_metadata(configured_server):
+    host, port = configured_server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        await ws.send(_pack({"type": "discover", "request_id": "d-1", "data": {}}))
+        resp = await _recv(ws)
+        assert resp["type"] == "discover"
+        assert resp["request_id"] == "d-1"
+        assert resp["data"]["protocol_version"] == BRIDGE_PROTOCOL_VERSION
+        assert resp["data"]["nodes"] == [{"node_type": "fake.Node", "properties": []}]
+        assert resp["data"]["load_errors"] == []
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_worker_status_reports_websocket_transport(configured_server):
+    host, port = configured_server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        await ws.send(_pack({"type": "worker.status", "request_id": "s-1", "data": {}}))
+        resp = await _recv(ws)
+        assert resp["type"] == "result"
+        assert resp["request_id"] == "s-1"
+        assert resp["data"]["transport"] == "websocket"
+        assert resp["data"]["protocol_version"] == BRIDGE_PROTOCOL_VERSION
+        assert resp["data"]["node_count"] == 1
+        assert resp["data"]["namespaces"] == ["fake"]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_execute_unknown_node_returns_error(configured_server):
+    host, port = configured_server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        await ws.send(_pack({
+            "type": "execute",
+            "request_id": "e-err",
+            "data": {"node_type": "fake.DoesNotExist", "fields": {}},
+        }))
+        resp = await _recv(ws)
+        assert resp["type"] == "error"
+        assert resp["request_id"] == "e-err"
+        assert "error" in resp["data"]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_unknown_message_type_returns_error(configured_server):
+    host, port = configured_server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        await ws.send(_pack({"type": "bogus.type", "request_id": "u-1", "data": {}}))
+        resp = await _recv(ws)
+        assert resp["type"] == "error"
+        assert resp["request_id"] == "u-1"
+        assert "Unknown message type" in resp["data"]["error"]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_execute_success(configured_server):
+    host, port = configured_server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        await ws.send(_pack({
+            "type": "execute",
+            "request_id": "e-ok",
+            "data": {"node_type": "fake.Echo", "fields": {"text": "hello"}},
+        }))
+        resp = await _recv(ws)
+        assert resp["type"] == "result"
+        assert resp["request_id"] == "e-ok"
+        assert resp["data"]["outputs"]["output"] == "hello"
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_execute_stream_emits_chunks_then_result(configured_server):
+    host, port = configured_server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        await ws.send(_pack({
+            "type": "execute.stream",
+            "request_id": "e-stream",
+            "data": {"node_type": "fake.Echo", "fields": {"text": "hi"}},
+        }))
+
+        chunks: list[dict] = []
+        while True:
+            resp = await _recv(ws)
+            assert resp["request_id"] == "e-stream"
+            if resp["type"] == "chunk":
+                chunks.append(resp["data"])
+                continue
+            # Terminator
+            assert resp["type"] == "result"
+            # execute.stream result frame is an empty terminator
+            assert resp["data"] == {"outputs": {}, "blobs": {}}
+            break
+
+        assert len(chunks) >= 1
+        assert chunks[0]["outputs"]["output"] == "a"
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_execute_stream_cancel_terminates_stream(cancellable_server):
+    """A streaming execute that loops until cancelled stops emitting chunks
+    once a ``cancel`` for its request_id arrives and sends a terminator."""
+    host, port = cancellable_server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        await ws.send(_pack({
+            "type": "execute.stream",
+            "request_id": "e-cancel",
+            "data": {"node_type": "fake.Stream"},
+        }))
+
+        # Read at least one chunk to confirm the stream is live.
+        first = await _recv(ws)
+        assert first["type"] == "chunk"
+        assert first["request_id"] == "e-cancel"
+
+        # Request cancellation for the same request_id.
+        await ws.send(_pack({"type": "cancel", "request_id": "e-cancel", "data": {}}))
+
+        # Drain until the terminator. The handler loops with a small sleep, so
+        # a bounded number of in-flight chunks may still arrive before it
+        # observes the cancel — but the stream MUST terminate with a result.
+        saw_result = False
+        frames_after_first = 0
+        while frames_after_first < 100:
+            resp = await _recv(ws)
+            assert resp["request_id"] == "e-cancel"
+            frames_after_first += 1
+            if resp["type"] == "result":
+                saw_result = True
+                break
+            assert resp["type"] == "chunk"
+
+        assert saw_result, "stream did not terminate after cancel"
+
+        # After the terminator no further frames are sent for this request.
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(ws.recv(), timeout=0.2)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_concurrent_requests_preserve_request_id_correlation(configured_server):
+    """Two execute requests dispatched as concurrent tracked tasks each get a
+    result frame correlated to their own request_id (no cross-talk).
+
+    Note: both executes are non-streaming (single frame each), so this proves
+    request_id correlation under concurrent dispatch rather than write-lock
+    frame ordering. See test_execute_stream_cancel for the stateful/streaming
+    branch.
+    """
+    host, port = configured_server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        await ws.send(_pack({
+            "type": "execute",
+            "request_id": "c-1",
+            "data": {"node_type": "fake.Echo", "fields": {"text": "one"}},
+        }))
+        await ws.send(_pack({
+            "type": "execute",
+            "request_id": "c-2",
+            "data": {"node_type": "fake.Echo", "fields": {"text": "two"}},
+        }))
+
+        seen: dict[str, str] = {}
+        for _ in range(2):
+            resp = await _recv(ws)
+            assert resp["type"] == "result"
+            seen[resp["request_id"]] = resp["data"]["outputs"]["output"]
+
+        assert seen == {"c-1": "one", "c-2": "two"}

--- a/uv.lock
+++ b/uv.lock
@@ -2492,7 +2492,7 @@ wheels = [
 
 [[package]]
 name = "nodetool-core"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## What

Brings the **WebSocket** worker server (`python -m nodetool.worker --host 0.0.0.0 --port 7777` — the transport the Docker image runs) to full parity with the stdio worker by delegating to the shared `WorkerProtocolServer`.

- New `WebSocketTransport` (msgpack over `ws.send`, lock-serialized) implementing the `WorkerTransport` protocol.
- `WorkerServer.handle_connection` now dispatches each frame via `WorkerProtocolServer.dispatch` as tracked asyncio tasks; the divergent inline handler is removed.
- WS entrypoint (`__main__.py`) registers the streaming 4-arg execute handler (`emit_progress`/`emit_chunk`), mirroring `run_stdio_worker`.
- `provider_handler`: `handle_provider_message_stdio` → transport-agnostic `handle_provider_message`; the dead WebSocket-specific path and orphaned helpers removed (−222 lines).
- Syncs `uv.lock`'s `nodetool-core` self-version to `0.7.1` (main's lockfile was stale at `0.7.0`; `pyproject` is already `0.7.1`).

## Why

The Docker worker's WS server lagged behind stdio — it lacked `execute.stream`, `worker.status`, and progress/chunk emission. This is the server-side half of the TypeScript `WebsocketPythonBridge` (see the paired PR in `nodetool-ai/nodetool`).

## Test plan

- New `tests/worker/test_websocket_server.py`: end-to-end over a real `websockets` client — discover, `worker.status` (`transport: "websocket"`), execute success + unknown-node error, `execute.stream` (chunks + empty terminator), unknown-message-type error, cancel-during-stream, concurrent request_id correlation.
- `uv run pytest tests/worker -q` → **39 passed**.
- `ruff` clean on changed files; `basedpyright` clean on authored files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)