### PR TITLE
Add ComfyUI proxy bridge (comfy.* worker protocol)

### DIFF
--- a/.github/workflows/docker-comfy.yml
+++ b/.github/workflows/docker-comfy.yml
@@ -1,0 +1,114 @@
+# Build and push the nodetool-worker-comfy Docker image (NodeTool worker +
+# headless ComfyUI proxied via the comfy.* bridge messages) to GHCR.
+#
+# Runs on every v*.*.* tag push — in parallel with publish-wheel.yml, which
+# publishes nodetool-core to PyPI on the same tag. Since Dockerfile.comfy
+# installs nodetool-core from PyPI, this workflow waits for the version to
+# appear there before building. Manual dispatch rebuilds the image for an
+# already-published version (e.g. to bump the bundled ComfyUI).
+#
+# Tags: ghcr.io/nodetool-ai/nodetool-worker-comfy:<version> and :latest
+
+name: Build ComfyUI Worker Image
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "nodetool-core version to install (e.g. 0.7.5, must be on PyPI)"
+        required: true
+        type: string
+      comfyui_version:
+        description: "ComfyUI git tag to bundle (defaults to the pinned default)"
+        required: false
+        type: string
+
+env:
+  # Default ComfyUI release baked into the image; override via dispatch input.
+  COMFYUI_VERSION_DEFAULT: v0.3.34
+
+jobs:
+  build-docker-comfy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Resolve versions
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
+
+          COMFYUI_VERSION="${{ github.event.inputs.comfyui_version }}"
+          if [ -z "$COMFYUI_VERSION" ]; then
+            COMFYUI_VERSION="${COMFYUI_VERSION_DEFAULT}"
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag-name=v$VERSION" >> $GITHUB_OUTPUT
+          echo "comfyui-version=$COMFYUI_VERSION" >> $GITHUB_OUTPUT
+
+          echo "📋 nodetool-core: $VERSION"
+          echo "🎨 ComfyUI: $COMFYUI_VERSION"
+
+      - name: Wait for nodetool-core on PyPI
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          echo "Waiting for nodetool-core==$VERSION on PyPI..."
+          for i in $(seq 1 60); do
+            if curl -fsSL "https://pypi.org/pypi/nodetool-core/${VERSION}/json" >/dev/null 2>&1; then
+              echo "✅ nodetool-core==$VERSION is available"
+              exit 0
+            fi
+            echo "  not yet available, retrying in 30s ($i/60)"
+            sleep 30
+          done
+          echo "❌ nodetool-core==$VERSION never appeared on PyPI"
+          exit 1
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.meta.outputs.tag-name }}
+
+      # torch CUDA wheels make this image large; reclaim runner disk first.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/.ghcup
+          sudo docker image prune --all --force
+          df -h /
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.comfy
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            NODETOOL_VERSION=${{ steps.meta.outputs.version }}
+            COMFYUI_VERSION=${{ steps.meta.outputs.comfyui-version }}
+          tags: |
+            ghcr.io/nodetool-ai/nodetool-worker-comfy:${{ steps.meta.outputs.version }}
+            ghcr.io/nodetool-ai/nodetool-worker-comfy:latest
+          cache-from: type=gha,scope=comfy
+          cache-to: type=gha,mode=max,scope=comfy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 
 nodetool-core is a **Python library and node runner** for the NodeTool platform. The TypeScript server handles HTTP API, WebSocket, database, auth, agents, chat, storage, deploy, and workflow orchestration. Python remains for two roles:
 
-1. **Node runner subprocess** — TS spawns `python -m nodetool.worker`, connects via WebSocket+MessagePack for `discover`/`execute`/`cancel`/`provider.*`
+1. **Node runner subprocess** — TS spawns `python -m nodetool.worker`, connects via WebSocket+MessagePack for `discover`/`execute`/`cancel`/`provider.*`/`models.*`/`comfy.*` (the `comfy.*` messages proxy a co-located ComfyUI server — see `docs/comfy-proxy.md`)
 2. **Node system and type definitions** — `BaseNode`, `ProcessingContext`, metadata types, used by all Python node packages
 
 Cloud/API providers (OpenAI, Anthropic, Gemini, Ollama, etc.) are implemented in the TS server. Python only has local-compute providers (HuggingFace local, MLX) registered via external packages.
@@ -135,6 +135,8 @@ Storage: `create_asset`, `download_asset`, `asset_storage_url`
 | `DB_PATH` | SQLite database path | `~/.config/nodetool/nodetool.sqlite3` |
 | `FFMPEG_PATH` | Path to ffmpeg | `ffmpeg` |
 | `SECRETS_MASTER_KEY` | Master key for encrypted secrets | auto-generated |
+| `COMFYUI_URL` | ComfyUI server proxied by the worker's `comfy.*` messages | `http://127.0.0.1:8188` |
+| `COMFY_MODELS_DIR` | Model tree for `comfy.models.*` (RunPod network volume) | `/workspace/models` |
 
 ## Testing
 

