### PR TITLE
fix(docker): probe the worker with a real WebSocket handshake in healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,10 +99,12 @@ RUN uv pip install \
 # Expose the worker's WebSocket port
 EXPOSE 7777
 
-# Health check — the worker is a WebSocket server (no HTTP /health route),
-# so verify the port is accepting connections rather than curling an endpoint.
+# Health check — the worker is a WebSocket server (no HTTP route), so probe it
+# with a real WebSocket handshake. A raw TCP connect gets rejected mid-handshake
+# and spams the worker log with tracebacks; a proper ws:// connect that closes
+# cleanly verifies liveness without the noise. `websockets` ships with nodetool-core.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import socket; socket.create_connection(('127.0.0.1', 7777), timeout=3).close()" || exit 1
+    CMD python -c "from websockets.sync.client import connect; connect('ws://127.0.0.1:7777', open_timeout=5).close()" || exit 1
 
 # Run the NodeTool Python worker (WebSocket transport, reachable from the TS server)
 CMD ["python", "-m", "nodetool.worker", "--host", "0.0.0.0", "--port", "7777"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -44,12 +44,13 @@ services:
       MEMCACHE_PORT: ${MEMCACHE_PORT:-11211}
       CHROMA_PATH: /chroma-data
     healthcheck:
-      # The worker is a WebSocket server (no HTTP /health route) — check the port.
+      # The worker is a WebSocket server (no HTTP route) — probe with a real
+      # WebSocket handshake so a rejected raw-TCP connect doesn't spam the log.
       test:
         - CMD
         - python
         - -c
-        - import socket; socket.create_connection(('127.0.0.1', 7777), timeout=3).close()
+        - from websockets.sync.client import connect; connect('ws://127.0.0.1:7777', open_timeout=4).close()
       interval: 10s
       timeout: 5s
       retries: 6


### PR DESCRIPTION
## What

The Python worker is a pure WebSocket server (no HTTP route). The current Docker/compose healthchecks open a **raw TCP** connection (`socket.create_connection`), which the server rejects mid-handshake and logs as a `websockets InvalidMessage` traceback **on every interval** (every 30s in the Dockerfile, 10s in compose).

This probes with a real `ws://` handshake via the bundled `websockets` client, so the check verifies liveness without spamming the worker log.

```diff
- CMD python -c "import socket; socket.create_connection(('127.0.0.1', 7777), timeout=3).close()"
+ CMD python -c "from websockets.sync.client import connect; connect('ws://127.0.0.1:7777', open_timeout=5).close()"
```

## Why now

Builds on the PyPI Dockerfile merged in #917. `websockets` ships as a `nodetool-core` dependency, so this works against the published `0.7.1` image with no extra deps.

## Test plan

Verified against a fresh container (`docker run -d nodetool-core:test`): container reaches **healthy** in ~9s, healthcheck exit code 0, and **zero** tracebacks in the worker log (previously one multi-line traceback per interval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)