### PR TITLE
Handle unknown msgpack extensions gracefully in worker

### DIFF
--- a/src/nodetool/worker/msgpack_codec.py
+++ b/src/nodetool/worker/msgpack_codec.py
@@ -1,0 +1,47 @@
+"""Shared msgpack decoding for the worker transports.
+
+The TypeScript server encodes some values (for example an unset/empty model
+selection) using msgpack *extension* types. The Python side has no encoder for
+those custom extensions, so a bare ``msgpack.unpackb`` leaves them as raw
+``msgpack.ExtType`` objects. Those objects then flow into node property
+assignment, where pydantic rejects them with a confusing error such as::
+
+    Error converting value for property `model`:
+    Input should be a valid string [input_value=ExtType(code=0, data=b'\\x00')]
+
+There is no meaningful Python value for an unknown extension, so we decode any
+unrecognized extension to ``None`` (treated downstream as "no value", which
+falls back to the property default). This keeps a single un-decodable sentinel
+from crashing the whole execute request.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import msgpack
+
+log = logging.getLogger(__name__)
+
+
+def _ext_hook(code: int, data: bytes) -> Any:
+    """Decode unknown msgpack extension types to ``None``.
+
+    Code ``-1`` (the standard msgpack timestamp) is left to msgpack's own
+    handling; everything else is an extension the Python worker has no decoder
+    for, so it is dropped to ``None`` rather than surfacing a raw ``ExtType``.
+    """
+    if code == -1:
+        return msgpack.ExtType(code, data)
+    log.debug("Dropping unknown msgpack extension type code=%s to None", code)
+    return None
+
+
+def decode_message(payload: bytes) -> Any:
+    """Decode a msgpack payload from a worker transport.
+
+    Uses :func:`_ext_hook` so unknown extension types become ``None`` instead
+    of raw ``ExtType`` objects.
+    """
+    return msgpack.unpackb(payload, raw=False, ext_hook=_ext_hook)

--- a/src/nodetool/worker/server.py
+++ b/src/nodetool/worker/server.py
@@ -6,6 +6,7 @@ from websockets.asyncio.server import ServerConnection
 from websockets.asyncio.server import serve as ws_serve
 from websockets.exceptions import ConnectionClosed
 
+from nodetool.worker.msgpack_codec import decode_message
 from nodetool.worker.protocol import WorkerProtocolServer
 from nodetool.worker.worker_auth import make_process_request
 
@@ -63,7 +64,7 @@ class WorkerServer:
 
         try:
             async for raw_message in websocket:
-                msg = msgpack.unpackb(raw_message, raw=False)
+                msg = decode_message(raw_message)
                 task = asyncio.create_task(self._protocol.dispatch(msg, transport))
                 tasks.add(task)
                 task.add_done_callback(tasks.discard)

--- a/src/nodetool/worker/stdio_server.py
+++ b/src/nodetool/worker/stdio_server.py
@@ -17,6 +17,7 @@ from typing import Any, Awaitable, Callable
 
 import msgpack
 
+from nodetool.worker.msgpack_codec import decode_message
 from nodetool.worker.protocol import MAX_BRIDGE_FRAME_SIZE, WorkerProtocolServer
 from nodetool.worker.stdio_stdout_guard import get_protocol_stdout_buffer
 
@@ -50,7 +51,7 @@ class StdioTransport:
         payload = await loop.run_in_executor(None, sys.stdin.buffer.read, length)
         if len(payload) < length:
             return None
-        return msgpack.unpackb(payload, raw=False)
+        return decode_message(payload)
 
     async def send(self, data: bytes) -> None:
         """Write a length-prefixed msgpack payload (thread-safe)."""

--- a/src/nodetool/workflows/base_node.py
+++ b/src/nodetool/workflows/base_node.py
@@ -1170,6 +1170,14 @@ class BaseNode(BaseModel):
             This method handles type conversion for enums, lists, and objects with 'model_validate' method.
         """
 
+        # A raw msgpack extension type means a value arrived over the wire that
+        # the worker could not decode (e.g. an unset model selection the
+        # frontend encoded with a custom extension). Treat it as "no value" so
+        # the property falls back to its default instead of failing validation
+        # with a confusing ExtType error.
+        if type(value).__name__ == "ExtType" and type(value).__module__.startswith("msgpack"):
+            value = None
+
         prop = self.find_property(name)
         if prop is None:
             if hasattr(self, name):