--- a/Dockerfile.comfy
+++ b/Dockerfile.comfy
@@ -1,0 +1,101 @@
+# Dockerfile.comfy — ghcr.io/nodetool-ai/nodetool-worker-comfy
+#
+# NodeTool worker + headless ComfyUI in one image. The worker speaks the
+# NodeTool bridge protocol on :7777 (discover/execute/provider.*/models.*)
+# and proxies the co-located ComfyUI server via the comfy.* messages
+# (see src/nodetool/worker/comfy_handler.py). ComfyUI listens on
+# 127.0.0.1:8188 only — nothing but the worker can reach it.
+#
+# Designed for RunPod: the network volume is mounted at /workspace and holds
+# models (comfy.models.download writes there), inputs, outputs and temp files,
+# so they survive pod restarts and cold starts skip model downloads.
+#
+# Build:
+#   docker build -f Dockerfile.comfy \
+#     --build-arg NODETOOL_VERSION=0.7.5 \
+#     --build-arg COMFYUI_VERSION=v0.3.34 .
+
+FROM mambaorg/micromamba:jammy AS base
+
+# Install uv (used to install ComfyUI deps and nodetool-core into the conda base env)
+COPY --from=ghcr.io/astral-sh/uv:0.8.5 /uv /uvx /bin/
+
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    SHELL=/bin/bash \
+    LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8 \
+    PYTHON_VERSION=3.11 \
+    VIRTUAL_ENV=/opt/conda
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    build-essential \
+    git \
+    wget \
+    curl \
+    # Audio/video nodes and media helpers
+    ffmpeg \
+    libsndfile1 \
+    # OpenCV runtime deps (common in ComfyUI custom nodes)
+    libgl1 \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender1 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN micromamba install -y -n base -c conda-forge python=$PYTHON_VERSION pip && \
+    micromamba clean --all --yes
+
+ENV PATH=$VIRTUAL_ENV/bin:$PATH
+
+
+FROM base AS final
+
+# Versions to install. Override at build time:
+#   docker build -f Dockerfile.comfy \
+#     --build-arg NODETOOL_VERSION=0.7.5 --build-arg COMFYUI_VERSION=v0.3.34 .
+ARG NODETOOL_VERSION=0.7.5
+ARG COMFYUI_VERSION=v0.3.34
+
+# ComfyUI, pinned to a release tag for reproducible builds.
+RUN git clone --depth 1 --branch ${COMFYUI_VERSION} \
+        https://github.com/comfyanonymous/ComfyUI.git /opt/ComfyUI && \
+    rm -rf /opt/ComfyUI/.git
+
+# ComfyUI requirements pull in torch CUDA wheels (bundled CUDA runtime — the
+# NVIDIA container runtime on RunPod provides the driver). nodetool-core comes
+# from PyPI like the plain worker image.
+RUN uv pip install \
+        --python $VIRTUAL_ENV \
+        --index-url https://pypi.org/simple \
+        -r /opt/ComfyUI/requirements.txt \
+        "nodetool-core==${NODETOOL_VERSION}" && \
+    rm -rf /root/.cache/uv /root/.cache/pip /tmp/* /var/tmp/*
+
+COPY docker/comfy/extra_model_paths.yaml /opt/comfy/extra_model_paths.yaml
+COPY docker/comfy/start.sh /opt/comfy/start.sh
+RUN chmod +x /opt/comfy/start.sh
+
+# /workspace is the RunPod network volume mount. COMFYUI_URL points the
+# worker's comfy.* handler at the co-located server; NODETOOL_COMFY_ENABLED
+# makes worker.status advertise the comfy capability.
+ENV WORKSPACE_DIR=/workspace \
+    COMFY_MODELS_DIR=/workspace/models \
+    COMFYUI_URL=http://127.0.0.1:8188 \
+    NODETOOL_COMFY_ENABLED=1
+
+# Only the worker's WebSocket port is exposed; ComfyUI stays loopback-only.
+EXPOSE 7777
+
+# Health check — the worker is a WebSocket server (no HTTP route), so probe it
+# with a real WebSocket handshake (same rationale as the plain worker image).
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+    CMD python -c "from websockets.sync.client import connect; connect('ws://127.0.0.1:7777', open_timeout=5).close()" || exit 1
+
+CMD ["/opt/comfy/start.sh"]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,104 @@ Python Worker (this repo)
     └── Media processing (ffmpeg, PIL, numpy)
 ```
 
+## Worker Protocol
+
+The worker speaks a msgpack message protocol to the TS server (bridge protocol **v3**, `nodetool.worker.BRIDGE_PROTOCOL_VERSION`). Two transports carry the same messages:
+
+- **WebSocket** (default): `python -m nodetool.worker --host 0.0.0.0 --port 7777`. Each message is one binary msgpack frame. On startup the worker prints `NODETOOL_WORKER_PORT=<port>` to stdout (the only thing on stdout). If `NODETOOL_WORKER_TOKEN` is set, the opening handshake must carry `Authorization: Bearer <token>` (constant-time compare, rejected with 401 before any frame); unset means open, for local/dev use.
+- **stdio** (`--stdio`): same msgpack payloads with 4-byte big-endian length-prefixed framing over stdin/stdout, for parent processes that spawn the worker directly.
+
+Frames are capped at 256 MiB by default (`NODETOOL_BRIDGE_MAX_FRAME_SIZE`). Unknown msgpack extension types decode to `None` rather than erroring. Binary data (images, audio, model files) travels as native msgpack `bin` values — there is no base64.
+
+### Message envelope
+
+Every message is a map: `{"type": string, "request_id": string, "data": object}`. Requests carry a unique `request_id`; every frame the worker sends back echoes it, so concurrent requests multiplex safely over one connection. The worker replies with frames of type:
+
+| Frame type | Meaning |
+|------------|---------|
+| `result` | Terminal success — one per request |
+| `error` | Terminal failure — `data: {error, traceback}` |
+| `progress` | Streamed progress updates (zero or more, before the terminal frame) |
+| `chunk` | Streamed payload items (streaming execution, token streams, TTS audio) |
+
+`cancel` (`{type: "cancel", request_id: <id-of-in-flight-request>}`) requests cooperative cancellation of a running request; it produces no reply of its own — the cancelled request emits its own terminal frame.
+
+### Core messages
+
+| Request | Data | Response |
+|---------|------|----------|
+| `discover` | – | `discover` frame: `{protocol_version, nodes: [metadata], load_errors}` |
+| `worker.status` | – | `{protocol_version, node_count, provider_count, namespaces, load_errors, transport, max_frame_size, comfy: {enabled, url}}` |
+| `execute` | `{node_type, fields, secrets, blobs}` | `progress`\* then `result {outputs, blobs}` |
+| `execute.stream` | same as `execute` | each yielded item as `chunk {outputs, blobs}`; empty `result` terminates the stream |
+| `cancel` | – (uses `request_id`) | none |
+
+For `execute`, `fields` are the node's property values; `blobs` maps field names to binary inputs (written to temp files and resolved as asset refs); `secrets` are forwarded to the node's context. Binary outputs come back in the result's `blobs` map.
+
+### Provider messages (`provider.*`)
+
+Local-compute providers (HuggingFace local, MLX) registered in this Python environment:
+
+| Request | Data | Response |
+|---------|------|----------|
+| `provider.list` | – | `{providers: [{id, capabilities, required_secrets}]}` |
+| `provider.models` | `{provider, model_type}` | `{models}` |
+| `provider.generate` | `{provider, model, messages, tools?, max_tokens?, temperature?, top_p?, response_format?}` | `{message}` |
+| `provider.stream` | same as `provider.generate` | `chunk {type: "chunk", content, done}` / `chunk {type: "tool_call", id, name, args}`, then `result {done: true}` |
+| `provider.text_to_image` | `{provider, params}` | `result {blobs: {image}}` |
+| `provider.image_to_image` | `{provider, image, params}` | `result {blobs: {image}}` |
+| `provider.text_to_video` | `{provider, model, prompt, ...}` | `result {blobs: {video}}` |
+| `provider.text_to_audio` | `{provider, model, prompt, ...}` | `result {blobs: {audio}}` |
+| `provider.tts` | `{provider, model, text, voice?, speed?}` | `chunk {blobs: {audio}}`\* then `result {done: true}` |
+| `provider.asr` | `{provider, model, audio, language?, ...}` | `{text, ...}` |
+| `provider.embedding` | `{provider, model, text, dimensions?}` | `{embeddings}` |
+
+`provider.stream` and `provider.tts` honor `cancel`.
+
+### Model cache messages (`models.*`)
+
+HuggingFace cache management on the worker's `HF_HOME`:
+
+| Request | Data | Response |
+|---------|------|----------|
+| `models.list_cached` | – | `{models: UnifiedModel[]}` |
+| `models.download` | `{repo_id, path?, allow_patterns?, ignore_patterns?}` | `progress {status: start/progress/completed/cancelled/error, downloaded_bytes, total_bytes, ...}`\* then `result {repo_id, status}` |
+| `models.delete` | `{repo_id}` | `{deleted}` |
+
+Tokens are resolved on the worker; client-supplied tokens are ignored. Downloads honor `cancel`.
+
+### ComfyUI proxy messages (`comfy.*`)
+
+When a ComfyUI server is co-located (`COMFYUI_URL`, advertised via `worker.status.comfy`), the worker proxies it — see [docs/comfy-proxy.md](docs/comfy-proxy.md) for frame-level shapes:
+
+| Request | Data | Response |
+|---------|------|----------|
+| `comfy.execute` | `{workflow, blobs?, previews?, include_temp?, timeout?}` | lifecycle `progress` frames (`queued`/`executing`/`progress`/`node_output`/`preview`/…), then `result {prompt_id, status, outputs, blobs}` |
+| `comfy.queue` | – | `{queue_running, queue_pending}` |
+| `comfy.interrupt` | – | `{interrupted}` |
+| `comfy.cancel` | `{prompt_id}` | `{cancelled, prompt_id}` |
+| `comfy.upload` | `{data, filename?, kind?, subfolder?, overwrite?, original_ref?}` | ComfyUI upload response `{name, subfolder, type}` |
+| `comfy.view` | `{filename, subfolder?, type?}` | `{filename, content_type, data}` |
+| `comfy.object_info` | `{node_class?}` | `{object_info}` |
+| `comfy.system_stats` | – | VRAM/RAM/device info |
+| `comfy.free` | `{unload_models?, free_memory?}` | `{freed}` |
+| `comfy.status` | – | `{enabled, url, reachable, system_stats?, queue_remaining?}` |
+| `comfy.models.download` | `{folder, filename?, force?, source: {type: huggingface/url, ...}}` | `progress`\* then `result {status, path, size_bytes}` |
+| `comfy.models.list` | – | `{models_dir, models: [{folder, filename, size_bytes}]}` |
+| `comfy.models.delete` | `{folder, filename}` | `{deleted}` |
+
+Input blobs are uploaded to ComfyUI and spliced into the workflow wherever a `"blob:<key>"` placeholder appears; file outputs are fetched from ComfyUI and returned as result blobs. `comfy.execute` and `comfy.models.download` honor `cancel`.
+
+### Protocol version history
+
+| Version | Changes |
+|---------|---------|
+| 1 | Initial protocol: `discover`/`execute`/`cancel` + `provider.*`, msgpack framing |
+| 2 | `models.*` HuggingFace cache management |
+| 3 | `comfy.*` ComfyUI proxy + `comfy` capability block in `worker.status` |
+
+The TS bridge declares the minimum version it can speak; a worker reporting a lower `protocol_version` in `discover`/`worker.status` is rejected.
+
 ## External Node Packages
 
 - **nodetool-huggingface** — HuggingFace model integrations + local provider

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Every message is a map: `{"type": string, "request_id": string, "data": object}`
 | `error` | Terminal failure — `data: {error, traceback}` |
 | `progress` | Streamed progress updates (zero or more, before the terminal frame) |
 | `chunk` | Streamed payload items (streaming execution, token streams, TTS audio) |
+| `comfy.event` | ComfyUI execution events streamed during `comfy.execute` — `data: {event, prompt_id, ...}` |
 
 `cancel` (`{type: "cancel", request_id: <id-of-in-flight-request>}`) requests cooperative cancellation of a running request; it produces no reply of its own — the cancelled request emits its own terminal frame.
 
@@ -142,7 +143,7 @@ When a ComfyUI server is co-located (`COMFYUI_URL`, advertised via `worker.statu
 
 | Request | Data | Response |
 |---------|------|----------|
-| `comfy.execute` | `{workflow, blobs?, previews?, include_temp?, timeout?}` | lifecycle `progress` frames (`queued`/`executing`/`progress`/`node_output`/`preview`/…), then `result {prompt_id, status, outputs, blobs}` |
+| `comfy.execute` | `{workflow, blobs?, previews?, include_temp?, timeout?}` | `comfy.event` frames (`queued`/`executing`/`progress`/`node_output`/`preview`/…), then `result {prompt_id, status, outputs, blobs}` |
 | `comfy.queue` | – | `{queue_running, queue_pending}` |
 | `comfy.interrupt` | – | `{interrupted}` |
 | `comfy.cancel` | `{prompt_id}` | `{cancelled, prompt_id}` |
@@ -164,7 +165,7 @@ Input blobs are uploaded to ComfyUI and spliced into the workflow wherever a `"b
 |---------|---------|
 | 1 | Initial protocol: `discover`/`execute`/`cancel` + `provider.*`, msgpack framing |
 | 2 | `models.*` HuggingFace cache management |
-| 3 | `comfy.*` ComfyUI proxy + `comfy` capability block in `worker.status` |
+| 3 | `comfy.*` ComfyUI proxy, `comfy.event` frame type, `comfy` capability block in `worker.status` |
 
 The TS bridge declares the minimum version it can speak; a worker reporting a lower `protocol_version` in `discover`/`worker.status` is rejected.
 

--- a/docker/comfy/extra_model_paths.yaml
+++ b/docker/comfy/extra_model_paths.yaml
@@ -1,0 +1,27 @@
+# Model folders on the persistent volume (RunPod network volume at /workspace).
+# is_default makes ComfyUI save downloaded/derived models there too, so the
+# container filesystem stays disposable. comfy.models.download writes into the
+# same tree (COMFY_MODELS_DIR=/workspace/models).
+nodetool:
+  base_path: /workspace
+  is_default: true
+  checkpoints: models/checkpoints
+  clip: models/clip
+  clip_vision: models/clip_vision
+  configs: models/configs
+  controlnet: models/controlnet
+  diffusers: models/diffusers
+  diffusion_models: models/diffusion_models
+  embeddings: models/embeddings
+  gligen: models/gligen
+  hypernetworks: models/hypernetworks
+  ipadapter: models/ipadapter
+  instantid: models/instantid
+  loras: models/loras
+  photomaker: models/photomaker
+  style_models: models/style_models
+  text_encoders: models/text_encoders
+  unet: models/unet
+  upscale_models: models/upscale_models
+  vae: models/vae
+  vae_approx: models/vae_approx

--- a/docker/comfy/start.sh
+++ b/docker/comfy/start.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Entrypoint for the nodetool-worker-comfy image: launch headless ComfyUI on
+# loopback, wait until its HTTP API answers, then launch the NodeTool worker
+# that proxies it. If either process dies the container exits so the
+# orchestrator (RunPod) restarts it.
+set -uo pipefail
+
+COMFY_HOST="${COMFY_HOST:-127.0.0.1}"
+COMFY_PORT="${COMFY_PORT:-8188}"
+WORKSPACE_DIR="${WORKSPACE_DIR:-/workspace}"
+WORKER_HOST="${NODETOOL_WORKER_HOST:-0.0.0.0}"
+WORKER_PORT="${NODETOOL_WORKER_PORT:-7777}"
+
+export COMFYUI_URL="${COMFYUI_URL:-http://${COMFY_HOST}:${COMFY_PORT}}"
+export COMFY_MODELS_DIR="${COMFY_MODELS_DIR:-${WORKSPACE_DIR}/models}"
+export NODETOOL_COMFY_ENABLED="${NODETOOL_COMFY_ENABLED:-1}"
+
+# Persist models, inputs, outputs and temp files on the network volume.
+mkdir -p \
+  "${COMFY_MODELS_DIR}" \
+  "${WORKSPACE_DIR}/input" \
+  "${WORKSPACE_DIR}/output" \
+  "${WORKSPACE_DIR}/temp"
+
+echo "[nodetool-worker-comfy] starting ComfyUI on ${COMFY_HOST}:${COMFY_PORT}" >&2
+# ${COMFY_ARGS} is intentionally unquoted: it carries extra CLI flags
+# (e.g. "--lowvram --disable-smart-memory").
+# shellcheck disable=SC2086
+python /opt/ComfyUI/main.py \
+  --listen "${COMFY_HOST}" \
+  --port "${COMFY_PORT}" \
+  --extra-model-paths-config /opt/comfy/extra_model_paths.yaml \
+  --input-directory "${WORKSPACE_DIR}/input" \
+  --output-directory "${WORKSPACE_DIR}/output" \
+  --temp-directory "${WORKSPACE_DIR}/temp" \
+  ${COMFY_ARGS:-} &
+COMFY_PID=$!
+
+# Wait for the ComfyUI HTTP API before starting the worker so the first
+# comfy.* message never races the server boot (model scans can take a while).
+STARTUP_TIMEOUT="${COMFY_STARTUP_TIMEOUT:-300}"
+for _ in $(seq 1 "${STARTUP_TIMEOUT}"); do
+  if ! kill -0 "${COMFY_PID}" 2>/dev/null; then
+    echo "[nodetool-worker-comfy] ComfyUI exited during startup" >&2
+    exit 1
+  fi
+  if curl -sf "http://127.0.0.1:${COMFY_PORT}/system_stats" >/dev/null 2>&1; then
+    echo "[nodetool-worker-comfy] ComfyUI is up" >&2
+    break
+  fi
+  sleep 1
+done
+
+if ! curl -sf "http://127.0.0.1:${COMFY_PORT}/system_stats" >/dev/null 2>&1; then
+  echo "[nodetool-worker-comfy] ComfyUI did not come up within ${STARTUP_TIMEOUT}s" >&2
+  kill -TERM "${COMFY_PID}" 2>/dev/null
+  exit 1
+fi
+
+echo "[nodetool-worker-comfy] starting NodeTool worker on ${WORKER_HOST}:${WORKER_PORT}" >&2
+python -m nodetool.worker --host "${WORKER_HOST}" --port "${WORKER_PORT}" &
+WORKER_PID=$!
+
+shutdown() {
+  kill -TERM "${COMFY_PID}" "${WORKER_PID}" 2>/dev/null
+}
+trap shutdown TERM INT
+
+# Exit as soon as either process dies.
+wait -n "${COMFY_PID}" "${WORKER_PID}"
+EXIT_CODE=$?
+shutdown
+wait
+exit "${EXIT_CODE}"

--- a/docs/comfy-proxy.md
+++ b/docs/comfy-proxy.md
@@ -52,10 +52,13 @@ unique `nodetool_*` filename (extension sniffed from the bytes), and every
 string value `"blob:<key>"` in the workflow is replaced with the uploaded
 filename before `POST /prompt`.
 
-Progress frames (`type: "progress"`), in submission order:
+Execution events stream back as dedicated `comfy.event` frames
+(`{"type": "comfy.event", "request_id": ..., "data": {"event": ..., "prompt_id": ..., ...}}`) —
+a separate frame type from `progress`, whose generic `{progress, total, message}`
+shape doesn't fit ComfyUI's lifecycle. In submission order:
 
-| `status` | Fields | Source |
-|----------|--------|--------|
+| `event` | Fields | Source |
+|---------|--------|--------|
 | `queued` | `prompt_id`, `queue_position` | `POST /prompt` response |
 | `queue` | `queue_remaining` | ws `status` event |
 | `started` / `cached` | `nodes` (cached) | ws `execution_start` / `execution_cached` |

--- a/docs/comfy-proxy.md
+++ b/docs/comfy-proxy.md
@@ -1,0 +1,154 @@
+# ComfyUI Proxy (comfy.* worker protocol)
+
+The worker can front a co-located ComfyUI server and expose it through the
+NodeTool bridge protocol (protocol version 3+). The TS server talks msgpack to
+the worker on `:7777`; the worker talks HTTP + WebSocket to ComfyUI on
+loopback. ComfyUI is never exposed directly.
+
+```
+TS server ──ws/msgpack──▶ nodetool worker ──http/ws──▶ ComfyUI (127.0.0.1:8188)
+                              │
+                              └─▶ /workspace (RunPod network volume: models, input, output)
+```
+
+Handler: `src/nodetool/worker/comfy_handler.py`. Image: `Dockerfile.comfy` →
+`ghcr.io/nodetool-ai/nodetool-worker-comfy` (built by
+`.github/workflows/docker-comfy.yml`).
+
+## Environment variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `COMFYUI_URL` | Base URL of the ComfyUI server to proxy | `http://127.0.0.1:8188` |
+| `COMFY_MODELS_DIR` | Model tree for `comfy.models.*` | `/workspace/models` |
+| `NODETOOL_COMFY_ENABLED` | Advertise the comfy capability in `worker.status` | implied by `COMFYUI_URL` |
+| `COMFY_ARGS` | Extra ComfyUI CLI flags (image entrypoint only) | – |
+| `COMFY_STARTUP_TIMEOUT` | Seconds to wait for ComfyUI boot (image entrypoint only) | `300` |
+
+`worker.status` includes a `comfy: {enabled, url}` block so the TS server can
+route ComfyUI jobs only to workers that proxy one.
+
+## comfy.execute
+
+Runs a workflow (ComfyUI **API-format** prompt JSON) with managed inputs and
+outputs. One request = one ComfyUI `client_id` + one events WebSocket, so
+concurrent prompts never leak events across bridge requests; routing stays
+keyed on the protocol `request_id`.
+
+Request `data`:
+
+```jsonc
+{
+  "workflow": { "1": { "class_type": "LoadImage", "inputs": { "image": "blob:photo" } }, ... },
+  "blobs": { "photo": "<bytes>" },   // binary inputs, msgpack bin
+  "previews": false,                  // forward binary preview frames
+  "include_temp": false,              // also fetch type=temp outputs (previews)
+  "timeout": 600                      // optional wall-clock seconds
+}
+```
+
+Input management: each blob is uploaded via `POST /upload/image` under a
+unique `nodetool_*` filename (extension sniffed from the bytes), and every
+string value `"blob:<key>"` in the workflow is replaced with the uploaded
+filename before `POST /prompt`.
+
+Progress frames (`type: "progress"`), in submission order:
+
+| `status` | Fields | Source |
+|----------|--------|--------|
+| `queued` | `prompt_id`, `queue_position` | `POST /prompt` response |
+| `queue` | `queue_remaining` | ws `status` event |
+| `started` / `cached` | `nodes` (cached) | ws `execution_start` / `execution_cached` |
+| `executing` | `node` | ws `executing` |
+| `progress` | `node`, `value`, `max` | ws `progress` |
+| `node_output` | `node`, `outputs` (filename metadata) | ws `executed` |
+| `preview` | `format` (`jpeg`/`png`), `image` (bytes) | ws binary frames (opt-in) |
+| `completed` / `cancelled` | `prompt_id` | terminal |
+
+Result frame `data`:
+
+```jsonc
+{
+  "prompt_id": "...",
+  "status": "completed",            // or "cancelled"
+  "outputs": {
+    "9": { "images": [ { "filename": "ComfyUI_0001.png", "subfolder": "", "type": "output",
+                          "content_type": "image/png", "blob": "9/images/0/ComfyUI_0001.png" } ] }
+  },
+  "blobs": { "9/images/0/ComfyUI_0001.png": "<bytes>" }
+}
+```
+
+Output management: after the events socket reports completion, the handler
+reads `GET /history/{prompt_id}` (with retries — history writes lag the
+socket) and fetches every file output via `GET /view`, returning the bytes as
+result blobs. Non-file outputs (e.g. text) pass through as-is. `type: "temp"`
+entries (preview nodes) keep their metadata but are only fetched with
+`include_temp`. If the socket drops mid-run the handler falls back to polling
+`/history` + `/queue`.
+
+Cancellation uses the standard protocol `cancel` message: the handler deletes
+the prompt from the pending queue (`POST /queue {"delete": [id]}`) and only
+calls `POST /interrupt` if `GET /queue` shows *our* prompt running —
+interrupting blindly would kill another client's job.
+
+Errors (workflow validation from `POST /prompt`, `execution_error` events,
+timeouts) surface as protocol `error` frames.
+
+## Other comfy.* messages
+
+| Message | Data | Result |
+|---------|------|--------|
+| `comfy.status` | – | `{enabled, url, reachable, system_stats, queue_remaining}` |
+| `comfy.queue` | – | `{queue_running, queue_pending}` (`GET /queue`) |
+| `comfy.interrupt` | – | `{interrupted}` (`POST /interrupt`) |
+| `comfy.cancel` | `prompt_id` | `{cancelled}` — queue-delete + guarded interrupt |
+| `comfy.upload` | `data` (bytes), `filename?`, `kind` (`image`/`mask`), `subfolder?`, `overwrite?`, `original_ref?` | ComfyUI upload response `{name, subfolder, type}` |
+| `comfy.view` | `filename`, `subfolder?`, `type?` | `{filename, content_type, data}` |
+| `comfy.object_info` | `node_class?` | `{object_info}` — node catalog |
+| `comfy.system_stats` | – | VRAM/RAM/device info |
+| `comfy.free` | `unload_models?`, `free_memory?` | `{freed}` — unload models without a cold start |
+
+## Model volume management (comfy.models.*)
+
+Models live under `COMFY_MODELS_DIR` (`/workspace/models` — the RunPod network
+volume), which the bundled `extra_model_paths.yaml` points ComfyUI at, so
+downloads survive pod restarts.
+
+`comfy.models.download`:
+
+```jsonc
+{
+  "folder": "checkpoints",           // ComfyUI folder, or a nodetool type name
+                                      // like "comfy.checkpoint_file" (mapped via
+                                      // comfy_model_to_folder)
+  "filename": "sd_xl_base_1.0.safetensors",  // optional; defaults to source basename
+  "force": false,                     // re-download even if present
+  "source": { "type": "huggingface", "repo_id": "org/repo", "path": "file.safetensors", "revision": "main" }
+  // or       { "type": "url", "url": "https://..." }
+}
+```
+
+Emits `start`/`progress`/`completed` (or `cancelled`/`error`) progress frames
+with `downloaded_bytes`/`total_bytes`, mirroring `models.download`. Downloads
+stream to a `.part` file and rename atomically; an existing file
+short-circuits with `status: "exists"` (no network). HuggingFace auth uses the
+worker-side token — client-supplied tokens are ignored. Paths are validated
+against traversal out of the models dir. Cancellable via the protocol `cancel`
+message.
+
+`comfy.models.list` → `{models_dir, models: [{folder, filename, size_bytes}]}`.
+`comfy.models.delete` `{folder, filename}` → `{deleted}`.
+
+## The nodetool-worker-comfy image
+
+`Dockerfile.comfy` bundles ComfyUI (pinned via `COMFYUI_VERSION` build-arg)
+and nodetool-core (from PyPI, `NODETOOL_VERSION` build-arg).
+`docker/comfy/start.sh` boots ComfyUI on loopback, waits for its HTTP API,
+then starts the worker on `0.0.0.0:7777`; if either process dies the container
+exits so the orchestrator restarts it. Only `:7777` is exposed.
+
+The GitHub workflow `docker-comfy.yml` builds and pushes
+`ghcr.io/nodetool-ai/nodetool-worker-comfy:<version>` on every release tag
+(waiting for the matching nodetool-core on PyPI first) and supports manual
+dispatch to rebuild with a different ComfyUI version.

--- a/src/nodetool/worker/__init__.py
+++ b/src/nodetool/worker/__init__.py
@@ -12,6 +12,11 @@ History:
       discover/execute/result/error/chunk/progress + provider.* messages).
   2 - Added models.* messages (models.list_cached / models.download /
       models.delete) for worker-side HuggingFace cache management.
+  3 - Added comfy.* messages (ComfyUI proxy: comfy.execute /
+      comfy.queue / comfy.interrupt / comfy.cancel / comfy.upload /
+      comfy.view / comfy.object_info / comfy.system_stats / comfy.free /
+      comfy.status + comfy.models.* volume management) and the `comfy`
+      capability block in worker.status.
 """
 
-BRIDGE_PROTOCOL_VERSION = 2
+BRIDGE_PROTOCOL_VERSION = 3

--- a/src/nodetool/worker/__init__.py
+++ b/src/nodetool/worker/__init__.py
@@ -15,8 +15,10 @@ History:
   3 - Added comfy.* messages (ComfyUI proxy: comfy.execute /
       comfy.queue / comfy.interrupt / comfy.cancel / comfy.upload /
       comfy.view / comfy.object_info / comfy.system_stats / comfy.free /
-      comfy.status + comfy.models.* volume management) and the `comfy`
-      capability block in worker.status.
+      comfy.status + comfy.models.* volume management), the `comfy`
+      capability block in worker.status, and the `comfy.event` frame
+      type carrying streamed ComfyUI execution events during
+      comfy.execute.
 """
 
 BRIDGE_PROTOCOL_VERSION = 3

--- a/src/nodetool/worker/comfy_handler.py
+++ b/src/nodetool/worker/comfy_handler.py
@@ -7,9 +7,10 @@ worker protocol so the TS server never talks to ComfyUI directly:
 - ``comfy.execute``      — submit a workflow (API-format prompt JSON) with clean
   input/output management: input blobs are uploaded via ``POST /upload/image``
   and spliced into the workflow (``"blob:<key>"`` placeholders), execution
-  events stream back as ``progress`` frames over the prompt's own
-  ``client_id``-scoped WebSocket, and file outputs from ``GET /history`` are
-  fetched via ``GET /view`` and returned as binary blobs in the result frame.
+  events stream back as dedicated ``comfy.event`` frames (``{event, prompt_id,
+  ...}``) over the prompt's own ``client_id``-scoped WebSocket, and file
+  outputs from ``GET /history`` are fetched via ``GET /view`` and returned as
+  binary blobs in the result frame.
 - ``comfy.queue`` / ``comfy.interrupt`` / ``comfy.cancel`` — queue introspection
   and cancellation (delete pending, interrupt running).
 - ``comfy.upload`` / ``comfy.view`` — stage inputs / fetch files standalone.
@@ -405,7 +406,7 @@ async def _handle_execute(
     data: dict[str, Any],
     request_id: str | None,
     cancel_flags: dict[str, asyncio.Event],
-    send_progress: Callable,
+    send_event: Callable,
     send_result: Callable,
 ) -> None:
     workflow = data.get("workflow")
@@ -438,8 +439,8 @@ async def _handle_execute(
                 if not prompt_id:
                     raise ComfyError(f"ComfyUI POST /prompt returned no prompt_id: {submit}")
 
-                await send_progress(request_id, {
-                    "status": "queued",
+                await send_event(request_id, {
+                    "event": "queued",
                     "prompt_id": prompt_id,
                     "queue_position": submit.get("number"),
                 })
@@ -452,11 +453,11 @@ async def _handle_execute(
                     cancel_event=cancel_event,
                     deadline=deadline,
                     forward_previews=forward_previews,
-                    send_progress=send_progress,
+                    send_event=send_event,
                 )
 
             if status == "cancelled":
-                await send_progress(request_id, {"status": "cancelled", "prompt_id": prompt_id})
+                await send_event(request_id, {"event": "cancelled", "prompt_id": prompt_id})
                 await send_result(request_id, {"prompt_id": prompt_id, "status": "cancelled"})
                 return
 
@@ -468,7 +469,7 @@ async def _handle_execute(
             outputs, output_blobs = await _collect_outputs(
                 client, entry.get("outputs", {}) or {}, include_temp=include_temp
             )
-            await send_progress(request_id, {"status": "completed", "prompt_id": prompt_id})
+            await send_event(request_id, {"event": "completed", "prompt_id": prompt_id})
             await send_result(request_id, {
                 "prompt_id": prompt_id,
                 "status": "completed",
@@ -489,7 +490,7 @@ async def _stream_events(
     cancel_event: asyncio.Event,
     deadline: float | None,
     forward_previews: bool,
-    send_progress: Callable,
+    send_event: Callable,
 ) -> str:
     """Forward execution events until the prompt completes.
 
@@ -533,38 +534,38 @@ async def _stream_events(
                         event_data.get("status", {}).get("exec_info", {}).get("queue_remaining")
                     )
                     if remaining is not None:
-                        await send_progress(request_id, {
-                            "status": "queue",
+                        await send_event(request_id, {
+                            "event": "queue",
                             "prompt_id": prompt_id,
                             "queue_remaining": remaining,
                         })
                 elif event_type == "execution_start" and event_prompt == prompt_id:
-                    await send_progress(request_id, {"status": "started", "prompt_id": prompt_id})
+                    await send_event(request_id, {"event": "started", "prompt_id": prompt_id})
                 elif event_type == "execution_cached" and event_prompt == prompt_id:
-                    await send_progress(request_id, {
-                        "status": "cached",
+                    await send_event(request_id, {
+                        "event": "cached",
                         "prompt_id": prompt_id,
                         "nodes": event_data.get("nodes", []),
                     })
                 elif event_type == "executing" and event_prompt == prompt_id:
                     if event_data.get("node") is None:
                         return "completed"
-                    await send_progress(request_id, {
-                        "status": "executing",
+                    await send_event(request_id, {
+                        "event": "executing",
                         "prompt_id": prompt_id,
                         "node": event_data.get("node"),
                     })
                 elif event_type == "progress":
-                    await send_progress(request_id, {
-                        "status": "progress",
+                    await send_event(request_id, {
+                        "event": "progress",
                         "prompt_id": prompt_id,
                         "node": event_data.get("node"),
                         "value": event_data.get("value"),
                         "max": event_data.get("max"),
                     })
                 elif event_type == "executed" and event_prompt == prompt_id:
-                    await send_progress(request_id, {
-                        "status": "node_output",
+                    await send_event(request_id, {
+                        "event": "node_output",
                         "prompt_id": prompt_id,
                         "node": event_data.get("node"),
                         "outputs": event_data.get("output"),
@@ -586,8 +587,8 @@ async def _stream_events(
                 if event_code != _BINARY_EVENT_PREVIEW_IMAGE:
                     continue
                 image_format = struct.unpack(">I", msg.data[4:8])[0]
-                await send_progress(request_id, {
-                    "status": "preview",
+                await send_event(request_id, {
+                    "event": "preview",
                     "prompt_id": prompt_id,
                     "format": _PREVIEW_FORMATS.get(image_format, "unknown"),
                     "image": msg.data[8:],
@@ -838,9 +839,16 @@ async def handle_comfy_message(
     async def send_progress(rid: str | None, d: dict) -> None:
         await transport.send_msg({"type": "progress", "request_id": rid, "data": d})
 
+    async def send_event(rid: str | None, d: dict) -> None:
+        # ComfyUI execution events get their own frame type: their shape
+        # ({event, prompt_id, ...}) is nothing like the generic progress
+        # frames ({progress, total, message}), so overloading `progress`
+        # would force every consumer to sniff the payload.
+        await transport.send_msg({"type": "comfy.event", "request_id": rid, "data": d})
+
     try:
         if msg_type == "comfy.execute":
-            await _handle_execute(data, request_id, cancel_flags, send_progress, send_result)
+            await _handle_execute(data, request_id, cancel_flags, send_event, send_result)
 
         elif msg_type == "comfy.status":
             info = get_comfy_info()

--- a/src/nodetool/worker/comfy_handler.py
+++ b/src/nodetool/worker/comfy_handler.py
@@ -1,0 +1,940 @@
+"""Handle comfy.* bridge messages: proxy a co-located ComfyUI server.
+
+The worker fronts a headless ComfyUI instance (same container or host,
+``COMFYUI_URL``, default ``http://127.0.0.1:8188``) and exposes it through the
+worker protocol so the TS server never talks to ComfyUI directly:
+
+- ``comfy.execute``      — submit a workflow (API-format prompt JSON) with clean
+  input/output management: input blobs are uploaded via ``POST /upload/image``
+  and spliced into the workflow (``"blob:<key>"`` placeholders), execution
+  events stream back as ``progress`` frames over the prompt's own
+  ``client_id``-scoped WebSocket, and file outputs from ``GET /history`` are
+  fetched via ``GET /view`` and returned as binary blobs in the result frame.
+- ``comfy.queue`` / ``comfy.interrupt`` / ``comfy.cancel`` — queue introspection
+  and cancellation (delete pending, interrupt running).
+- ``comfy.upload`` / ``comfy.view`` — stage inputs / fetch files standalone.
+- ``comfy.object_info`` / ``comfy.system_stats`` / ``comfy.free`` /
+  ``comfy.status`` — node catalog, health, VRAM management.
+- ``comfy.models.download`` / ``comfy.models.list`` / ``comfy.models.delete`` —
+  manage model files on the persistent volume (``COMFY_MODELS_DIR``, default
+  ``/workspace/models`` — the RunPod network volume mount), downloading from
+  HuggingFace or a direct URL with streamed progress and cancellation.
+
+Mirrors ``model_handler.handle_models_message``: transport-agnostic, it only
+needs a transport exposing an async ``send_msg``, so the same code path serves
+both the WebSocket and stdio workers. Each ``comfy.execute`` gets its own
+ComfyUI ``client_id`` and WebSocket connection, so concurrent prompts from
+different bridge requests never leak events into each other — routing back to
+the caller stays keyed on the protocol-level ``request_id``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import mimetypes
+import os
+import re
+import struct
+import traceback
+import uuid
+from pathlib import Path
+from typing import Any, Callable
+
+import aiohttp
+
+DEFAULT_COMFYUI_URL = "http://127.0.0.1:8188"
+DEFAULT_MODELS_DIR = "/workspace/models"
+
+# ComfyUI binary WebSocket frames: 4-byte big-endian event type, then payload.
+# Event type 1 = preview image, whose payload is 4-byte format + image bytes.
+_BINARY_EVENT_PREVIEW_IMAGE = 1
+_PREVIEW_FORMATS = {1: "jpeg", 2: "png"}
+
+# How long to keep retrying GET /history/{prompt_id} after the WebSocket said
+# the prompt finished — history is written asynchronously and can lag briefly.
+_HISTORY_RETRIES = 40
+_HISTORY_RETRY_DELAY = 0.25
+
+_SAFE_NAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def comfy_url() -> str:
+    return os.environ.get("COMFYUI_URL", DEFAULT_COMFYUI_URL).rstrip("/")
+
+
+def comfy_enabled() -> bool:
+    """Whether this worker advertises ComfyUI proxying in worker.status.
+
+    Explicit via NODETOOL_COMFY_ENABLED, otherwise implied by COMFYUI_URL
+    being configured. comfy.* messages are always dispatched regardless —
+    they fail with a connection error when no ComfyUI is reachable.
+    """
+    flag = os.environ.get("NODETOOL_COMFY_ENABLED")
+    if flag is not None:
+        return flag.strip().lower() in ("1", "true", "yes", "on")
+    return "COMFYUI_URL" in os.environ
+
+
+def get_comfy_info() -> dict[str, Any]:
+    return {"enabled": comfy_enabled(), "url": comfy_url()}
+
+
+def models_dir() -> Path:
+    return Path(os.environ.get("COMFY_MODELS_DIR", DEFAULT_MODELS_DIR))
+
+
+class ComfyError(Exception):
+    """A ComfyUI API call failed; the message carries the response detail."""
+
+
+class ComfyClient:
+    """Thin async client for the ComfyUI HTTP + WebSocket API."""
+
+    def __init__(self, base_url: str | None = None) -> None:
+        self.base_url = (base_url or comfy_url()).rstrip("/")
+        self._session: aiohttp.ClientSession | None = None
+
+    async def __aenter__(self) -> ComfyClient:
+        # No total timeout: prompt executions and file transfers are long-lived.
+        timeout = aiohttp.ClientTimeout(total=None, sock_connect=30)
+        self._session = aiohttp.ClientSession(timeout=timeout)
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    @property
+    def session(self) -> aiohttp.ClientSession:
+        if self._session is None:
+            raise RuntimeError("ComfyClient must be used as an async context manager")
+        return self._session
+
+    async def _raise_for_status(self, resp: aiohttp.ClientResponse) -> None:
+        if resp.status < 400:
+            return
+        body = (await resp.text())[:4000]
+        raise ComfyError(f"ComfyUI {resp.method} {resp.url.path} failed with HTTP {resp.status}: {body}")
+
+    async def get_json(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        async with self.session.get(f"{self.base_url}{path}", params=params) as resp:
+            await self._raise_for_status(resp)
+            return await resp.json(content_type=None)
+
+    async def post_json(self, path: str, payload: dict[str, Any] | None = None) -> Any:
+        async with self.session.post(f"{self.base_url}{path}", json=payload or {}) as resp:
+            await self._raise_for_status(resp)
+            if resp.content_type == "application/json":
+                return await resp.json(content_type=None)
+            return await resp.text()
+
+    # --- must-have endpoints -------------------------------------------------
+
+    async def submit_prompt(self, workflow: dict[str, Any], client_id: str) -> dict[str, Any]:
+        """POST /prompt — submit an API-format workflow, returns prompt_id."""
+        return await self.post_json("/prompt", {"prompt": workflow, "client_id": client_id})
+
+    async def history(self, prompt_id: str) -> dict[str, Any]:
+        """GET /history/{prompt_id} — {} until the prompt has finished."""
+        return await self.get_json(f"/history/{prompt_id}")
+
+    async def view(self, filename: str, subfolder: str = "", type_: str = "output") -> tuple[bytes, str]:
+        """GET /view — fetch output/input/temp file bytes and content type."""
+        params = {"filename": filename, "subfolder": subfolder, "type": type_}
+        async with self.session.get(f"{self.base_url}/view", params=params) as resp:
+            await self._raise_for_status(resp)
+            content_type = resp.headers.get("Content-Type") or (
+                mimetypes.guess_type(filename)[0] or "application/octet-stream"
+            )
+            return await resp.read(), content_type
+
+    async def upload(
+        self,
+        data: bytes,
+        filename: str,
+        *,
+        kind: str = "image",
+        subfolder: str = "",
+        overwrite: bool = True,
+        original_ref: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """POST /upload/image (or /upload/mask) — stage bytes into the input dir."""
+        form = aiohttp.FormData()
+        content_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+        form.add_field("image", data, filename=filename, content_type=content_type)
+        form.add_field("overwrite", "true" if overwrite else "false")
+        if subfolder:
+            form.add_field("subfolder", subfolder)
+        if kind == "mask" and original_ref is not None:
+            form.add_field("original_ref", json.dumps(original_ref))
+        endpoint = "/upload/mask" if kind == "mask" else "/upload/image"
+        async with self.session.post(f"{self.base_url}{endpoint}", data=form) as resp:
+            await self._raise_for_status(resp)
+            return await resp.json(content_type=None)
+
+    # --- queue management ----------------------------------------------------
+
+    async def queue(self) -> dict[str, Any]:
+        """GET /queue — full running + pending queue contents."""
+        return await self.get_json("/queue")
+
+    async def queue_remaining(self) -> int:
+        """GET /prompt — lightweight queue depth (distinct from POST /prompt)."""
+        info = await self.get_json("/prompt")
+        return int(info.get("exec_info", {}).get("queue_remaining", 0))
+
+    async def delete_queued(self, prompt_ids: list[str]) -> None:
+        """POST /queue {"delete": [...]} — drop queued-but-not-running prompts."""
+        await self.post_json("/queue", {"delete": prompt_ids})
+
+    async def clear_queue(self) -> None:
+        await self.post_json("/queue", {"clear": True})
+
+    async def interrupt(self) -> None:
+        """POST /interrupt — stop the currently executing prompt."""
+        await self.post_json("/interrupt")
+
+    # --- situational ----------------------------------------------------------
+
+    async def object_info(self, node_class: str | None = None) -> dict[str, Any]:
+        path = f"/object_info/{node_class}" if node_class else "/object_info"
+        return await self.get_json(path)
+
+    async def system_stats(self) -> dict[str, Any]:
+        return await self.get_json("/system_stats")
+
+    async def free(self, *, unload_models: bool = True, free_memory: bool = False) -> None:
+        await self.post_json("/free", {"unload_models": unload_models, "free_memory": free_memory})
+
+    def ws_connect(self, client_id: str):
+        ws_base = self.base_url.replace("http://", "ws://", 1).replace("https://", "wss://", 1)
+        return self.session.ws_connect(f"{ws_base}/ws?clientId={client_id}", max_msg_size=0)
+
+
+def _is_prompt_running(queue_data: dict[str, Any], prompt_id: str) -> bool:
+    """Queue entries are [number, prompt_id, prompt, extra_data, outputs]."""
+    for entry in queue_data.get("queue_running", []):
+        if isinstance(entry, (list, tuple)) and len(entry) > 1 and entry[1] == prompt_id:
+            return True
+    return False
+
+
+async def _cancel_prompt(client: ComfyClient, prompt_id: str) -> None:
+    """Best-effort cancel: drop from the pending queue, interrupt if running.
+
+    /interrupt only stops the *active* prompt, so guard it with a queue check —
+    blindly interrupting would kill another client's job.
+    """
+    try:
+        await client.delete_queued([prompt_id])
+    except ComfyError:
+        pass
+    try:
+        if _is_prompt_running(await client.queue(), prompt_id):
+            await client.interrupt()
+    except ComfyError:
+        pass
+
+
+def _sniff_extension(data: bytes) -> str:
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return ".png"
+    if data[:3] == b"\xff\xd8\xff":
+        return ".jpg"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return ".webp"
+    if data[:4] == b"RIFF" and data[8:12] == b"WAVE":
+        return ".wav"
+    if data[:6] in (b"GIF87a", b"GIF89a"):
+        return ".gif"
+    if data[4:8] == b"ftyp":
+        return ".mp4"
+    return ".bin"
+
+
+def _patch_blob_refs(obj: Any, uploads: dict[str, str]) -> Any:
+    """Replace ``"blob:<key>"`` string values with uploaded ComfyUI filenames."""
+    if isinstance(obj, dict):
+        return {k: _patch_blob_refs(v, uploads) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_patch_blob_refs(v, uploads) for v in obj]
+    if isinstance(obj, str) and obj.startswith("blob:"):
+        key = obj[len("blob:"):]
+        if key not in uploads:
+            raise ComfyError(f"Workflow references input blob '{key}' but no such blob was sent")
+        return uploads[key]
+    return obj
+
+
+async def _upload_input_blobs(
+    client: ComfyClient,
+    blobs: dict[str, bytes],
+) -> dict[str, str]:
+    """Upload each input blob, returning blob key → ComfyUI filename reference."""
+    uploads: dict[str, str] = {}
+    for key, data in blobs.items():
+        if not isinstance(data, (bytes, bytearray)):
+            raise ComfyError(f"Input blob '{key}' must be binary, got {type(data).__name__}")
+        safe_key = _SAFE_NAME_RE.sub("_", str(key)) or "input"
+        filename = f"nodetool_{uuid.uuid4().hex[:12]}_{safe_key}{_sniff_extension(bytes(data))}"
+        info = await client.upload(bytes(data), filename)
+        name = info.get("name", filename)
+        subfolder = info.get("subfolder") or ""
+        uploads[str(key)] = f"{subfolder}/{name}" if subfolder else name
+    return uploads
+
+
+def _looks_like_file_output(values: Any) -> bool:
+    return (
+        isinstance(values, list)
+        and len(values) > 0
+        and all(isinstance(v, dict) and "filename" in v for v in values)
+    )
+
+
+async def _collect_outputs(
+    client: ComfyClient,
+    history_outputs: dict[str, Any],
+    *,
+    include_temp: bool = False,
+) -> tuple[dict[str, Any], dict[str, bytes]]:
+    """Fetch every file output via GET /view; pass scalar outputs through.
+
+    Returns (outputs, blobs) where each file entry carries a ``blob`` key into
+    the blobs dict. SaveImage-style nodes write type="output"; preview nodes
+    write type="temp" and are skipped unless include_temp is set.
+    """
+    outputs: dict[str, Any] = {}
+    blobs: dict[str, bytes] = {}
+
+    for node_id, node_outputs in history_outputs.items():
+        if not isinstance(node_outputs, dict):
+            outputs[node_id] = node_outputs
+            continue
+        node_result: dict[str, Any] = {}
+        for slot, values in node_outputs.items():
+            if not _looks_like_file_output(values):
+                node_result[slot] = values
+                continue
+            entries: list[dict[str, Any]] = []
+            for index, item in enumerate(values):
+                file_type = item.get("type", "output")
+                meta: dict[str, Any] = {
+                    "filename": item.get("filename"),
+                    "subfolder": item.get("subfolder", ""),
+                    "type": file_type,
+                }
+                if file_type == "temp" and not include_temp:
+                    entries.append(meta)
+                    continue
+                data, content_type = await client.view(
+                    item["filename"], item.get("subfolder", ""), file_type
+                )
+                blob_key = f"{node_id}/{slot}/{index}/{item['filename']}"
+                blobs[blob_key] = data
+                meta["content_type"] = content_type
+                meta["blob"] = blob_key
+                entries.append(meta)
+            node_result[slot] = entries
+        outputs[node_id] = node_result
+
+    return outputs, blobs
+
+
+async def _wait_history(client: ComfyClient, prompt_id: str) -> dict[str, Any]:
+    """Fetch the history entry, retrying briefly — history writes lag the ws."""
+    for _ in range(_HISTORY_RETRIES):
+        history = await client.history(prompt_id)
+        entry = history.get(prompt_id)
+        if entry is not None:
+            return entry
+        await asyncio.sleep(_HISTORY_RETRY_DELAY)
+    raise ComfyError(f"Prompt {prompt_id} finished but never appeared in /history")
+
+
+async def _poll_until_done(
+    client: ComfyClient,
+    prompt_id: str,
+    cancel_event: asyncio.Event,
+    deadline: float | None,
+) -> dict[str, Any]:
+    """History-polling fallback for when the WebSocket drops mid-execution."""
+    loop = asyncio.get_running_loop()
+    while True:
+        if cancel_event.is_set():
+            await _cancel_prompt(client, prompt_id)
+            return {"__cancelled__": True}
+        if deadline is not None and loop.time() > deadline:
+            await _cancel_prompt(client, prompt_id)
+            raise ComfyError(f"Prompt {prompt_id} timed out")
+        history = await client.history(prompt_id)
+        entry = history.get(prompt_id)
+        if entry is not None:
+            return entry
+        queue_data = await client.queue()
+        pending = [
+            e[1]
+            for e in queue_data.get("queue_pending", []) + queue_data.get("queue_running", [])
+            if isinstance(e, (list, tuple)) and len(e) > 1
+        ]
+        if prompt_id not in pending:
+            raise ComfyError(
+                f"Prompt {prompt_id} disappeared from the queue without a history entry "
+                "(ComfyUI may have crashed or restarted)"
+            )
+        await asyncio.sleep(1.0)
+
+
+def _extract_history_error(entry: dict[str, Any]) -> str | None:
+    status = entry.get("status") or {}
+    if status.get("status_str") == "error":
+        for event_name, event_data in status.get("messages", []) or []:
+            if event_name == "execution_error":
+                node = event_data.get("node_id") or event_data.get("node_type")
+                message = event_data.get("exception_message", "execution error")
+                return f"Execution failed at node {node}: {message}"
+        return "Execution failed"
+    return None
+
+
+async def _handle_execute(
+    data: dict[str, Any],
+    request_id: str | None,
+    cancel_flags: dict[str, asyncio.Event],
+    send_progress: Callable,
+    send_result: Callable,
+) -> None:
+    workflow = data.get("workflow")
+    if not isinstance(workflow, dict) or not workflow:
+        raise ComfyError("comfy.execute requires a non-empty 'workflow' (API-format prompt JSON)")
+
+    blobs: dict[str, bytes] = data.get("blobs") or {}
+    forward_previews = bool(data.get("previews", False))
+    include_temp = bool(data.get("include_temp", False))
+    timeout = data.get("timeout")
+
+    cancel_event = asyncio.Event()
+    if request_id:
+        cancel_flags[request_id] = cancel_event
+
+    loop = asyncio.get_running_loop()
+    deadline = (loop.time() + float(timeout)) if timeout else None
+
+    try:
+        async with ComfyClient() as client:
+            client_id = uuid.uuid4().hex
+
+            # Connect the events socket BEFORE submitting so no event is missed.
+            async with client.ws_connect(client_id) as ws:
+                uploads = await _upload_input_blobs(client, blobs)
+                patched = _patch_blob_refs(workflow, uploads)
+
+                submit = await client.submit_prompt(patched, client_id)
+                prompt_id = submit.get("prompt_id")
+                if not prompt_id:
+                    raise ComfyError(f"ComfyUI POST /prompt returned no prompt_id: {submit}")
+
+                await send_progress(request_id, {
+                    "status": "queued",
+                    "prompt_id": prompt_id,
+                    "queue_position": submit.get("number"),
+                })
+
+                status = await _stream_events(
+                    ws=ws,
+                    client=client,
+                    prompt_id=prompt_id,
+                    request_id=request_id,
+                    cancel_event=cancel_event,
+                    deadline=deadline,
+                    forward_previews=forward_previews,
+                    send_progress=send_progress,
+                )
+
+            if status == "cancelled":
+                await send_progress(request_id, {"status": "cancelled", "prompt_id": prompt_id})
+                await send_result(request_id, {"prompt_id": prompt_id, "status": "cancelled"})
+                return
+
+            entry = await _wait_history(client, prompt_id)
+            error = _extract_history_error(entry)
+            if error:
+                raise ComfyError(error)
+
+            outputs, output_blobs = await _collect_outputs(
+                client, entry.get("outputs", {}) or {}, include_temp=include_temp
+            )
+            await send_progress(request_id, {"status": "completed", "prompt_id": prompt_id})
+            await send_result(request_id, {
+                "prompt_id": prompt_id,
+                "status": "completed",
+                "outputs": outputs,
+                "blobs": output_blobs,
+            })
+    finally:
+        if request_id:
+            cancel_flags.pop(request_id, None)
+
+
+async def _stream_events(
+    *,
+    ws: Any,
+    client: ComfyClient,
+    prompt_id: str,
+    request_id: str | None,
+    cancel_event: asyncio.Event,
+    deadline: float | None,
+    forward_previews: bool,
+    send_progress: Callable,
+) -> str:
+    """Forward execution events until the prompt completes.
+
+    Returns "completed" or "cancelled"; raises ComfyError on execution errors
+    or timeout. Falls back to history polling if the socket drops.
+    """
+    loop = asyncio.get_running_loop()
+    cancel_task = asyncio.create_task(cancel_event.wait())
+    try:
+        while True:
+            recv_task = asyncio.create_task(ws.receive())
+            timeout_left = None if deadline is None else max(deadline - loop.time(), 0.0)
+            done, _pending = await asyncio.wait(
+                {recv_task, cancel_task},
+                return_when=asyncio.FIRST_COMPLETED,
+                timeout=timeout_left,
+            )
+
+            if not done:
+                recv_task.cancel()
+                await _cancel_prompt(client, prompt_id)
+                raise ComfyError(f"Prompt {prompt_id} timed out")
+
+            if cancel_task in done:
+                recv_task.cancel()
+                await _cancel_prompt(client, prompt_id)
+                return "cancelled"
+
+            msg = recv_task.result()
+
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                event = json.loads(msg.data)
+                event_type = event.get("type")
+                event_data = event.get("data") or {}
+                event_prompt = event_data.get("prompt_id")
+                if event_prompt is not None and event_prompt != prompt_id:
+                    continue
+
+                if event_type == "status":
+                    remaining = (
+                        event_data.get("status", {}).get("exec_info", {}).get("queue_remaining")
+                    )
+                    if remaining is not None:
+                        await send_progress(request_id, {
+                            "status": "queue",
+                            "prompt_id": prompt_id,
+                            "queue_remaining": remaining,
+                        })
+                elif event_type == "execution_start" and event_prompt == prompt_id:
+                    await send_progress(request_id, {"status": "started", "prompt_id": prompt_id})
+                elif event_type == "execution_cached" and event_prompt == prompt_id:
+                    await send_progress(request_id, {
+                        "status": "cached",
+                        "prompt_id": prompt_id,
+                        "nodes": event_data.get("nodes", []),
+                    })
+                elif event_type == "executing" and event_prompt == prompt_id:
+                    if event_data.get("node") is None:
+                        return "completed"
+                    await send_progress(request_id, {
+                        "status": "executing",
+                        "prompt_id": prompt_id,
+                        "node": event_data.get("node"),
+                    })
+                elif event_type == "progress":
+                    await send_progress(request_id, {
+                        "status": "progress",
+                        "prompt_id": prompt_id,
+                        "node": event_data.get("node"),
+                        "value": event_data.get("value"),
+                        "max": event_data.get("max"),
+                    })
+                elif event_type == "executed" and event_prompt == prompt_id:
+                    await send_progress(request_id, {
+                        "status": "node_output",
+                        "prompt_id": prompt_id,
+                        "node": event_data.get("node"),
+                        "outputs": event_data.get("output"),
+                    })
+                elif event_type == "execution_success" and event_prompt == prompt_id:
+                    return "completed"
+                elif event_type == "execution_interrupted" and event_prompt == prompt_id:
+                    return "cancelled"
+                elif event_type == "execution_error" and event_prompt == prompt_id:
+                    node = event_data.get("node_id") or event_data.get("node_type")
+                    message = event_data.get("exception_message", "execution error")
+                    raise ComfyError(f"Execution failed at node {node}: {message}")
+
+            elif msg.type == aiohttp.WSMsgType.BINARY:
+                # 8-byte header: 4-byte event type + 4-byte image format, then bytes.
+                if not forward_previews or len(msg.data) < 8:
+                    continue
+                event_code = struct.unpack(">I", msg.data[:4])[0]
+                if event_code != _BINARY_EVENT_PREVIEW_IMAGE:
+                    continue
+                image_format = struct.unpack(">I", msg.data[4:8])[0]
+                await send_progress(request_id, {
+                    "status": "preview",
+                    "prompt_id": prompt_id,
+                    "format": _PREVIEW_FORMATS.get(image_format, "unknown"),
+                    "image": msg.data[8:],
+                })
+
+            elif msg.type in (
+                aiohttp.WSMsgType.CLOSED,
+                aiohttp.WSMsgType.CLOSE,
+                aiohttp.WSMsgType.CLOSING,
+                aiohttp.WSMsgType.ERROR,
+            ):
+                # Socket dropped mid-run — fall back to polling /history.
+                entry = await _poll_until_done(client, prompt_id, cancel_event, deadline)
+                if entry.get("__cancelled__"):
+                    return "cancelled"
+                error = _extract_history_error(entry)
+                if error:
+                    raise ComfyError(error)
+                return "completed"
+    finally:
+        cancel_task.cancel()
+
+
+# --- model volume management --------------------------------------------------
+
+
+def _validate_relpath(*parts: str) -> Path:
+    """Join path components, rejecting traversal / absolute segments."""
+    rel = Path()
+    for part in parts:
+        if not part:
+            raise ComfyError("Empty path component")
+        candidate = part.replace("\\", "/")
+        p = Path(candidate)
+        if p.is_absolute() or any(seg in ("..", "") for seg in p.parts) or "\x00" in candidate:
+            raise ComfyError(f"Unsafe path component: {part!r}")
+        rel = rel / p
+    return rel
+
+
+def _resolve_model_path(folder: str, filename: str) -> Path:
+    from nodetool.metadata.types import comfy_model_to_folder
+
+    folder = comfy_model_to_folder(folder)
+    root = models_dir()
+    target = root / _validate_relpath(folder, filename)
+    resolved_root = root.resolve()
+    if not target.resolve().is_relative_to(resolved_root):
+        raise ComfyError(f"Path escapes the models directory: {folder}/{filename}")
+    return target
+
+
+async def _resolve_hf_token() -> str | None:
+    from nodetool.integrations.huggingface.huggingface_models import get_hf_token
+
+    return await get_hf_token()
+
+
+def _hf_file_url(repo_id: str, path: str, revision: str = "main") -> str:
+    return f"https://huggingface.co/{repo_id}/resolve/{revision}/{path}"
+
+
+async def _open_model_source(
+    session: aiohttp.ClientSession, source: dict[str, Any]
+) -> tuple[aiohttp.ClientResponse, str]:
+    """Resolve a download source to an open streaming response + default name."""
+    source_type = source.get("type")
+    headers: dict[str, str] = {}
+
+    if source_type == "huggingface":
+        repo_id = source.get("repo_id")
+        path = source.get("path")
+        if not repo_id or not path:
+            raise ComfyError("huggingface source requires 'repo_id' and 'path'")
+        url = _hf_file_url(repo_id, path, source.get("revision", "main"))
+        # The token is resolved on the worker — client-supplied tokens are ignored.
+        token = await _resolve_hf_token()
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        default_name = os.path.basename(path)
+    elif source_type == "url":
+        url = source.get("url")
+        if not url or not str(url).startswith(("http://", "https://")):
+            raise ComfyError("url source requires an http(s) 'url'")
+        default_name = os.path.basename(str(url).split("?", 1)[0]) or "model.bin"
+    else:
+        raise ComfyError(f"Unknown model source type: {source_type!r} (expected 'huggingface' or 'url')")
+
+    resp = await session.get(url, headers=headers, allow_redirects=True)
+    if resp.status >= 400:
+        body = (await resp.text())[:1000]
+        resp.release()
+        raise ComfyError(f"Model download failed with HTTP {resp.status}: {body}")
+    return resp, default_name
+
+
+async def _handle_models_download(
+    data: dict[str, Any],
+    request_id: str | None,
+    cancel_flags: dict[str, asyncio.Event],
+    send_progress: Callable,
+    send_result: Callable,
+) -> None:
+    source = data.get("source") or {}
+    folder = data.get("folder")
+    if not folder:
+        raise ComfyError("comfy.models.download requires 'folder' (e.g. 'checkpoints' or 'comfy.checkpoint_file')")
+
+    cancel_event = asyncio.Event()
+    if request_id:
+        cancel_flags[request_id] = cancel_event
+
+    def frame(status: str, downloaded: int, total: int, *, error: str | None = None) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "status": status,
+            "folder": folder,
+            "filename": data.get("filename"),
+            "downloaded_bytes": downloaded,
+            "total_bytes": total,
+        }
+        if error:
+            d["error"] = error
+        return d
+
+    async def report_exists(target: Path, filename: str) -> None:
+        existing = target.stat().st_size
+        await send_progress(request_id, frame("exists", existing, existing))
+        await send_result(request_id, {
+            "status": "exists",
+            "folder": folder,
+            "filename": filename,
+            "path": str(target),
+            "size_bytes": existing,
+        })
+
+    try:
+        # With an explicit filename the existence check needs no network —
+        # keeps warm restarts on a populated volume instant and offline-safe.
+        filename = data.get("filename")
+        if filename and not data.get("force"):
+            target = _resolve_model_path(str(folder), str(filename))
+            if target.exists():
+                await report_exists(target, str(filename))
+                return
+
+        timeout = aiohttp.ClientTimeout(total=None, sock_connect=30)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            resp, default_name = await _open_model_source(session, source)
+            async with resp:
+                filename = filename or default_name
+                data["filename"] = filename
+                target = _resolve_model_path(str(folder), str(filename))
+                total = int(resp.headers.get("Content-Length") or 0)
+
+                if target.exists() and not data.get("force"):
+                    await report_exists(target, str(filename))
+                    return
+
+                target.parent.mkdir(parents=True, exist_ok=True)
+                part_path = target.with_name(target.name + ".part")
+                downloaded = 0
+
+                await send_progress(request_id, frame("start", 0, total))
+                try:
+                    with open(part_path, "wb") as out:
+                        async for chunk in resp.content.iter_chunked(1024 * 1024):
+                            if cancel_event.is_set():
+                                raise asyncio.CancelledError()
+                            out.write(chunk)
+                            downloaded += len(chunk)
+                            await send_progress(request_id, frame("progress", downloaded, total))
+                    os.replace(part_path, target)
+                except asyncio.CancelledError:
+                    part_path.unlink(missing_ok=True)
+                    await send_progress(request_id, frame("cancelled", downloaded, total))
+                    await send_result(request_id, {
+                        "status": "cancelled",
+                        "folder": folder,
+                        "filename": filename,
+                    })
+                    return
+                except BaseException:
+                    part_path.unlink(missing_ok=True)
+                    raise
+
+                await send_progress(request_id, frame("completed", downloaded, downloaded or total))
+                await send_result(request_id, {
+                    "status": "completed",
+                    "folder": folder,
+                    "filename": filename,
+                    "path": str(target),
+                    "size_bytes": downloaded,
+                })
+    except ComfyError as e:
+        await send_progress(request_id, frame("error", 0, 0, error=str(e)))
+        raise
+    finally:
+        if request_id:
+            cancel_flags.pop(request_id, None)
+
+
+def _list_models() -> list[dict[str, Any]]:
+    root = models_dir()
+    if not root.is_dir():
+        return []
+    result: list[dict[str, Any]] = []
+    for folder in sorted(p for p in root.iterdir() if p.is_dir()):
+        for path in sorted(folder.rglob("*")):
+            if not path.is_file() or path.name.endswith(".part"):
+                continue
+            result.append({
+                "folder": folder.name,
+                "filename": str(path.relative_to(folder)),
+                "size_bytes": path.stat().st_size,
+            })
+    return result
+
+
+# --- dispatch -------------------------------------------------------------------
+
+
+async def handle_comfy_message(
+    msg_type: str,
+    request_id: str | None,
+    data: dict[str, Any],
+    transport: Any,  # WorkerTransport (exposes async send_msg)
+    cancel_flags: dict[str, asyncio.Event],
+) -> None:
+    """Handle a comfy.* message via any transport exposing ``send_msg``."""
+
+    async def send_result(rid: str | None, d: dict) -> None:
+        await transport.send_msg({"type": "result", "request_id": rid, "data": d})
+
+    async def send_error(rid: str | None, error: str, tb: str | None = None) -> None:
+        await transport.send_msg(
+            {"type": "error", "request_id": rid, "data": {"error": error, "traceback": tb}}
+        )
+
+    async def send_progress(rid: str | None, d: dict) -> None:
+        await transport.send_msg({"type": "progress", "request_id": rid, "data": d})
+
+    try:
+        if msg_type == "comfy.execute":
+            await _handle_execute(data, request_id, cancel_flags, send_progress, send_result)
+
+        elif msg_type == "comfy.status":
+            info = get_comfy_info()
+            try:
+                async with ComfyClient() as client:
+                    info["system_stats"] = await client.system_stats()
+                    info["queue_remaining"] = await client.queue_remaining()
+                    info["reachable"] = True
+            except Exception as e:
+                info["reachable"] = False
+                info["error"] = str(e)
+            await send_result(request_id, info)
+
+        elif msg_type == "comfy.queue":
+            async with ComfyClient() as client:
+                queue_data = await client.queue()
+            await send_result(request_id, {
+                "queue_running": queue_data.get("queue_running", []),
+                "queue_pending": queue_data.get("queue_pending", []),
+            })
+
+        elif msg_type == "comfy.interrupt":
+            async with ComfyClient() as client:
+                await client.interrupt()
+            await send_result(request_id, {"interrupted": True})
+
+        elif msg_type == "comfy.cancel":
+            prompt_id = data.get("prompt_id")
+            if not prompt_id:
+                raise ComfyError("comfy.cancel requires 'prompt_id'")
+            async with ComfyClient() as client:
+                await _cancel_prompt(client, str(prompt_id))
+            await send_result(request_id, {"cancelled": True, "prompt_id": prompt_id})
+
+        elif msg_type == "comfy.upload":
+            blob = data.get("data")
+            if not isinstance(blob, (bytes, bytearray)):
+                raise ComfyError("comfy.upload requires binary 'data'")
+            filename = data.get("filename") or f"nodetool_{uuid.uuid4().hex[:12]}{_sniff_extension(bytes(blob))}"
+            async with ComfyClient() as client:
+                info = await client.upload(
+                    bytes(blob),
+                    str(filename),
+                    kind=str(data.get("kind", "image")),
+                    subfolder=str(data.get("subfolder", "")),
+                    overwrite=bool(data.get("overwrite", True)),
+                    original_ref=data.get("original_ref"),
+                )
+            await send_result(request_id, info)
+
+        elif msg_type == "comfy.view":
+            if not data.get("filename"):
+                raise ComfyError("comfy.view requires 'filename'")
+            async with ComfyClient() as client:
+                blob, content_type = await client.view(
+                    str(data["filename"]),
+                    str(data.get("subfolder", "")),
+                    str(data.get("type", "output")),
+                )
+            await send_result(request_id, {
+                "filename": data["filename"],
+                "content_type": content_type,
+                "data": blob,
+            })
+
+        elif msg_type == "comfy.object_info":
+            async with ComfyClient() as client:
+                info = await client.object_info(data.get("node_class"))
+            await send_result(request_id, {"object_info": info})
+
+        elif msg_type == "comfy.system_stats":
+            async with ComfyClient() as client:
+                stats = await client.system_stats()
+            await send_result(request_id, stats)
+
+        elif msg_type == "comfy.free":
+            async with ComfyClient() as client:
+                await client.free(
+                    unload_models=bool(data.get("unload_models", True)),
+                    free_memory=bool(data.get("free_memory", False)),
+                )
+            await send_result(request_id, {"freed": True})
+
+        elif msg_type == "comfy.models.download":
+            await _handle_models_download(data, request_id, cancel_flags, send_progress, send_result)
+
+        elif msg_type == "comfy.models.list":
+            await send_result(request_id, {
+                "models_dir": str(models_dir()),
+                "models": _list_models(),
+            })
+
+        elif msg_type == "comfy.models.delete":
+            folder = data.get("folder")
+            filename = data.get("filename")
+            if not folder or not filename:
+                raise ComfyError("comfy.models.delete requires 'folder' and 'filename'")
+            target = _resolve_model_path(str(folder), str(filename))
+            deleted = target.is_file()
+            if deleted:
+                target.unlink()
+            await send_result(request_id, {"deleted": deleted})
+
+        else:
+            await send_error(request_id, f"Unknown comfy message type: {msg_type}")
+
+    except Exception as e:
+        await send_error(request_id, str(e), traceback.format_exc())

--- a/src/nodetool/worker/comfy_handler.py
+++ b/src/nodetool/worker/comfy_handler.py
@@ -277,7 +277,9 @@ async def _upload_input_blobs(
     for key, data in blobs.items():
         if not isinstance(data, (bytes, bytearray)):
             raise ComfyError(f"Input blob '{key}' must be binary, got {type(data).__name__}")
-        safe_key = _SAFE_NAME_RE.sub("_", str(key)) or "input"
+        # Cap the key segment so the full name stays well under the ~255-byte
+        # filesystem filename limit; uniqueness comes from the uuid prefix.
+        safe_key = (_SAFE_NAME_RE.sub("_", str(key)) or "input")[:64]
         filename = f"nodetool_{uuid.uuid4().hex[:12]}_{safe_key}{_sniff_extension(bytes(data))}"
         info = await client.upload(bytes(data), filename)
         name = info.get("name", filename)
@@ -747,6 +749,8 @@ async def _handle_models_download(
                 target.parent.mkdir(parents=True, exist_ok=True)
                 part_path = target.with_name(target.name + ".part")
                 downloaded = 0
+                last_progress = 0.0
+                loop = asyncio.get_running_loop()
 
                 await send_progress(request_id, frame("start", 0, total))
                 try:
@@ -756,7 +760,14 @@ async def _handle_models_download(
                                 raise asyncio.CancelledError()
                             out.write(chunk)
                             downloaded += len(chunk)
-                            await send_progress(request_id, frame("progress", downloaded, total))
+                            # Throttle to ~2 frames/sec: transport writes are
+                            # serialized, so awaiting a send per chunk would gate
+                            # download throughput on bridge latency (and a
+                            # multi-GB model would emit thousands of frames).
+                            now = loop.time()
+                            if now - last_progress >= 0.5:
+                                last_progress = now
+                                await send_progress(request_id, frame("progress", downloaded, total))
                     os.replace(part_path, target)
                 except asyncio.CancelledError:
                     part_path.unlink(missing_ok=True)
@@ -857,11 +868,11 @@ async def handle_comfy_message(
             await send_result(request_id, {"interrupted": True})
 
         elif msg_type == "comfy.cancel":
-            prompt_id = data.get("prompt_id")
-            if not prompt_id:
+            if not data.get("prompt_id"):
                 raise ComfyError("comfy.cancel requires 'prompt_id'")
+            prompt_id = str(data["prompt_id"])
             async with ComfyClient() as client:
-                await _cancel_prompt(client, str(prompt_id))
+                await _cancel_prompt(client, prompt_id)
             await send_result(request_id, {"cancelled": True, "prompt_id": prompt_id})
 
         elif msg_type == "comfy.upload":

--- a/src/nodetool/worker/protocol.py
+++ b/src/nodetool/worker/protocol.py
@@ -24,6 +24,7 @@ class WorkerStatus:
     load_errors: list[dict[str, Any]]
     transport: str
     max_frame_size: int
+    comfy: dict[str, Any]
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -34,6 +35,7 @@ class WorkerStatus:
             "load_errors": self.load_errors,
             "transport": self.transport,
             "max_frame_size": self.max_frame_size,
+            "comfy": self.comfy,
         }
 
 
@@ -88,6 +90,7 @@ class WorkerProtocolServer:
             return
 
         if msg_type == "worker.status":
+            from nodetool.worker.comfy_handler import get_comfy_info
             from nodetool.worker.provider_handler import get_available_providers
 
             status = WorkerStatus(
@@ -98,6 +101,7 @@ class WorkerProtocolServer:
                 load_errors=list(self._load_errors),
                 transport=self._transport_name,
                 max_frame_size=MAX_BRIDGE_FRAME_SIZE,
+                comfy=get_comfy_info(),
             )
             await transport.send_msg({
                 "type": "result",
@@ -183,6 +187,18 @@ class WorkerProtocolServer:
             from nodetool.worker.model_handler import handle_models_message
 
             await handle_models_message(
+                msg_type=str(msg_type),
+                request_id=request_id,
+                data=msg.get("data", {}),
+                transport=transport,
+                cancel_flags=self._cancel_flags,
+            )
+            return
+
+        if msg_type and str(msg_type).startswith("comfy."):
+            from nodetool.worker.comfy_handler import handle_comfy_message
+
+            await handle_comfy_message(
                 msg_type=str(msg_type),
                 request_id=request_id,
                 data=msg.get("data", {}),

--- a/tests/worker/test_comfy_handler.py
+++ b/tests/worker/test_comfy_handler.py
@@ -1,0 +1,710 @@
+"""Tests for the comfy.* bridge handler (ComfyUI proxy).
+
+A fake ComfyUI server (aiohttp.web) implements the endpoints the proxy uses —
+POST /prompt, GET /ws, GET /history/{id}, GET /view, POST /upload/image,
+GET/POST /queue, POST /interrupt, GET /object_info, GET /system_stats,
+POST /free — and the tests drive the real worker WebSocket server end to end,
+exactly like the TS bridge would.
+"""
+
+import asyncio
+import json
+import struct
+
+import msgpack
+import pytest
+import pytest_asyncio
+import websockets
+from aiohttp import web
+
+from nodetool.worker.comfy_handler import (
+    ComfyError,
+    _hf_file_url,
+    _patch_blob_refs,
+    _sniff_extension,
+)
+from nodetool.worker.server import WorkerServer, start_server
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"fake-png-payload"
+OUTPUT_BYTES = b"\x89PNG\r\n\x1a\n" + b"fake-output-image"
+
+
+class FakeComfy:
+    """Minimal in-process ComfyUI double covering the proxied endpoints."""
+
+    def __init__(self) -> None:
+        self.prompt_counter = 0
+        self.prompts: dict[str, dict] = {}
+        self.uploads: dict[str, bytes] = {}
+        self.history_entries: dict[str, dict] = {}
+        self.ws_by_client: dict[str, web.WebSocketResponse] = {}
+        self.queue_running: list[list] = []
+        self.queue_pending: list[list] = []
+        self.deleted: list[str] = []
+        self.interrupts = 0
+        self.freed: list[dict] = []
+        self.hold = False  # prompt "runs" until POST /interrupt
+        self.fail_prompt: dict | None = None  # 400 body for POST /prompt
+        self.error_event: dict | None = None  # execution_error payload
+        self.send_preview = False
+        self.model_files: dict[str, bytes] = {}
+        self._interrupt_events: dict[str, asyncio.Event] = {}
+
+        self.app = web.Application()
+        self.app.add_routes([
+            web.get("/ws", self.handle_ws),
+            web.post("/prompt", self.handle_post_prompt),
+            web.get("/prompt", self.handle_get_prompt),
+            web.get("/history/{prompt_id}", self.handle_history),
+            web.get("/view", self.handle_view),
+            web.post("/upload/image", self.handle_upload),
+            web.get("/queue", self.handle_get_queue),
+            web.post("/queue", self.handle_post_queue),
+            web.post("/interrupt", self.handle_interrupt),
+            web.get("/system_stats", self.handle_system_stats),
+            web.get("/object_info", self.handle_object_info),
+            web.get("/object_info/{node_class}", self.handle_object_info),
+            web.post("/free", self.handle_free),
+            web.get("/files/{name}", self.handle_model_file),
+        ])
+
+    async def handle_ws(self, request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        client_id = request.rel_url.query.get("clientId", "")
+        self.ws_by_client[client_id] = ws
+        async for _msg in ws:
+            pass
+        self.ws_by_client.pop(client_id, None)
+        return ws
+
+    async def _send_event(self, client_id: str, event: dict) -> None:
+        ws = self.ws_by_client.get(client_id)
+        if ws is not None and not ws.closed:
+            await ws.send_str(json.dumps(event))
+
+    async def handle_post_prompt(self, request: web.Request) -> web.Response:
+        if self.fail_prompt is not None:
+            return web.json_response(self.fail_prompt, status=400)
+        body = await request.json()
+        self.prompt_counter += 1
+        prompt_id = f"prompt-{self.prompt_counter}"
+        client_id = body.get("client_id", "")
+        self.prompts[prompt_id] = {"workflow": body.get("prompt"), "client_id": client_id}
+        asyncio.get_running_loop().create_task(self._run(prompt_id, client_id))
+        return web.json_response({"prompt_id": prompt_id, "number": self.prompt_counter})
+
+    async def _run(self, prompt_id: str, client_id: str) -> None:
+        await asyncio.sleep(0.05)
+        await self._send_event(client_id, {"type": "execution_start", "data": {"prompt_id": prompt_id}})
+
+        if self.error_event is not None:
+            await self._send_event(client_id, {
+                "type": "execution_error",
+                "data": {"prompt_id": prompt_id, **self.error_event},
+            })
+            return
+
+        if self.hold:
+            self.queue_running.append([1, prompt_id, {}, {}, []])
+            await self._send_event(client_id, {
+                "type": "executing", "data": {"prompt_id": prompt_id, "node": "1"},
+            })
+            event = self._interrupt_events.setdefault(prompt_id, asyncio.Event())
+            await event.wait()
+            self.queue_running = [e for e in self.queue_running if e[1] != prompt_id]
+            await self._send_event(client_id, {
+                "type": "execution_interrupted", "data": {"prompt_id": prompt_id},
+            })
+            return
+
+        await self._send_event(client_id, {
+            "type": "executing", "data": {"prompt_id": prompt_id, "node": "1"},
+        })
+        await self._send_event(client_id, {
+            "type": "progress", "data": {"prompt_id": prompt_id, "node": "1", "value": 1, "max": 2},
+        })
+        if self.send_preview:
+            ws = self.ws_by_client.get(client_id)
+            if ws is not None and not ws.closed:
+                # 4-byte event type (1 = preview) + 4-byte format (2 = png) + bytes
+                await ws.send_bytes(struct.pack(">II", 1, 2) + b"preview-bytes")
+        node_output = {"images": [{"filename": "out.png", "subfolder": "", "type": "output"}]}
+        self.history_entries[prompt_id] = {
+            "outputs": {"9": node_output},
+            "status": {"status_str": "success", "completed": True, "messages": []},
+        }
+        await self._send_event(client_id, {
+            "type": "executed", "data": {"prompt_id": prompt_id, "node": "9", "output": node_output},
+        })
+        await self._send_event(client_id, {
+            "type": "executing", "data": {"prompt_id": prompt_id, "node": None},
+        })
+
+    async def handle_get_prompt(self, request: web.Request) -> web.Response:
+        return web.json_response({"exec_info": {"queue_remaining": len(self.queue_pending)}})
+
+    async def handle_history(self, request: web.Request) -> web.Response:
+        prompt_id = request.match_info["prompt_id"]
+        entry = self.history_entries.get(prompt_id)
+        return web.json_response({prompt_id: entry} if entry is not None else {})
+
+    async def handle_view(self, request: web.Request) -> web.Response:
+        filename = request.rel_url.query.get("filename", "")
+        if filename == "out.png":
+            return web.Response(body=OUTPUT_BYTES, content_type="image/png")
+        if filename in self.uploads:
+            return web.Response(body=self.uploads[filename], content_type="image/png")
+        return web.Response(status=404, text="not found")
+
+    async def handle_upload(self, request: web.Request) -> web.Response:
+        reader = await request.multipart()
+        filename = ""
+        data = b""
+        field = await reader.next()
+        while field is not None:
+            if field.name == "image":
+                filename = field.filename or "upload.bin"
+                data = await field.read()
+            else:
+                await field.read()
+            field = await reader.next()
+        self.uploads[filename] = data
+        return web.json_response({"name": filename, "subfolder": "", "type": "input"})
+
+    async def handle_get_queue(self, request: web.Request) -> web.Response:
+        return web.json_response({
+            "queue_running": self.queue_running,
+            "queue_pending": self.queue_pending,
+        })
+
+    async def handle_post_queue(self, request: web.Request) -> web.Response:
+        body = await request.json()
+        self.deleted.extend(body.get("delete", []))
+        return web.json_response({})
+
+    async def handle_interrupt(self, request: web.Request) -> web.Response:
+        self.interrupts += 1
+        for event in self._interrupt_events.values():
+            event.set()
+        return web.Response()
+
+    async def handle_system_stats(self, request: web.Request) -> web.Response:
+        return web.json_response({"system": {"os": "fake", "comfyui_version": "0.0.0"}, "devices": []})
+
+    async def handle_object_info(self, request: web.Request) -> web.Response:
+        node_class = request.match_info.get("node_class")
+        catalog = {"KSampler": {"input": {"required": {}}}}
+        if node_class:
+            return web.json_response({node_class: catalog.get(node_class, {})})
+        return web.json_response(catalog)
+
+    async def handle_free(self, request: web.Request) -> web.Response:
+        self.freed.append(await request.json())
+        return web.Response()
+
+    async def handle_model_file(self, request: web.Request) -> web.Response:
+        name = request.match_info["name"]
+        if name not in self.model_files:
+            return web.Response(status=404, text="no such file")
+        return web.Response(body=self.model_files[name])
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def fake_comfy(monkeypatch):
+    fake = FakeComfy()
+    runner = web.AppRunner(fake.app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    host, port = runner.addresses[0][:2]
+    fake.base_url = f"http://{host}:{port}"
+    monkeypatch.setenv("COMFYUI_URL", fake.base_url)
+    yield fake
+    await runner.cleanup()
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def server():
+    worker = WorkerServer()
+    host, port, stop_event, task = await start_server(
+        host="127.0.0.1", port=0, worker=worker,
+    )
+    yield host, port
+    stop_event.set()
+    await task
+
+
+async def _request(ws, msg: dict) -> list[dict]:
+    """Send one bridge message, collect frames until result/error."""
+    await ws.send(msgpack.packb(msg))
+    frames = []
+    while True:
+        raw = await asyncio.wait_for(ws.recv(), timeout=10)
+        frame = msgpack.unpackb(raw, raw=False)
+        frames.append(frame)
+        if frame["type"] in ("result", "error"):
+            return frames
+
+
+# --- pure helpers ----------------------------------------------------------------
+
+
+def test_sniff_extension():
+    assert _sniff_extension(PNG_BYTES) == ".png"
+    assert _sniff_extension(b"\xff\xd8\xff\xe0rest") == ".jpg"
+    assert _sniff_extension(b"RIFF1234WEBPdata") == ".webp"
+    assert _sniff_extension(b"RIFF1234WAVEdata") == ".wav"
+    assert _sniff_extension(b"arbitrary") == ".bin"
+
+
+def test_patch_blob_refs_replaces_placeholders():
+    workflow = {
+        "1": {"class_type": "LoadImage", "inputs": {"image": "blob:img", "extra": ["blob:img"]}},
+        "2": {"inputs": {"text": "not a blob"}},
+    }
+    patched = _patch_blob_refs(workflow, {"img": "sub/nodetool_x.png"})
+    assert patched["1"]["inputs"]["image"] == "sub/nodetool_x.png"
+    assert patched["1"]["inputs"]["extra"] == ["sub/nodetool_x.png"]
+    assert patched["2"]["inputs"]["text"] == "not a blob"
+    # original untouched
+    assert workflow["1"]["inputs"]["image"] == "blob:img"
+
+
+def test_patch_blob_refs_unknown_key_raises():
+    with pytest.raises(ComfyError, match="missing"):
+        _patch_blob_refs({"1": {"inputs": {"image": "blob:missing"}}}, {})
+
+
+def test_hf_file_url():
+    assert (
+        _hf_file_url("org/repo", "unet/model.safetensors")
+        == "https://huggingface.co/org/repo/resolve/main/unet/model.safetensors"
+    )
+    assert (
+        _hf_file_url("org/repo", "m.bin", revision="fp16")
+        == "https://huggingface.co/org/repo/resolve/fp16/m.bin"
+    )
+
+
+# --- worker.status capability flag -------------------------------------------------
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_worker_status_reports_comfy(server, fake_comfy):
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {"type": "worker.status", "request_id": "st-1", "data": {}})
+    status = frames[-1]["data"]
+    assert status["comfy"]["enabled"] is True
+    assert status["comfy"]["url"] == fake_comfy.base_url
+
+
+# --- comfy.execute ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_execute_end_to_end(server, fake_comfy):
+    """Blobs upload → workflow patched → events stream → outputs fetched as blobs."""
+    workflow = {
+        "1": {"class_type": "LoadImage", "inputs": {"image": "blob:img1"}},
+        "9": {"class_type": "SaveImage", "inputs": {"images": ["1", 0]}},
+    }
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {
+            "type": "comfy.execute",
+            "request_id": "ex-1",
+            "data": {"workflow": workflow, "blobs": {"img1": PNG_BYTES}},
+        })
+
+    result = frames[-1]
+    assert result["type"] == "result", result
+    assert result["data"]["status"] == "completed"
+    assert result["data"]["prompt_id"] == "prompt-1"
+
+    # Input management: the blob was uploaded and spliced into the workflow.
+    submitted = fake_comfy.prompts["prompt-1"]["workflow"]
+    uploaded_name = submitted["1"]["inputs"]["image"]
+    assert uploaded_name.startswith("nodetool_")
+    assert uploaded_name.endswith(".png")
+    assert fake_comfy.uploads[uploaded_name] == PNG_BYTES
+
+    # Progress stream carries the ComfyUI execution lifecycle.
+    statuses = [f["data"]["status"] for f in frames if f["type"] == "progress"]
+    assert statuses[0] == "queued"
+    for expected in ("started", "executing", "progress", "node_output", "completed"):
+        assert expected in statuses
+
+    # Output management: the SaveImage file came back as a binary blob.
+    images = result["data"]["outputs"]["9"]["images"]
+    assert images[0]["filename"] == "out.png"
+    assert images[0]["content_type"] == "image/png"
+    blob_key = images[0]["blob"]
+    assert result["data"]["blobs"][blob_key] == OUTPUT_BYTES
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_execute_forwards_previews_when_enabled(server, fake_comfy):
+    fake_comfy.send_preview = True
+    workflow = {"9": {"class_type": "SaveImage", "inputs": {}}}
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {
+            "type": "comfy.execute",
+            "request_id": "ex-prev",
+            "data": {"workflow": workflow, "previews": True},
+        })
+    previews = [f["data"] for f in frames if f["type"] == "progress" and f["data"]["status"] == "preview"]
+    assert len(previews) == 1
+    assert previews[0]["format"] == "png"
+    assert previews[0]["image"] == b"preview-bytes"
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_execute_skips_previews_by_default(server, fake_comfy):
+    fake_comfy.send_preview = True
+    workflow = {"9": {"class_type": "SaveImage", "inputs": {}}}
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {
+            "type": "comfy.execute",
+            "request_id": "ex-noprev",
+            "data": {"workflow": workflow},
+        })
+    assert frames[-1]["type"] == "result"
+    assert not any(
+        f["type"] == "progress" and f["data"]["status"] == "preview" for f in frames
+    )
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_execute_submit_rejection_is_an_error(server, fake_comfy):
+    fake_comfy.fail_prompt = {"error": {"message": "invalid prompt"}, "node_errors": {}}
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {
+            "type": "comfy.execute",
+            "request_id": "ex-bad",
+            "data": {"workflow": {"1": {"class_type": "Nope", "inputs": {}}}},
+        })
+    assert frames[-1]["type"] == "error"
+    assert "invalid prompt" in frames[-1]["data"]["error"]
+    assert "400" in frames[-1]["data"]["error"]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_execute_execution_error_event(server, fake_comfy):
+    fake_comfy.error_event = {"node_id": "5", "node_type": "KSampler", "exception_message": "CUDA OOM"}
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {
+            "type": "comfy.execute",
+            "request_id": "ex-err",
+            "data": {"workflow": {"5": {"class_type": "KSampler", "inputs": {}}}},
+        })
+    assert frames[-1]["type"] == "error"
+    assert "CUDA OOM" in frames[-1]["data"]["error"]
+    assert "5" in frames[-1]["data"]["error"]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_execute_missing_blob_reference(server, fake_comfy):
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {
+            "type": "comfy.execute",
+            "request_id": "ex-miss",
+            "data": {"workflow": {"1": {"inputs": {"image": "blob:nope"}}}},
+        })
+    assert frames[-1]["type"] == "error"
+    assert "nope" in frames[-1]["data"]["error"]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_execute_requires_workflow(server, fake_comfy):
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {
+            "type": "comfy.execute", "request_id": "ex-empty", "data": {},
+        })
+    assert frames[-1]["type"] == "error"
+    assert "workflow" in frames[-1]["data"]["error"]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_execute_cancel_interrupts_running_prompt(server, fake_comfy):
+    """The protocol-level cancel maps to queue-delete + interrupt on ComfyUI."""
+    fake_comfy.hold = True
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        await ws.send(msgpack.packb({
+            "type": "comfy.execute",
+            "request_id": "ex-cancel",
+            "data": {"workflow": {"1": {"class_type": "KSampler", "inputs": {}}}},
+        }))
+        # Wait until the prompt is executing, then cancel it.
+        while True:
+            frame = msgpack.unpackb(await asyncio.wait_for(ws.recv(), timeout=10), raw=False)
+            if frame["type"] == "progress" and frame["data"]["status"] == "executing":
+                break
+        await ws.send(msgpack.packb({"type": "cancel", "request_id": "ex-cancel"}))
+        while True:
+            frame = msgpack.unpackb(await asyncio.wait_for(ws.recv(), timeout=10), raw=False)
+            if frame["type"] in ("result", "error"):
+                break
+
+    assert frame["type"] == "result"
+    assert frame["data"]["status"] == "cancelled"
+    assert fake_comfy.interrupts == 1
+    assert fake_comfy.deleted == ["prompt-1"]
+
+
+# --- passthrough endpoints -----------------------------------------------------------
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_comfy_status(server, fake_comfy):
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {"type": "comfy.status", "request_id": "cs-1", "data": {}})
+    data = frames[-1]["data"]
+    assert data["reachable"] is True
+    assert data["enabled"] is True
+    assert data["queue_remaining"] == 0
+    assert data["system_stats"]["system"]["os"] == "fake"
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_comfy_status_unreachable(server, monkeypatch):
+    monkeypatch.setenv("COMFYUI_URL", "http://127.0.0.1:1")
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {"type": "comfy.status", "request_id": "cs-2", "data": {}})
+    data = frames[-1]["data"]
+    assert frames[-1]["type"] == "result"
+    assert data["reachable"] is False
+    assert "error" in data
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_comfy_queue(server, fake_comfy):
+    fake_comfy.queue_pending = [[2, "prompt-x", {}, {}, []]]
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {"type": "comfy.queue", "request_id": "cq-1", "data": {}})
+    data = frames[-1]["data"]
+    assert data["queue_running"] == []
+    assert data["queue_pending"][0][1] == "prompt-x"
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_comfy_interrupt(server, fake_comfy):
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {"type": "comfy.interrupt", "request_id": "ci-1", "data": {}})
+    assert frames[-1]["data"]["interrupted"] is True
+    assert fake_comfy.interrupts == 1
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_comfy_cancel_pending_prompt(server, fake_comfy):
+    """comfy.cancel deletes from the queue but does NOT interrupt someone else's job."""
+    fake_comfy.queue_running = [[1, "other-prompt", {}, {}, []]]
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {
+            "type": "comfy.cancel", "request_id": "cc-1", "data": {"prompt_id": "pending-1"},
+        })
+    assert frames[-1]["data"]["cancelled"] is True
+    assert fake_comfy.deleted == ["pending-1"]
+    assert fake_comfy.interrupts == 0  # running prompt belongs to another client
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_comfy_upload_and_view(server, fake_comfy):
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {
+            "type": "comfy.upload",
+            "request_id": "cu-1",
+            "data": {"data": PNG_BYTES, "filename": "staged.png"},
+        })
+        assert frames[-1]["data"]["name"] == "staged.png"
+        assert fake_comfy.uploads["staged.png"] == PNG_BYTES
+
+        frames = await _request(ws, {
+            "type": "comfy.view",
+            "request_id": "cv-1",
+            "data": {"filename": "staged.png", "type": "input"},
+        })
+    assert frames[-1]["data"]["data"] == PNG_BYTES
+    assert frames[-1]["data"]["content_type"] == "image/png"
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_comfy_object_info_and_system_stats_and_free(server, fake_comfy):
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {"type": "comfy.object_info", "request_id": "co-1", "data": {}})
+        assert "KSampler" in frames[-1]["data"]["object_info"]
+
+        frames = await _request(ws, {"type": "comfy.system_stats", "request_id": "cst-1", "data": {}})
+        assert frames[-1]["data"]["system"]["os"] == "fake"
+
+        frames = await _request(ws, {
+            "type": "comfy.free", "request_id": "cf-1", "data": {"free_memory": True},
+        })
+    assert frames[-1]["data"]["freed"] is True
+    assert fake_comfy.freed == [{"unload_models": True, "free_memory": True}]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_comfy_unknown_type(server, fake_comfy):
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {"type": "comfy.nonexistent", "request_id": "cx-1", "data": {}})
+    assert frames[-1]["type"] == "error"
+    assert "Unknown comfy message type" in frames[-1]["data"]["error"]
+
+
+# --- model volume management ----------------------------------------------------------
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_models_download_from_url(server, fake_comfy, tmp_path, monkeypatch):
+    monkeypatch.setenv("COMFY_MODELS_DIR", str(tmp_path))
+    payload = b"x" * 64
+    fake_comfy.model_files["sd.safetensors"] = payload
+
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {
+            "type": "comfy.models.download",
+            "request_id": "cmd-1",
+            "data": {
+                "folder": "checkpoints",
+                "source": {"type": "url", "url": f"{fake_comfy.base_url}/files/sd.safetensors"},
+            },
+        })
+
+    result = frames[-1]
+    assert result["type"] == "result"
+    assert result["data"]["status"] == "completed"
+    assert result["data"]["filename"] == "sd.safetensors"
+    assert result["data"]["size_bytes"] == 64
+
+    target = tmp_path / "checkpoints" / "sd.safetensors"
+    assert target.read_bytes() == payload
+    assert not target.with_name("sd.safetensors.part").exists()
+
+    statuses = [f["data"]["status"] for f in frames if f["type"] == "progress"]
+    assert statuses[0] == "start"
+    assert statuses[-1] == "completed"
+    assert "progress" in statuses
+    progress_frames = [f["data"] for f in frames if f["type"] == "progress" and f["data"]["status"] == "progress"]
+    assert progress_frames[-1]["downloaded_bytes"] == 64
+    assert progress_frames[-1]["total_bytes"] == 64
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_models_download_existing_is_skipped_without_network(server, tmp_path, monkeypatch):
+    """A file already on the volume short-circuits — no ComfyUI/PyPI/HF needed."""
+    monkeypatch.setenv("COMFY_MODELS_DIR", str(tmp_path))
+    target = tmp_path / "loras" / "style.safetensors"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"y" * 10)
+
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {
+            "type": "comfy.models.download",
+            "request_id": "cmd-2",
+            "data": {
+                "folder": "loras",
+                "filename": "style.safetensors",
+                # Unreachable source proves no network round-trip happens.
+                "source": {"type": "url", "url": "http://127.0.0.1:1/nope.safetensors"},
+            },
+        })
+    assert frames[-1]["type"] == "result"
+    assert frames[-1]["data"]["status"] == "exists"
+    assert frames[-1]["data"]["size_bytes"] == 10
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_models_download_maps_comfy_type_to_folder(server, fake_comfy, tmp_path, monkeypatch):
+    """comfy.checkpoint_file-style type names map to the ComfyUI folder layout."""
+    monkeypatch.setenv("COMFY_MODELS_DIR", str(tmp_path))
+    fake_comfy.model_files["model.ckpt"] = b"z" * 8
+
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {
+            "type": "comfy.models.download",
+            "request_id": "cmd-3",
+            "data": {
+                "folder": "comfy.checkpoint_file",
+                "source": {"type": "url", "url": f"{fake_comfy.base_url}/files/model.ckpt"},
+            },
+        })
+    assert frames[-1]["data"]["status"] == "completed"
+    assert (tmp_path / "checkpoints" / "model.ckpt").exists()
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_models_download_rejects_path_traversal(server, tmp_path, monkeypatch):
+    monkeypatch.setenv("COMFY_MODELS_DIR", str(tmp_path))
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        for folder, filename in (
+            ("../evil", "model.bin"),
+            ("checkpoints", "../../etc/passwd"),
+            ("/abs", "model.bin"),
+        ):
+            frames = await _request(ws, {
+                "type": "comfy.models.download",
+                "request_id": f"cmd-trav-{folder}",
+                "data": {
+                    "folder": folder,
+                    "filename": filename,
+                    "source": {"type": "url", "url": "http://127.0.0.1:1/x"},
+                },
+            })
+            assert frames[-1]["type"] == "error"
+            assert "Unsafe path" in frames[-1]["data"]["error"]
+    assert not (tmp_path / "model.bin").exists()
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_models_list_and_delete(server, tmp_path, monkeypatch):
+    monkeypatch.setenv("COMFY_MODELS_DIR", str(tmp_path))
+    (tmp_path / "checkpoints").mkdir(parents=True)
+    (tmp_path / "checkpoints" / "a.safetensors").write_bytes(b"a" * 3)
+    (tmp_path / "loras" / "sub").mkdir(parents=True)
+    (tmp_path / "loras" / "sub" / "b.safetensors").write_bytes(b"b" * 5)
+    (tmp_path / "loras" / "partial.safetensors.part").write_bytes(b"junk")
+
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {"type": "comfy.models.list", "request_id": "cml-1", "data": {}})
+        models = frames[-1]["data"]["models"]
+        assert {(m["folder"], m["filename"], m["size_bytes"]) for m in models} == {
+            ("checkpoints", "a.safetensors", 3),
+            ("loras", "sub/b.safetensors", 5),
+        }
+
+        frames = await _request(ws, {
+            "type": "comfy.models.delete",
+            "request_id": "cml-2",
+            "data": {"folder": "checkpoints", "filename": "a.safetensors"},
+        })
+        assert frames[-1]["data"]["deleted"] is True
+        assert not (tmp_path / "checkpoints" / "a.safetensors").exists()
+
+        frames = await _request(ws, {
+            "type": "comfy.models.delete",
+            "request_id": "cml-3",
+            "data": {"folder": "checkpoints", "filename": "a.safetensors"},
+        })
+    assert frames[-1]["data"]["deleted"] is False

--- a/tests/worker/test_comfy_handler.py
+++ b/tests/worker/test_comfy_handler.py
@@ -330,11 +330,13 @@ async def test_execute_end_to_end(server, fake_comfy):
     assert uploaded_name.endswith(".png")
     assert fake_comfy.uploads[uploaded_name] == PNG_BYTES
 
-    # Progress stream carries the ComfyUI execution lifecycle.
-    statuses = [f["data"]["status"] for f in frames if f["type"] == "progress"]
-    assert statuses[0] == "queued"
+    # The execution lifecycle streams as dedicated comfy.event frames —
+    # never as generic `progress` frames, whose shape is different.
+    assert not any(f["type"] == "progress" for f in frames)
+    events = [f["data"]["event"] for f in frames if f["type"] == "comfy.event"]
+    assert events[0] == "queued"
     for expected in ("started", "executing", "progress", "node_output", "completed"):
-        assert expected in statuses
+        assert expected in events
 
     # Output management: the SaveImage file came back as a binary blob.
     images = result["data"]["outputs"]["9"]["images"]
@@ -355,7 +357,7 @@ async def test_execute_forwards_previews_when_enabled(server, fake_comfy):
             "request_id": "ex-prev",
             "data": {"workflow": workflow, "previews": True},
         })
-    previews = [f["data"] for f in frames if f["type"] == "progress" and f["data"]["status"] == "preview"]
+    previews = [f["data"] for f in frames if f["type"] == "comfy.event" and f["data"]["event"] == "preview"]
     assert len(previews) == 1
     assert previews[0]["format"] == "png"
     assert previews[0]["image"] == b"preview-bytes"
@@ -374,7 +376,7 @@ async def test_execute_skips_previews_by_default(server, fake_comfy):
         })
     assert frames[-1]["type"] == "result"
     assert not any(
-        f["type"] == "progress" and f["data"]["status"] == "preview" for f in frames
+        f["type"] == "comfy.event" and f["data"]["event"] == "preview" for f in frames
     )
 
 
@@ -446,7 +448,7 @@ async def test_execute_cancel_interrupts_running_prompt(server, fake_comfy):
         # Wait until the prompt is executing, then cancel it.
         while True:
             frame = msgpack.unpackb(await asyncio.wait_for(ws.recv(), timeout=10), raw=False)
-            if frame["type"] == "progress" and frame["data"]["status"] == "executing":
+            if frame["type"] == "comfy.event" and frame["data"]["event"] == "executing":
                 break
         await ws.send(msgpack.packb({"type": "cancel", "request_id": "ex-cancel"}))
         while True:

--- a/tests/worker/test_comfy_handler.py
+++ b/tests/worker/test_comfy_handler.py
@@ -608,6 +608,51 @@ async def test_models_download_from_url(server, fake_comfy, tmp_path, monkeypatc
 
 
 @pytest.mark.asyncio(loop_scope="function")
+async def test_models_download_progress_is_throttled(server, fake_comfy, tmp_path, monkeypatch):
+    """Progress frames are time-throttled, not one per chunk — per-chunk awaits
+    on the serialized transport would gate download throughput on bridge latency."""
+    monkeypatch.setenv("COMFY_MODELS_DIR", str(tmp_path))
+    fake_comfy.model_files["big.safetensors"] = b"x" * (3 * 1024 * 1024)
+
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {
+            "type": "comfy.models.download",
+            "request_id": "cmd-throttle",
+            "data": {
+                "folder": "checkpoints",
+                "source": {"type": "url", "url": f"{fake_comfy.base_url}/files/big.safetensors"},
+            },
+        })
+
+    assert frames[-1]["data"]["status"] == "completed"
+    assert frames[-1]["data"]["size_bytes"] == 3 * 1024 * 1024
+    assert (tmp_path / "checkpoints" / "big.safetensors").stat().st_size == 3 * 1024 * 1024
+    # A loopback 3 MB body arrives in well under the 0.5s throttle window, so
+    # only the first chunk emits a progress frame — not one per chunk.
+    progress_frames = [f for f in frames if f["type"] == "progress" and f["data"]["status"] == "progress"]
+    assert len(progress_frames) == 1
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_execute_truncates_long_blob_keys_in_filenames(server, fake_comfy):
+    """A pathologically long blob key must not overflow filesystem name limits."""
+    long_key = "k" * 300
+    workflow = {"1": {"class_type": "LoadImage", "inputs": {"image": f"blob:{long_key}"}}}
+    host, port = server
+    async with websockets.connect(f"ws://{host}:{port}") as ws:
+        frames = await _request(ws, {
+            "type": "comfy.execute",
+            "request_id": "ex-longkey",
+            "data": {"workflow": workflow, "blobs": {long_key: PNG_BYTES}},
+        })
+    assert frames[-1]["type"] == "result"
+    uploaded_name = fake_comfy.prompts["prompt-1"]["workflow"]["1"]["inputs"]["image"]
+    assert len(uploaded_name.encode()) < 255
+    assert fake_comfy.uploads[uploaded_name] == PNG_BYTES
+
+
+@pytest.mark.asyncio(loop_scope="function")
 async def test_models_download_existing_is_skipped_without_network(server, tmp_path, monkeypatch):
     """A file already on the volume short-circuits — no ComfyUI/PyPI/HF needed."""
     monkeypatch.setenv("COMFY_MODELS_DIR", str(tmp_path))

--- a/tests/worker/test_model_handler.py
+++ b/tests/worker/test_model_handler.py
@@ -12,8 +12,8 @@ from nodetool.worker import BRIDGE_PROTOCOL_VERSION
 from nodetool.worker.server import WorkerServer, start_server
 
 
-def test_protocol_version_is_2():
-    assert BRIDGE_PROTOCOL_VERSION == 2
+def test_protocol_version_is_3():
+    assert BRIDGE_PROTOCOL_VERSION == 3
 
 
 @pytest_asyncio.fixture(loop_scope="function")


### PR DESCRIPTION
## Summary

Adds a complete ComfyUI proxy layer to the worker, exposing a co-located headless ComfyUI server through the NodeTool bridge protocol via new `comfy.*` messages. The worker fronts ComfyUI on loopback (never exposed directly) and handles input/output management, queue introspection, model downloads, and execution streaming.

## Key Changes

- **New `comfy_handler.py`** — Transport-agnostic handler for all `comfy.*` messages:
  - `comfy.execute` — Submit workflows with blob input management (upload via `/upload/image`, splice into workflow), stream execution events over WebSocket, fetch file outputs as binary blobs
  - `comfy.queue`, `comfy.interrupt`, `comfy.cancel` — Queue introspection and cancellation
  - `comfy.upload`, `comfy.view` — Standalone input staging and file fetching
  - `comfy.object_info`, `comfy.system_stats`, `comfy.free`, `comfy.status` — Node catalog and health checks
  - `comfy.models.download`, `comfy.models.list`, `comfy.models.delete` — Model management on persistent volume with HuggingFace support and streamed progress

- **ComfyUI client** — Thin async HTTP + WebSocket client (`ComfyClient` class) wrapping the ComfyUI API with proper timeout and error handling

- **Event streaming** — Each `comfy.execute` gets its own `client_id` and WebSocket connection; concurrent prompts never leak events across bridge requests; routing stays keyed on protocol `request_id`

- **Input/output management**:
  - Input blobs uploaded with unique `nodetool_*` filenames (extension sniffed from bytes)
  - Workflow placeholders (`"blob:<key>"`) replaced with uploaded filenames before submission
  - File outputs fetched via `GET /view` and returned as binary blobs in result frame
  - Scalar outputs passed through unchanged

- **Comprehensive test suite** (`test_comfy_handler.py`) — Fake in-process ComfyUI server (aiohttp.web) covering end-to-end workflows, blob handling, preview forwarding, cancellation, error cases, and model downloads

- **Docker image** (`Dockerfile.comfy`, `docker/comfy/start.sh`) — Bundles NodeTool worker + headless ComfyUI; entrypoint waits for ComfyUI boot before starting worker; designed for RunPod with persistent `/workspace` volume for models/inputs/outputs

- **Protocol version bump** — Bridge protocol v2 → v3; `worker.status` now includes `comfy: {enabled, url}` capability block

- **Documentation** (`docs/comfy-proxy.md`) — Full API reference for all `comfy.*` messages, progress frame lifecycle, output structure, and environment variables

## Implementation Details

- **Execution lifecycle**: Prompts queued → execution_start → executing nodes → progress updates → node outputs → executed → completion with history fetch (retries for async history writes)
- **Cancellation**: Best-effort via queue deletion + interrupt guard (only interrupts if prompt is actually running)
- **Preview forwarding**: Binary WebSocket frames (4-byte event type + format + image bytes) decoded and forwarded as progress frames when `previews: true`
- **Model downloads**: Streamed from HuggingFace or direct URLs with progress callbacks and cancellation support
- **Error handling**: Execution errors extracted from history status, timeouts enforced with deadline tracking, WebSocket drops fall back to history polling

https://claude.ai/code/session_0159cuaVhiTmujWWkEYk8v5B