### PR TITLE
⚡ Bolt: [performance improvement] Explicitly cast to float32 in convert_to_float

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,7 @@
 ## 2024-05-18 - PyTorch Tensor Creation Memory Copy Optimization
 **Learning:** In PyTorch, using `torch.tensor(numpy_array)` causes a full memory copy of the array's data. For read-only applications like model inference or input conversion, this unnecessary byte-copying adds substantial memory and CPU overhead.
 **Action:** Use `torch.from_numpy(numpy_array)` instead of `torch.tensor()` to create a zero-copy, memory-efficient tensor view of the existing NumPy array data. Keep in mind this creates a shared-memory tensor, so mutations to the tensor will affect the original NumPy array.
+
+## 2025-06-10 - NumPy Implicit Float64 Conversion Bottleneck
+**Learning:** When scaling an integer numpy array by dividing by a Python integer (e.g., `a / 2**15` where `a` is `np.int16` or `np.int32`), NumPy implicitly promotes the result to `np.float64`. This doubles the memory usage and decreases computation speed compared to using `np.float32`, which is completely unnecessary when the target format only requires `np.float32`.
+**Action:** Always explicitly cast the integer array to `np.float32` and divide by a `np.float32` constant (e.g., `a.astype(np.float32) / np.float32(2**15)`) when scaling audio or image data to float format to halve memory footprint and speed up execution.

--- a/src/nodetool/media/audio/audio_helpers.py
+++ b/src/nodetool/media/audio/audio_helpers.py
@@ -22,11 +22,11 @@ def convert_to_float(audio_data: np.ndarray):
     if dtype == np.float32 or dtype == np.float64:
         return audio_data
     if dtype == np.int16:
-        return audio_data / 2**15
+        return audio_data.astype(np.float32) / np.float32(2**15)
     if dtype == np.int32:
-        return audio_data / 2**31
+        return audio_data.astype(np.float32) / np.float32(2**31)
     if dtype == np.int64:
-        return audio_data / 2**63
+        return audio_data.astype(np.float32) / np.float32(2**63)
 
     raise Exception(f"Unsupported dtype: {dtype}")
 


### PR DESCRIPTION
## What
Explicitly cast numpy arrays to `np.float32` and divide by a `np.float32` constant in `convert_to_float`.

## Why
When scaling integer numpy arrays by dividing by a Python integer (e.g., `a / 2**15` where `a` is `np.int16`), NumPy implicitly promotes the result to `np.float64`. This doubles the memory usage and decreases computation speed compared to using `np.float32`, which is completely unnecessary when the target audio format only requires `float32`. 

## Impact
Halves the memory footprint for the resulting float arrays and speeds up the conversion execution time by approximately 2x.

## Verification
- Ran the test suite via `uv run pytest tests/` which completed successfully with 0 failures, ensuring correctness and no regressions.
- Profiled execution using `timeit` in a bash session, confirming a ~2x speedup.

---
*PR created automatically by Jules for task [8733434253026088629](https://jules.google.com/task/8733434253026088629) started by @georgi*