--- a/tests/worker/test_msgpack_codec.py
+++ b/tests/worker/test_msgpack_codec.py
@@ -1,0 +1,28 @@
+"""Tests for the worker's shared msgpack decoding (ext_hook handling)."""
+
+import msgpack
+
+from nodetool.worker.msgpack_codec import decode_message
+
+
+def test_decodes_plain_message():
+    payload = msgpack.packb({"type": "execute", "node": {"model": "whisper"}})
+    assert decode_message(payload) == {
+        "type": "execute",
+        "node": {"model": "whisper"},
+    }
+
+
+def test_unknown_extension_decodes_to_none():
+    # The frontend encodes an unset/empty value with a custom extension type
+    # (e.g. ExtType(code=0, data=b"\x00")). It must decode to None rather than
+    # surface a raw ExtType that later breaks property validation.
+    payload = msgpack.packb({"model": msgpack.ExtType(0, b"\x00")})
+    assert decode_message(payload) == {"model": None}
+
+
+def test_nested_unknown_extension_decodes_to_none():
+    payload = msgpack.packb(
+        {"properties": {"model": msgpack.ExtType(0, b"\x00"), "name": "x"}}
+    )
+    assert decode_message(payload) == {"properties": {"model": None, "name": "x"}}

--- a/tests/workflows/test_base_node.py
+++ b/tests/workflows/test_base_node.py
@@ -560,6 +560,33 @@ def test_node_assign_property_uses_from_dict_for_base_types():
     assert node.image.asset_id == "12345"
 
 
+def test_node_assign_property_ignores_msgpack_ext_type():
+    """A raw msgpack ExtType (un-decodable wire value) falls back to default.
+
+    Regression test for the Whisper node failing with:
+        Error converting value for property `model`:
+        Input should be a valid string [input_value=ExtType(code=0, data=b'\\x00')]
+    """
+    import msgpack
+
+    from nodetool.metadata.types import ImageRef
+
+    class ImageNode(BaseNode):
+        image: ImageRef = ImageRef()
+
+        async def process(self, context: ProcessingContext) -> ImageRef:
+            return self.image
+
+    node = ImageNode()
+    default = node.image
+
+    error = node.assign_property("image", msgpack.ExtType(0, b"\x00"))
+
+    # No error, and the property keeps its default instead of crashing.
+    assert error is None
+    assert node.image == default
+
+
 def test_node_from_dict_with_base_type_properties():
     """Test that node deserialization handles BaseType properties correctly"""
     node_dict = {


### PR DESCRIPTION
## Summary

The TypeScript server encodes some values (e.g., unset/empty model selections) using msgpack extension types that the Python worker cannot decode. Previously, these arrived as raw `msgpack.ExtType` objects that caused confusing validation errors downstream. This change adds graceful handling to decode unknown extensions to `None`, allowing properties to fall back to their defaults instead of crashing.

## Changes

- **New module `src/nodetool/worker/msgpack_codec.py`**: Centralized msgpack decoding with an `ext_hook` that converts unknown extension types to `None` while preserving standard msgpack timestamp handling. The `decode_message()` function replaces bare `msgpack.unpackb()` calls.

- **Updated `src/nodetool/worker/server.py`**: Use `decode_message()` instead of `msgpack.unpackb()` when processing WebSocket messages.

- **Updated `src/nodetool/worker/stdio_server.py`**: Use `decode_message()` instead of `msgpack.unpackb()` when reading stdin messages.

- **Updated `src/nodetool/workflows/base_node.py`**: Added defensive check in `assign_property()` to detect raw `msgpack.ExtType` objects and treat them as `None`, ensuring properties fall back to defaults rather than failing validation.

- **New test file `tests/worker/test_msgpack_codec.py`**: Tests for the codec's handling of plain messages, unknown extensions, and nested unknown extensions.

- **Updated `tests/workflows/test_base_node.py`**: Regression test verifying that raw `ExtType` objects in property assignment are handled gracefully without errors.

## Implementation Details

The solution uses a two-layer approach:
1. **Transport layer** (`msgpack_codec.py`): Decode unknown extensions at the point of deserialization, before they reach business logic.
2. **Property layer** (`base_node.py`): Defensive fallback that treats any remaining `ExtType` objects as `None`, preventing validation errors.

This keeps a single un-decodable sentinel from crashing the entire execute request while maintaining backward compatibility.

https://claude.ai/code/session_01X8h9FSk6JM6RJvzhvSyGs4