### PR TITLE
Fix audit findings: crash bugs, SSRF/traversal, config precedence, dead code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,24 +15,22 @@ Cloud/API providers (OpenAI, Anthropic, Gemini, Ollama, etc.) are implemented in
 
 ```
 src/nodetool/
-├── config/          # Environment, logging, settings
-├── dsl/             # DSL for graph construction (codegen, handles)
-├── integrations/    # HuggingFace models, vector stores
-├── io/              # URI utilities, media fetch
-├── media/           # Audio, image, video processing helpers
-├── metadata/        # Type definitions, node metadata, tool_types
-├── ml/              # Model management, TTS/ASR/image model lists
-├── models/          # Database models (Asset, Job, Secret, etc.)
-├── nodes/           # Built-in node implementations
-├── packages/        # Package registry and scanning
-├── providers/       # Provider base classes, registry, fake provider
-├── runtime/         # ResourceScope, DB connection pools
-├── security/        # Crypto, master key, secret helper, auth providers
-├── storage/         # Abstract storage, memory/file/S3 backends
-├── types/           # API graph types, prediction types
-├── utils/           # Misc utilities
-├── worker/          # Worker subprocess (WebSocket server, executor)
-└── workflows/       # Node execution core (see below)
+├── config/            # Environment, logging, settings
+├── integrations/      # HuggingFace models, vector stores
+├── io/                # URI utilities, media fetch
+├── media/             # Audio, image, video processing helpers
+├── metadata/          # Type definitions, node metadata, tool_types
+├── ml/                # Model management, TTS/ASR/image model lists
+├── package_metadata/  # Package metadata JSON (nodetool-core.json)
+├── package_tools/     # Package registry scanning (nodetool-pkg CLI)
+├── providers/         # Provider base classes, registry
+├── runtime/           # ResourceScope, DB connection pools
+├── security/          # Crypto, master key, secret helper
+├── storage/           # Abstract storage, memory/file/S3 backends
+├── types/             # API graph types, prediction types
+├── utils/             # Misc utilities
+├── worker/            # Worker subprocess (WebSocket server, executor)
+└── workflows/         # Node execution core (see below)
 ```
 
 ### workflows/ — Node Execution Core
@@ -48,7 +46,6 @@ These files support node execution. There is no workflow runner or orchestration
 - `processing_offload.py` — Thread offloading for CPU-bound work
 - `torch_support.py` — PyTorch device management
 - `property.py` — Node property descriptors
-- `recommended_models.py` — Model recommendations per node
 - `asset_storage.py` — Asset ref utilities (content type, auto-save)
 - `io.py` — Node input/output helpers
 
@@ -67,7 +64,7 @@ The following were moved to the TypeScript server and deleted from Python:
 conda create -n nodetool python=3.11 pandoc ffmpeg -c conda-forge
 conda activate nodetool
 uv sync
-uv sync --group dev
+uv sync --extra dev
 ```
 
 ## Common Commands
@@ -144,8 +141,8 @@ Tests are in `tests/` mirroring `src/` structure. Key test directories:
 
 - `tests/worker/` — Worker subprocess tests
 - `tests/workflows/` — Node execution, processing context, graph tests
-- `tests/models/` — Database model tests
 - `tests/security/` — Crypto, secret helper tests
-- `tests/providers/` — Cost calculator, provider infrastructure tests
+- `tests/integrations/` — HuggingFace model detection, safetensors, vector stores
+- `tests/storage/` — Storage backend tests
 
 Note: `tests/io/test_media_fetch.py` has a pre-existing mock recursion timeout — skip with `--ignore=tests/io/test_media_fetch.py` if needed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ dev = [
     "pytest-timeout>=2.3.1",
     "pytest-xdist>=3.6.0",
     "aioresponses>=0.7.8",
+    "safetensors>=0.4.0",
     "mypy>=1.0.0",
     "ruff==0.15.17",
     "ty>=0.0.7",

--- a/src/nodetool/config/environment.py
+++ b/src/nodetool/config/environment.py
@@ -104,21 +104,38 @@ def load_dotenv_files():
 
     logger.debug(f"Loading environment: {env_name}")
 
-    # Load .env files in order of precedence (later files override earlier ones)
+    # Load .env files in order of increasing specificity. Later (more specific)
+    # files override earlier ones, but genuine process/shell environment
+    # variables always take precedence over any .env file value.
+    #
+    # dotenv semantics:
+    #   - override=False -> existing os.environ wins over the file
+    #   - override=True  -> the file wins over previously-loaded values
+    # To honor documented precedence (base first, local overrides last) while
+    # preserving real OS env vars, we snapshot the original os.environ and load
+    # the base with override=False and the more-specific files with
+    # override=True, then restore the snapshot so real env vars stay authoritative.
     env_files = [
-        project_root / ".env",  # Base .env file
-        project_root / f".env.{env_name}",  # Environment-specific file
-        project_root / f".env.{env_name}.local",  # Local overrides (gitignored)
+        (project_root / ".env", False),  # Base .env file
+        (project_root / f".env.{env_name}", True),  # Environment-specific file
+        (project_root / f".env.{env_name}.local", True),  # Local overrides (gitignored)
     ]
 
+    original_env = dict(os.environ)
+
     loaded_files = []
-    for env_file in env_files:
+    for env_file, override in env_files:
         if env_file.exists():
             logger.info(f"Loading environment file: {env_file}")
             loaded_files.append(str(env_file))
-            load_dotenv(env_file, override=False)  # type: ignore[arg-type]
+            load_dotenv(env_file, override=override)  # type: ignore[arg-type]
         else:
             logger.debug(f"Environment file not found: {env_file}")
+
+    # Genuine process env vars (e.g. real shell exports) must win over any
+    # .env file, so restore their original values after loading.
+    for key, value in original_env.items():
+        os.environ[key] = value
 
     if loaded_files:
         logger.info(f"Loaded {len(loaded_files)} environment file(s): {loaded_files}")
@@ -207,12 +224,15 @@ class Environment:
     def get_environment(cls) -> dict[str, Any]:
         settings = cls.get_settings()
 
+        # Precedence (lowest to highest): defaults < settings.yaml < environment.
+        # Environment variables take priority, so they are applied last.
         env = DEFAULT_ENV.copy()
-        env.update(get_system_env())
 
         for k, v in settings.items():
             if v is not None:
                 env[k] = v
+
+        env.update(get_system_env())
 
         return env
 
@@ -615,7 +635,6 @@ class Environment:
         # Default to system-specific path
         return str(get_system_data_path("assets"))
 
-    @classmethod
     @classmethod
     def get_logger(cls):
         """Return the shared nodetool logger using centralized config."""

--- a/src/nodetool/config/logging_config.py
+++ b/src/nodetool/config/logging_config.py
@@ -47,7 +47,7 @@ def configure_logging(
     """
     from nodetool.config.environment import Environment
 
-    global _current_config
+    global _current_config, _configured
 
     if isinstance(level, str):
         level = level.upper()
@@ -65,7 +65,7 @@ def configure_logging(
         "console_output": console_output,
     }
 
-    if _current_config == new_config:
+    if _configured and _current_config == new_config:
         return level
 
     _current_config = new_config
@@ -80,6 +80,18 @@ def configure_logging(
     datefmt = datefmt if datefmt is not None else _DEFAULT_DATEFMT
 
     root = logging.getLogger()
+
+    # As a library, nodetool must not destroy a host application's logging
+    # configuration on import (get_logger() triggers this lazily). If the host
+    # has already installed root handlers and we have not configured logging
+    # ourselves, respect their setup: only tame noisy third-party loggers and
+    # record that we've run, without touching the root handlers or level.
+    host_owns_logging = bool(root.handlers) and not _configured
+    if host_owns_logging:
+        _set_third_party_levels()
+        _configured = True
+        return level
+
     root.setLevel(level)
     root.propagate = propagate_root
 
@@ -121,7 +133,14 @@ def configure_logging(
         file_handler.setFormatter(logging.Formatter(fmt=_DEFAULT_FORMAT, datefmt=datefmt))
         root.addHandler(file_handler)
 
-    # Ensure noisy third-party loggers stay at INFO regardless of root level
+    _set_third_party_levels()
+
+    _configured = True
+    return level
+
+
+def _set_third_party_levels() -> None:
+    """Tame noisy third-party loggers regardless of the root level."""
     logging.getLogger("aiosqlite").setLevel(logging.INFO)
     logging.getLogger("hpack").setLevel(logging.INFO)
     logging.getLogger("httpcore").setLevel(logging.INFO)
@@ -133,8 +152,6 @@ def configure_logging(
     logging.getLogger("urllib3").setLevel(logging.WARNING)
     logging.getLogger("opentelemetry").setLevel(logging.WARNING)
     logging.getLogger("transformers").setLevel(logging.WARNING)
-
-    return level
 
 
 def get_logger(name: str) -> logging.Logger:

--- a/src/nodetool/config/settings.py
+++ b/src/nodetool/config/settings.py
@@ -412,22 +412,9 @@ register_setting(
     ),
 )
 
-register_setting(
-    package_name="nodetool",
-    env_var="SERVER_AUTH_TOKEN",
-    group="Deployment",
-    description=(
-        "Bearer auth token for securing NodeTool server endpoints in deployment. "
-        "Set this environment variable on the server to enable auth. "
-        "If unset, bearer auth is disabled. "
-        "When enabled, all API endpoints except /health and /ping require "
-        "Authorization: Bearer <SERVER_AUTH_TOKEN>. "
-        "On clients (curl, nodetool workflow_runner auth_token, or custom SDK), "
-        "send this header with every request. "
-        "Recommended for Docker and production deployments. "
-        "Generate with: openssl rand -base64 32"
-    ),
-)
+# NOTE: SERVER_AUTH_TOKEN is intentionally registered only as a secret (above),
+# not as a setting, to avoid persisting the bearer token in plaintext
+# settings.yaml.
 
 
 # ---------------------------------------------------------------------------
@@ -540,12 +527,12 @@ def get_value(
     3. Default environment values
     4. Default parameter
     """
-    # Check settings (non-secrets from settings.yaml)
-    value = settings.get(key)
-
     # Environment variables take priority
+    value = get_system_env_value(key)
+
+    # Fall back to settings (non-secrets from settings.yaml)
     if value is None or str(value) == "":
-        value = get_system_env_value(key)
+        value = settings.get(key)
 
     # Fall back to default environment values
     if value is None:

--- a/src/nodetool/integrations/huggingface/artifact_inspector.py
+++ b/src/nodetool/integrations/huggingface/artifact_inspector.py
@@ -115,40 +115,76 @@ def detect_gguf(paths: Sequence[str | Path]) -> ArtifactDetection | None:
     )
 
 
+# GGUF metadata value-type enum (v2/v3). Fixed-width scalar sizes in bytes.
+# String(8) and Array(9) are variable-length and handled separately.
+_GGUF_TYPE_SIZES = {
+    0: 1,  # uint8
+    1: 1,  # int8
+    2: 2,  # uint16
+    3: 2,  # int16
+    4: 4,  # uint32
+    5: 4,  # int32
+    6: 4,  # float32
+    7: 1,  # bool
+    10: 8,  # uint64
+    11: 8,  # int64
+    12: 8,  # float64
+}
+_GGUF_TYPE_STRING = 8
+_GGUF_TYPE_ARRAY = 9
+
+
+def _read_gguf_string(f) -> str:
+    """Read a GGUF string: uint64 length prefix followed by UTF-8 bytes."""
+    (length,) = struct.unpack("<Q", f.read(8))
+    return f.read(length).decode("utf-8", errors="replace")
+
+
+def _read_gguf_value(f, value_type: int) -> str | None:
+    """Consume a single GGUF metadata value, keeping the stream aligned.
+
+    Returns the decoded string for STRING values, otherwise ``None`` after
+    skipping the value's bytes (we only need string values to reach the
+    ``general.*`` keys ``detect_gguf`` cares about).
+    """
+    if value_type == _GGUF_TYPE_STRING:
+        return _read_gguf_string(f)
+    if value_type == _GGUF_TYPE_ARRAY:
+        (elem_type,) = struct.unpack("<I", f.read(4))
+        (count,) = struct.unpack("<Q", f.read(8))
+        for _ in range(count):
+            _read_gguf_value(f, elem_type)
+        return None
+    size = _GGUF_TYPE_SIZES.get(value_type)
+    if size is None:
+        raise ValueError(f"Unknown GGUF value type: {value_type}")
+    f.read(size)
+    return None
+
+
 def _read_gguf_header(path: Path) -> dict[str, str]:
-    """Minimal GGUF header reader."""
+    """Minimal GGUF (v2/v3) header reader.
+
+    Follows the real GGUF layout so the stream stays aligned across all value
+    types and we can reach the ``general.*`` keys used for detection. Only
+    string-valued metadata entries are recorded.
+    """
     with path.open("rb") as f:
         magic = f.read(4)
-        if magic not in (b"GGUF",):
+        if magic != b"GGUF":
             raise ValueError("Not a GGUF file")
-        struct.unpack("<I", f.read(4))[0]
-        # Skip tensor_count (uint64) and kv_count (uint64)
-        f.read(8)  # tensor_count
-        kv_count = struct.unpack("<Q", f.read(8))[0]
+        struct.unpack("<I", f.read(4))  # version (uint32)
+        struct.unpack("<Q", f.read(8))  # tensor_count (uint64)
+        (kv_count,) = struct.unpack("<Q", f.read(8))  # kv_count (uint64)
+
         info: dict[str, str] = {}
         for _ in range(kv_count):
-            key_len = struct.unpack("<I", f.read(4))[0]
-            key = f.read(key_len).decode("utf-8")
-            value_type = struct.unpack("<I", f.read(4))[0]
-            if value_type == 2:  # string
-                str_len = struct.unpack("<I", f.read(4))[0]
-                value = f.read(str_len).decode("utf-8")
+            key = _read_gguf_string(f)
+            (value_type,) = struct.unpack("<I", f.read(4))
+            value = _read_gguf_value(f, value_type)
+            if value is not None:
                 info[key] = value
-            else:
-                # Skip other types
-                _skip_gguf_value(f, value_type)
         return info
-
-
-def _skip_gguf_value(f, value_type: int) -> None:
-    if value_type == 0 or value_type == 1:  # uint8
-        f.read(1)
-    elif value_type in (3, 4):  # array of bytes/ints: skip length + payload
-        length = struct.unpack("<Q", f.read(8))[0]
-        f.read(length)
-    else:
-        # Fallback: skip 8 bytes to avoid misalignment
-        f.read(8)
 
 
 # ---- Torch bin detection ----------------------------------------------------

--- a/src/nodetool/integrations/huggingface/async_downloader.py
+++ b/src/nodetool/integrations/huggingface/async_downloader.py
@@ -33,6 +33,34 @@ class HfFileMeta:
     original_url: str  # original /resolve url
 
 
+def _validate_path_component(component: str, *, allow_subdirs: bool = False) -> str:
+    """Validate a server/listing-controlled value used to build a cache path.
+
+    Rejects absolute paths, parent-directory traversal (``..``), NUL bytes and
+    (unless ``allow_subdirs``) embedded path separators. Returns the normalized
+    (forward-slash) value. Mirrors the ``_validate_relpath`` guard used by the
+    worker's comfy handler.
+
+    Args:
+        component: Raw value (e.g. an ETag, commit hash or filename).
+        allow_subdirs: When True, forward-slash subpaths such as
+            ``"onnx/model.onnx"`` are permitted (but ``..`` segments are not).
+    """
+    if not component:
+        raise ValueError("Empty path component")
+    if "\x00" in component:
+        raise ValueError(f"Invalid NUL byte in path component: {component!r}")
+    candidate = component.replace("\\", "/")
+    p = Path(candidate)
+    if p.is_absolute():
+        raise ValueError(f"Absolute path not allowed: {component!r}")
+    if any(seg in ("..", "") for seg in p.parts):
+        raise ValueError(f"Unsafe path component: {component!r}")
+    if not allow_subdirs and len(p.parts) > 1:
+        raise ValueError(f"Path separators not allowed in component: {component!r}")
+    return candidate
+
+
 def _env_bool(name: str) -> bool:
     v = os.getenv(name)
     if v is None:
@@ -441,8 +469,21 @@ async def async_hf_download(
         repo_cache = _hf_repo_cache_dir(repo_id, repo_type=repo_type, cache_dir=cache_dir)
         blobs_dir = repo_cache / "blobs"
         commit_or_rev = meta.commit_hash or revision
-        snapshot_path = repo_cache / "snapshots" / commit_or_rev / filename
-        blob_path = blobs_dir / meta.etag
+
+        # Sanitize server/listing-controlled values before joining them into
+        # cache paths (etag + commit from response headers, filename from hub
+        # listing) so they cannot traverse outside the intended directories.
+        safe_etag = _validate_path_component(meta.etag)
+        safe_commit = _validate_path_component(commit_or_rev)
+        safe_filename = _validate_path_component(filename, allow_subdirs=True)
+
+        snapshot_root = repo_cache / "snapshots" / safe_commit
+        snapshot_path = snapshot_root / safe_filename
+        # filename may legitimately contain subdirs; assert the resolved path
+        # stays within the snapshot commit directory.
+        if not snapshot_path.resolve().is_relative_to(snapshot_root.resolve()):
+            raise ValueError(f"Filename escapes snapshot directory: {filename!r}")
+        blob_path = blobs_dir / safe_etag
 
         # Blob already cached and looks complete
         if blob_path.exists() and (meta.size is None or blob_path.stat().st_size == meta.size):

--- a/src/nodetool/integrations/huggingface/hf_fast_cache.py
+++ b/src/nodetool/integrations/huggingface/hf_fast_cache.py
@@ -178,6 +178,15 @@ class HfFastCache:
         rel = _normalize_relpath(relpath)
         candidate = state.snapshot_dir / rel
 
+        # Defense-in-depth: ensure the lexical join stays within the snapshot
+        # directory. We intentionally do NOT resolve symlinks here because HF
+        # cache files legitimately symlink out to the shared blobs/ directory;
+        # `_normalize_relpath` already rejects ".." so this guards odd joins.
+        snapshot_root = os.path.normpath(str(state.snapshot_dir))
+        normalized = os.path.normpath(str(candidate))
+        if normalized != snapshot_root and not normalized.startswith(snapshot_root + os.sep):
+            return None
+
         try:
             exists = await aiofiles.os.path.exists(str(candidate))
             is_link = await aiofiles.os.path.islink(str(candidate))
@@ -694,9 +703,16 @@ async def _count_files_async(root: Path) -> int:
 
 
 def _normalize_relpath(path: str) -> Path:
-    """Normalize a repo-relative path into a :class:`Path`."""
+    """Normalize a repo-relative path into a :class:`Path`.
+
+    Rejects absolute paths and parent-directory (``..``) traversal so a
+    caller-supplied relpath cannot escape the snapshot directory.
+    """
     path = path.replace("\\", "/").lstrip("/")
-    return Path(path)
+    rel = Path(path)
+    if rel.is_absolute() or any(part == ".." for part in rel.parts):
+        raise ValueError(f"Unsafe relative path: {path!r}")
+    return rel
 
 
 def _changed(now: Optional[float], old: Optional[float]) -> bool:

--- a/src/nodetool/integrations/huggingface/llama_cpp_download.py
+++ b/src/nodetool/integrations/huggingface/llama_cpp_download.py
@@ -44,6 +44,19 @@ if TYPE_CHECKING:
 log = get_logger(__name__)
 
 
+def _validate_component(value: str, *, name: str) -> str:
+    """Reject path separators, traversal and NUL bytes in a single component.
+
+    Used to sanitize server/caller-controlled values (``filename``, ``tag``)
+    before they are joined into cache/manifest paths.
+    """
+    if not value:
+        raise ValueError(f"Empty {name}")
+    if "\x00" in value or "/" in value or "\\" in value or value in (".", ".."):
+        raise ValueError(f"Unsafe {name}: {value!r}")
+    return value
+
+
 def get_llama_cpp_model_filename(repo_id: str, filename: str) -> str:
     """Get the llama.cpp cache filename for a model.
 
@@ -116,12 +129,21 @@ async def download_llama_cpp_model(
     Returns:
         Path to the downloaded model file
     """
+    # Sanitize caller-controlled values before joining into cache paths.
+    filename = _validate_component(filename, name="filename")
+    tag = _validate_component(tag, name="tag")
+
     cache_dir = get_llama_cpp_cache_dir()
     os.makedirs(cache_dir, exist_ok=True)
 
     flat_filename = get_llama_cpp_model_filename(repo_id, filename)
     output_path = Path(cache_dir) / flat_filename
     etag_path = Path(cache_dir) / f"{flat_filename}.etag"
+
+    # Defense-in-depth: ensure the final output stays inside the cache dir.
+    cache_root = Path(cache_dir).resolve()
+    if not output_path.resolve().is_relative_to(cache_root):
+        raise ValueError(f"Output path escapes cache dir: {output_path}")
 
     # Manifest path: manifest={org}={repo}={tag}.json
     org, repo = repo_id.split("/", 1) if "/" in repo_id else ("", repo_id)
@@ -174,8 +196,9 @@ async def download_llama_cpp_model(
                     if progress_callback:
                         progress_callback(len(chunk), total_size)
 
-        # Rename temp file to final location
-        temp_path.rename(output_path)
+        # Move temp file to final location (replace: avoids FileExistsError on
+        # Windows when the target already exists).
+        temp_path.replace(output_path)
         log.info(f"Moved {temp_path} to {output_path}")
 
         # Write etag file (keep quotes for llama-server compatibility)

--- a/src/nodetool/io/media_fetch.py
+++ b/src/nodetool/io/media_fetch.py
@@ -58,18 +58,30 @@ def _normalize_image_like_to_png_bytes(obj: object) -> bytes:
 
 
 def _parse_data_uri(uri: str) -> tuple[str, bytes]:
-    """Parse a data: URI and return (mime, bytes)."""
-    try:
-        header, b64data = uri.split(",", 1)
-        mime_type = "application/octet-stream"
-        if ";" in header:
-            meta = header[5:]
-            parts = meta.split(";")
-            if parts and "/" in parts[0]:
-                mime_type = parts[0]
-        import base64
+    """Parse a data: URI and return (mime, bytes).
 
-        raw = base64.b64decode(b64data.encode("utf-8") if not isinstance(b64data, bytes) else b64data)
+    Supports both base64-encoded payloads (``data:...;base64,...``) and
+    URL-encoded text payloads (``data:text/plain,Hello%20World``) per RFC 2397.
+    """
+    try:
+        header, payload = uri.split(",", 1)
+        # RFC 2397 default mime is text/plain when none is supplied.
+        mime_type = "text/plain"
+        # header looks like "data:[<mime>][;<param>...][;base64]"
+        meta = header[len("data:") :]
+        params = meta.split(";")
+        is_base64 = any(p.strip().lower() == "base64" for p in params)
+        if params and "/" in params[0]:
+            mime_type = params[0]
+
+        if is_base64:
+            import base64
+
+            raw = base64.b64decode(payload.encode("utf-8") if not isinstance(payload, bytes) else payload)
+        else:
+            from urllib.parse import unquote_to_bytes
+
+            raw = unquote_to_bytes(payload)
         return mime_type, raw
     except Exception as e:
         # Tests expect the phrase "Invalid data URI" to appear
@@ -95,28 +107,57 @@ def _fetch_file_uri(uri: str) -> tuple[str, bytes]:
     return mime_type, data
 
 
-async def _fetch_http_uri_async(uri: str) -> tuple[str, bytes]:
-    """Fetch content from an HTTP/HTTPS URL. Local storage URLs are handled by the caller."""
+def _validate_uri_host(uri: str) -> None:
+    """Raise if the URI's hostname resolves to a private/restricted IP.
 
+    Also guards against redirect targets that use an IP literal to bypass the
+    connector's SSRF resolver.
+    """
     parsed = urlparse(uri)
     if parsed.hostname and is_ip_private(parsed.hostname):
         raise ValueError(f"Access to private/restricted IP blocked: {parsed.hostname}")
 
-    connector = aiohttp.TCPConnector(resolver=SSRFProtectResolver())
-    async with aiohttp.ClientSession(connector=connector) as session, session.get(uri) as response:
-        response.raise_for_status()
-        data = await response.read()
-        content_type = response.headers.get("Content-Type")
-        mime_type: str | None = None
-        if content_type:
-            mime_type = content_type.split(";", 1)[0]
-        if not mime_type:
-            import mimetypes
 
-            mime_type, _ = mimetypes.guess_type(uri)
-        if not mime_type:
-            mime_type = "application/octet-stream"
-        return mime_type, data
+async def _fetch_http_uri_async(uri: str) -> tuple[str, bytes]:
+    """Fetch content from an HTTP/HTTPS URL. Local storage URLs are handled by the caller.
+
+    Redirects are followed manually so that each hop's hostname is re-validated
+    against ``is_ip_private``. aiohttp's automatic redirects (and the connector's
+    IP-literal short-circuit) would otherwise let a redirect to an IP literal
+    such as ``http://169.254.169.254/`` bypass the SSRF check.
+    """
+    from urllib.parse import urljoin
+
+    max_redirects = 5
+    current_uri = uri
+    connector = aiohttp.TCPConnector(resolver=SSRFProtectResolver())
+    async with aiohttp.ClientSession(connector=connector) as session:
+        for _ in range(max_redirects + 1):
+            _validate_uri_host(current_uri)
+            async with session.get(current_uri, allow_redirects=False) as response:
+                if response.status in (301, 302, 303, 307, 308):
+                    location = response.headers.get("Location")
+                    if not location:
+                        raise ValueError(f"Redirect response without Location header from {current_uri}")
+                    # Resolve relative redirects against the current URL.
+                    current_uri = urljoin(current_uri, location)
+                    continue
+
+                response.raise_for_status()
+                data = await response.read()
+                content_type = response.headers.get("Content-Type")
+                mime_type: str | None = None
+                if content_type:
+                    mime_type = content_type.split(";", 1)[0]
+                if not mime_type:
+                    import mimetypes
+
+                    mime_type, _ = mimetypes.guess_type(current_uri)
+                if not mime_type:
+                    mime_type = "application/octet-stream"
+                return mime_type, data
+
+    raise ValueError(f"Too many redirects while fetching {uri}")
 
 
 def _is_local_storage_url(uri: str) -> bool:
@@ -204,7 +245,7 @@ def _parse_asset_id_from_uri(uri: str) -> str:
         raise ValueError(f"Invalid asset URI: {uri}")
 
     # Remove the asset:// prefix
-    path = uri[len("asset://"):]
+    path = uri[len("asset://") :]
 
     # Remove extension if present (everything after the first dot)
     asset_id = path.split(".")[0] if "." in path else path

--- a/src/nodetool/io/media_fetch.py
+++ b/src/nodetool/io/media_fetch.py
@@ -65,8 +65,8 @@ def _parse_data_uri(uri: str) -> tuple[str, bytes]:
     """
     try:
         header, payload = uri.split(",", 1)
-        # RFC 2397 default mime is text/plain when none is supplied.
-        mime_type = "text/plain"
+        # Default mime when none is supplied in the URI.
+        mime_type = "application/octet-stream"
         # header looks like "data:[<mime>][;<param>...][;base64]"
         meta = header[len("data:") :]
         params = meta.split(";")

--- a/src/nodetool/media/audio/audio_helpers.py
+++ b/src/nodetool/media/audio/audio_helpers.py
@@ -65,7 +65,7 @@ def resize_audio(audio: AudioSegment, duration: float) -> AudioSegment:
     if len(audio) > duration:
         return cast("AudioSegment", audio[:duration])
     elif len(audio) < duration:
-        padding = AudioSegment.silent(duration=int(len(audio) - duration))
+        padding = AudioSegment.silent(duration=int(duration - len(audio)))
         return audio + padding
     else:
         return audio

--- a/src/nodetool/media/image/web_font_utils.py
+++ b/src/nodetool/media/image/web_font_utils.py
@@ -183,20 +183,77 @@ def _get_cache_filename(font_name: str, weight: str, url: str = "") -> str:
         return f"google_{clean_name}_{weight}.ttf"
 
 
+def _validate_font_host(url: str) -> None:
+    """Raise if the URL's hostname resolves to a private/restricted IP.
+
+    Also guards against redirect targets that use an IP literal to bypass the
+    connector's SSRF resolver.
+    """
+    from urllib.parse import urlparse
+
+    hostname = urlparse(url).hostname
+    if hostname and is_ip_private(hostname):
+        raise ValueError(f"Access to private/restricted IP blocked: {hostname}")
+
+
 async def _download_font_async(url: str, cache_path: Path) -> bytes:
-    """Asynchronously download font data with SSRF protection."""
+    """Asynchronously download font data with SSRF protection.
+
+    Redirects are followed manually so each hop's hostname is re-validated with
+    ``is_ip_private``. aiohttp's automatic redirects (and the connector's
+    IP-literal short-circuit) would otherwise let a redirect to an IP literal
+    such as ``http://169.254.169.254/`` bypass the SSRF check.
+    """
+    from urllib.parse import urljoin
+
+    max_redirects = 5
+    current_url = url
     connector = aiohttp.TCPConnector(resolver=SSRFProtectResolver())
     async with aiohttp.ClientSession(connector=connector) as session:
         try:
-            async with session.get(url, timeout=30, headers={"User-Agent": "NodeTool/1.0"}) as response:
-                if response.status == 404:
-                    raise FileNotFoundError(f"Font file not found at {url}")
-                response.raise_for_status()
-                return await response.read()
+            for _ in range(max_redirects + 1):
+                _validate_font_host(current_url)
+                async with session.get(
+                    current_url,
+                    timeout=30,
+                    headers={"User-Agent": "NodeTool/1.0"},
+                    allow_redirects=False,
+                ) as response:
+                    if response.status in (301, 302, 303, 307, 308):
+                        location = response.headers.get("Location")
+                        if not location:
+                            raise ConnectionError(f"Redirect response without Location header from {current_url}")
+                        current_url = urljoin(current_url, location)
+                        continue
+                    if response.status == 404:
+                        raise FileNotFoundError(f"Font file not found at {current_url}")
+                    response.raise_for_status()
+                    return await response.read()
+            raise ConnectionError(f"Too many redirects while downloading font from {url}")
         except aiohttp.ClientError as e:
             raise ConnectionError(f"Failed to download font from {url}: {e}") from e
         except TimeoutError as e:
             raise ConnectionError(f"Timeout while downloading font from {url}") from e
+
+
+def _run_font_coroutine(coro) -> bytes:
+    """Run a font-download coroutine from either sync or async contexts.
+
+    ``download_google_font`` / ``download_font_from_url`` keep sync signatures but
+    are reachable from within a running event loop (async node execution via
+    ``ProcessingContext.get_font_path``). ``asyncio.run`` raises there, so when a
+    loop is already running we execute the coroutine on a separate thread.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop in this thread — safe to drive one directly.
+        return asyncio.run(coro)
+
+    from concurrent.futures import ThreadPoolExecutor
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(lambda: asyncio.run(coro)).result()
 
 
 def download_google_font(font_name: str, weight: str = "regular") -> str:
@@ -285,7 +342,7 @@ def download_google_font(font_name: str, weight: str = "regular") -> str:
         log.debug(f"Trying to download font from: {url}")
 
         try:
-            font_data = asyncio.run(_download_font_async(url, cache_path))
+            font_data = _run_font_coroutine(_download_font_async(url, cache_path))
 
             # Save to cache
             cache_path.write_bytes(font_data)
@@ -338,7 +395,7 @@ def download_font_from_url(url: str) -> str:
 
     log.info(f"Downloading font from URL: {url}")
 
-    font_data = asyncio.run(_download_font_async(url, cache_path))
+    font_data = _run_font_coroutine(_download_font_async(url, cache_path))
 
     # Basic validation - check for TTF/OTF magic bytes
     if len(font_data) < 4:

--- a/src/nodetool/metadata/typecheck.py
+++ b/src/nodetool/metadata/typecheck.py
@@ -171,8 +171,11 @@ def is_assignable(type_meta: TypeMetadata, value: Any) -> bool:
             return is_assignable(element_type, value)
         return False
 
-    # Handle dictionary values
-    if python_type is dict and "type" in value:
+    # Handle dictionary values that carry their own "type" tag.
+    # Skip for union/enum types, whose members are expanded further below.
+    # Otherwise a typed payload like {"type": "image", ...} would be compared
+    # against the container's own type ("union"/"enum") and never match a member.
+    if python_type is dict and "type" in value and type_meta.type not in ("union", "enum"):
         return value["type"] == type_meta.type
 
     # Handle dict values without explicit 'type' field - check if they validate

--- a/src/nodetool/metadata/types.py
+++ b/src/nodetool/metadata/types.py
@@ -101,9 +101,7 @@ class BaseType(BaseModel):
         if type_name is None:
             raise ValueError("Type name is missing. Types must derive from BaseType")
         if type_name not in NameToType:
-            raise ValueError(
-                f"Unknown type name: {type_name}. Types must derive from BaseType. Data: {data}"
-            )
+            raise ValueError(f"Unknown type name: {type_name}. Types must derive from BaseType. Data: {data}")
         return NameToType[type_name](**data)
 
 
@@ -116,9 +114,7 @@ class ImageSize(BaseType):
     type: Literal["image_size"] = "image_size"
     width: int = Field(default=1024, description="Image width")
     height: int = Field(default=1024, description="Image height")
-    preset: Optional[str] = Field(
-        None, description="Aspect ratio preset name (e.g. 'square_hd')"
-    )
+    preset: Optional[str] = Field(None, description="Aspect ratio preset name (e.g. 'square_hd')")
 
     def __str__(self):
         if self.preset:
@@ -181,11 +177,7 @@ class Datetime(BaseType):
             minute=self.minute,
             second=self.second,
             microsecond=self.microsecond,
-            tzinfo=(
-                timezone(timedelta(seconds=self.utc_offset), self.tzinfo)
-                if self.utc_offset
-                else UTC
-            ),
+            tzinfo=(timezone(timedelta(seconds=self.utc_offset), self.tzinfo) if self.utc_offset else UTC),
         )
 
     @staticmethod
@@ -415,12 +407,7 @@ class AudioStream(BaseType):
 
     def duration_seconds(self) -> float:
         """Calculate duration in seconds based on data length and format."""
-        if (
-            not self.data
-            or self.sample_rate == 0
-            or self.channels == 0
-            or self.sample_width == 0
-        ):
+        if not self.data or self.sample_rate == 0 or self.channels == 0 or self.sample_width == 0:
             return 0.0
         num_samples = len(self.data) // (self.sample_width * self.channels)
         return num_samples / self.sample_rate
@@ -453,13 +440,9 @@ class Model3DRef(AssetRef):
     """
 
     type: Literal["model_3d"] = "model_3d"
-    format: Optional[str] = (
-        None  # The 3D format (glb, gltf, obj, mtl, fbx, stl, ply, usdz)
-    )
+    format: Optional[str] = None  # The 3D format (glb, gltf, obj, mtl, fbx, stl, ply, usdz)
     material_file: Optional["AssetRef"] = None  # Material file (e.g., MTL for OBJ)
-    texture_files: list["ImageRef"] = Field(
-        default_factory=list
-    )  # Associated texture images
+    texture_files: list["ImageRef"] = Field(default_factory=list)  # Associated texture images
 
 
 class RSSEntry(BaseType):
@@ -587,9 +570,7 @@ class InferenceProvider(enum.StrEnum):
 
 
 class InferenceProviderAudioClassificationModel(BaseType):
-    type: Literal["inference_provider_audio_classification_model"] = (
-        "inference_provider_audio_classification_model"
-    )
+    type: Literal["inference_provider_audio_classification_model"] = "inference_provider_audio_classification_model"
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
@@ -603,89 +584,67 @@ class InferenceProviderAutomaticSpeechRecognitionModel(BaseType):
 
 
 class InferenceProviderImageClassificationModel(BaseType):
-    type: Literal["inference_provider_image_classification_model"] = (
-        "inference_provider_image_classification_model"
-    )
+    type: Literal["inference_provider_image_classification_model"] = "inference_provider_image_classification_model"
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderImageToImageModel(BaseType):
-    type: Literal["inference_provider_image_to_image_model"] = (
-        "inference_provider_image_to_image_model"
-    )
+    type: Literal["inference_provider_image_to_image_model"] = "inference_provider_image_to_image_model"
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderImageSegmentationModel(BaseType):
-    type: Literal["inference_provider_image_segmentation_model"] = (
-        "inference_provider_image_segmentation_model"
-    )
+    type: Literal["inference_provider_image_segmentation_model"] = "inference_provider_image_segmentation_model"
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderTextClassificationModel(BaseType):
-    type: Literal["inference_provider_text_classification_model"] = (
-        "inference_provider_text_classification_model"
-    )
+    type: Literal["inference_provider_text_classification_model"] = "inference_provider_text_classification_model"
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderSummarizationModel(BaseType):
-    type: Literal["inference_provider_summarization_model"] = (
-        "inference_provider_summarization_model"
-    )
+    type: Literal["inference_provider_summarization_model"] = "inference_provider_summarization_model"
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderTextToImageModel(BaseType):
-    type: Literal["inference_provider_text_to_image_model"] = (
-        "inference_provider_text_to_image_model"
-    )
+    type: Literal["inference_provider_text_to_image_model"] = "inference_provider_text_to_image_model"
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderTranslationModel(BaseType):
-    type: Literal["inference_provider_translation_model"] = (
-        "inference_provider_translation_model"
-    )
+    type: Literal["inference_provider_translation_model"] = "inference_provider_translation_model"
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderTextToTextModel(BaseType):
-    type: Literal["inference_provider_text_to_text_model"] = (
-        "inference_provider_text_to_text_model"
-    )
+    type: Literal["inference_provider_text_to_text_model"] = "inference_provider_text_to_text_model"
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderTextToSpeechModel(BaseType):
-    type: Literal["inference_provider_text_to_speech_model"] = (
-        "inference_provider_text_to_speech_model"
-    )
+    type: Literal["inference_provider_text_to_speech_model"] = "inference_provider_text_to_speech_model"
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderTextToAudioModel(BaseType):
-    type: Literal["inference_provider_text_to_audio_model"] = (
-        "inference_provider_text_to_audio_model"
-    )
+    type: Literal["inference_provider_text_to_audio_model"] = "inference_provider_text_to_audio_model"
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
 
 class InferenceProviderTextGenerationModel(BaseType):
-    type: Literal["inference_provider_text_generation_model"] = (
-        "inference_provider_text_generation_model"
-    )
+    type: Literal["inference_provider_text_generation_model"] = "inference_provider_text_generation_model"
     provider: InferenceProvider = InferenceProvider.hf_inference
     model_id: str = ""
 
@@ -893,9 +852,7 @@ class HFStableDiffusionXL(HuggingFaceModel):
 
 
 class HFStableDiffusionXLCheckpoint(HuggingFaceModel):
-    type: Literal["hf.stable_diffusion_xl_checkpoint"] = (
-        "hf.stable_diffusion_xl_checkpoint"
-    )
+    type: Literal["hf.stable_diffusion_xl_checkpoint"] = "hf.stable_diffusion_xl_checkpoint"
 
 
 class HFStableDiffusion3(HuggingFaceModel):
@@ -903,9 +860,7 @@ class HFStableDiffusion3(HuggingFaceModel):
 
 
 class HFStableDiffusion3Checkpoint(HuggingFaceModel):
-    type: Literal["hf.stable_diffusion_3_checkpoint"] = (
-        "hf.stable_diffusion_3_checkpoint"
-    )
+    type: Literal["hf.stable_diffusion_3_checkpoint"] = "hf.stable_diffusion_3_checkpoint"
 
 
 class HFStableDiffusionXLRefiner(HuggingFaceModel):
@@ -913,9 +868,7 @@ class HFStableDiffusionXLRefiner(HuggingFaceModel):
 
 
 class HFStableDiffusionXLRefinerCheckpoint(HuggingFaceModel):
-    type: Literal["hf.stable_diffusion_xl_refiner_checkpoint"] = (
-        "hf.stable_diffusion_xl_refiner_checkpoint"
-    )
+    type: Literal["hf.stable_diffusion_xl_refiner_checkpoint"] = "hf.stable_diffusion_xl_refiner_checkpoint"
 
 
 class HFFlux(HuggingFaceModel):
@@ -1035,9 +988,7 @@ class HFImageToVideo(HuggingFaceModel):
 
 
 class HFUnconditionalImageGeneration(HuggingFaceModel):
-    type: Literal["hf.unconditional_image_generation"] = (
-        "hf.unconditional_image_generation"
-    )
+    type: Literal["hf.unconditional_image_generation"] = "hf.unconditional_image_generation"
 
 
 class HFUnet(HuggingFaceModel):
@@ -1073,9 +1024,7 @@ class HFTextToVideo(HuggingFaceModel):
 
 
 class HFZeroShotImageClassification(HuggingFaceModel):
-    type: Literal["hf.zero_shot_image_classification"] = (
-        "hf.zero_shot_image_classification"
-    )
+    type: Literal["hf.zero_shot_image_classification"] = "hf.zero_shot_image_classification"
 
 
 class HFMaskGeneration(HuggingFaceModel):
@@ -1175,9 +1124,7 @@ class HFAudioClassification(HuggingFaceModel):
 
 
 class HFZeroShotAudioClassification(HuggingFaceModel):
-    type: Literal["hf.zero_shot_audio_classification"] = (
-        "hf.zero_shot_audio_classification"
-    )
+    type: Literal["hf.zero_shot_audio_classification"] = "hf.zero_shot_audio_classification"
 
 
 class HFRealESRGAN(HuggingFaceModel):
@@ -1314,19 +1261,29 @@ class StyleModelFile(ModelFile):
 
 
 def comfy_model_to_folder(type_name: str) -> str:
-    folder_mapping = {
-        "comfy.checkpoint_file": "checkpoints",
-        "comfy.vae_file": "vae",
-        "comfy.clip": "clip",
-        "comfy.clip_vision": "clip_vision",
-        "comfy.control_net": "controlnet",
-        "comfy.ip_adapter": "ipadapter",
-        "comfy.gligen": "gligen",
-        "comfy.upscale_model": "upscale_models",
-        "comfy.lora": "loras",
-        "comfy.unet": "unet",
-        "comfy.instant_id_file": "instantid",
+    # Base ComfyUI folder per model family. Callers pass either the ComfyModel
+    # type ("comfy.lora") or its ModelFile variant ("comfy.lora_file"); both
+    # resolve to the same folder. Values that are already folder names (e.g.
+    # "checkpoints") pass through unchanged.
+    base_folders = {
+        "checkpoint": "checkpoints",
+        "unet": "unet",
+        "vae": "vae",
+        "clip": "clip",
+        "unclip": "checkpoints",
+        "clip_vision": "clip_vision",
+        "control_net": "controlnet",
+        "ip_adapter": "ipadapter",
+        "gligen": "gligen",
+        "upscale_model": "upscale_models",
+        "lora": "loras",
+        "instant_id": "instantid",
+        "style_model": "style_models",
     }
+    folder_mapping: dict[str, str] = {}
+    for base, folder in base_folders.items():
+        folder_mapping[f"comfy.{base}"] = folder
+        folder_mapping[f"comfy.{base}_file"] = folder
     return folder_mapping.get(type_name, type_name)
 
 
@@ -1513,9 +1470,7 @@ class Step(BaseType):
     completed: bool = Field(default=False, description="Whether the step is completed")
     start_time: int = Field(default=0, description="The start time of the step")
     end_time: int = Field(default=0, description="The end time of the step")
-    depends_on: list[str] = Field(
-        default=[], description="The IDs of steps this step depends on"
-    )
+    depends_on: list[str] = Field(default=[], description="The IDs of steps this step depends on")
     tools: list[str] | None = Field(
         default=None,
         description="Optional list of allowed tool names for this step (None = no restriction).",
@@ -1532,12 +1487,8 @@ class Step(BaseType):
     def to_markdown(self) -> str:
         """Convert the step to markdown format."""
         checkbox = "[x]" if self.completed else "[*]" if self.is_running() else "[ ]"
-        deps_str = (
-            f" (depends on {', '.join(self.depends_on)})" if self.depends_on else ""
-        )
-        output_schema_str = (
-            f" (output schema: {self.output_schema})" if self.output_schema else ""
-        )
+        deps_str = f" (depends on {', '.join(self.depends_on)})" if self.depends_on else ""
+        output_schema_str = f" (output schema: {self.output_schema})" if self.output_schema else ""
         return f"- {checkbox} {self.instructions}{deps_str}{output_schema_str}"
 
     def is_running(self) -> bool:
@@ -1552,7 +1503,7 @@ class Step(BaseType):
         Returns:
             bool: True if the step is currently running, False otherwise
         """
-        return self.start_time > 0 and not self.completed
+        return self.start_time > 0 and self.end_time == 0 and not self.completed
 
 
 class Task(BaseType):
@@ -1566,12 +1517,8 @@ class Task(BaseType):
     type: Literal["task"] = "task"
 
     title: str = Field(default="", description="The title of the task")
-    description: str = Field(
-        default="", description="A description of the task, not used for execution"
-    )
-    steps: list[Step] = Field(
-        default=[], description="The steps of the task, a list of step IDs"
-    )
+    description: str = Field(default="", description="A description of the task, not used for execution")
+    steps: list[Step] = Field(default=[], description="The steps of the task, a list of step IDs")
 
     def is_completed(self) -> bool:
         """Returns True if all steps are marked as completed."""
@@ -1579,7 +1526,7 @@ class Task(BaseType):
 
     def to_markdown(self) -> str:
         """Converts task and steps to markdown format with headings and checkboxes."""
-        parts = [f"# Task: {self.title}\n", f"Description: {self.description}\n"]
+        parts = [f"# Task: {self.title}\n"]
         if self.description:
             parts.append(f"{self.description}\n")
         if self.steps:
@@ -1712,9 +1659,7 @@ class NPArray(BaseType):
 
     @staticmethod
     def from_numpy(arr: "np.ndarray", **kwargs):
-        return NPArray(
-            value=arr.tobytes(), dtype=arr.dtype.str, shape=arr.shape, **kwargs
-        )
+        return NPArray(value=arr.tobytes(), dtype=arr.dtype.str, shape=arr.shape, **kwargs)
 
     @staticmethod
     def from_list(arr: list, **_kwargs):
@@ -1734,13 +1679,7 @@ def to_numpy(num: float | int | NPArray) -> "np.ndarray":
         raise ValueError()
 
 
-ColumnType = (
-    Literal["int"]
-    | Literal["float"]
-    | Literal["datetime"]
-    | Literal["string"]
-    | Literal["object"]
-)
+ColumnType = Literal["int"] | Literal["float"] | Literal["datetime"] | Literal["string"] | Literal["object"]
 
 
 class ColumnDef(BaseModel):
@@ -2355,19 +2294,11 @@ class PlotlySeries(BaseType):
         default=None,
         description="Column name for y-axis (optional for some charts like histogram)",
     )
-    color: str | None = Field(
-        default=None, description="Column name for color encoding"
-    )
+    color: str | None = Field(default=None, description="Column name for color encoding")
     size: str | None = Field(default=None, description="Column name for size encoding")
-    symbol: str | None = Field(
-        default=None, description="Column name for symbol encoding"
-    )
-    line_dash: str | None = Field(
-        default=None, description="Column name for line dash pattern encoding"
-    )
-    chart_type: str = Field(
-        description="The type of chart to create (scatter, line, bar, histogram, box, violin)"
-    )
+    symbol: str | None = Field(default=None, description="Column name for symbol encoding")
+    line_dash: str | None = Field(default=None, description="Column name for line dash pattern encoding")
+    chart_type: str = Field(description="The type of chart to create (scatter, line, bar, histogram, box, violin)")
 
 
 class PlotlyConfig(BaseType):
@@ -2567,9 +2498,7 @@ class EmailSearchCriteria(BaseType):
     cc: Optional[str] = None
     label: Optional[str] = None
     date_query: Optional[DateSearchCondition] = None
-    date_condition: Optional[DateSearchCondition] = (
-        None  # Alias for date_query for backwards compatibility
-    )
+    date_condition: Optional[DateSearchCondition] = None  # Alias for date_query for backwards compatibility
     flags: list[EmailFlag] = Field(default_factory=list)
     keywords: list[str] = Field(default_factory=list)
     folder: Optional[str] = None

--- a/src/nodetool/ml/core/model_manager.py
+++ b/src/nodetool/ml/core/model_manager.py
@@ -101,6 +101,22 @@ class ModelManager:
         logger.debug(f"Model cache status - Total models: {len(cls._models)}, Key searched: {cache_key}")
         return model
 
+    @staticmethod
+    def _make_cache_key(model_id: str, task: str | None = None, path: str | None = None) -> str:
+        """Build a cache key consistently across set_model/get_model/unload_model.
+
+        The key is ``model_id`` optionally suffixed with ``_task`` and ``_path``.
+        Only non-empty ``task``/``path`` segments are appended so that, e.g.,
+        ``unload_model(model_id, task)`` produces the same key that the legacy
+        ``set_model(node_id, model_id, task, model)`` signature stores.
+        """
+        key = model_id
+        if task:
+            key = f"{key}_{task}"
+        if path:
+            key = f"{key}_{path}"
+        return key
+
     @classmethod
     def set_model(
         cls,
@@ -122,7 +138,7 @@ class ModelManager:
             model_instance = task_or_model
         else:
             task = str(task_or_model)
-            cache_key = f"{model_id_or_cache_key}_{task}" if task else model_id_or_cache_key
+            cache_key = cls._make_cache_key(model_id_or_cache_key, task)
             model_instance = model
 
         cls._ensure_memory_capacity(reason=f"Preparing to cache model {cache_key}")
@@ -327,9 +343,7 @@ class ModelManager:
             keys = cls._models_by_node.pop(node_id, None)
             if keys:
                 for key in list(keys):
-                    is_still_referenced = any(
-                        key in mapped_keys for mapped_keys in cls._models_by_node.values()
-                    )
+                    is_still_referenced = any(key in mapped_keys for mapped_keys in cls._models_by_node.values())
                     if is_still_referenced:
                         continue
 
@@ -377,7 +391,7 @@ class ModelManager:
     @classmethod
     def unload_model(cls, model_id: str, task: str, path: str | None = None) -> bool:
         """Explicitly remove a cached model and free associated VRAM."""
-        key = f"{model_id}_{task}_{path}"
+        key = cls._make_cache_key(model_id, task, path)
         model = cls._models.pop(key, None)
         if model is None:
             return False
@@ -625,15 +639,17 @@ class ModelManager:
 
         snapshot = cls._capture_vram_snapshot()
         if snapshot is None:
-            if aggressive:
-                logger.warning(
-                    "VRAM cleanup requested (%s) but telemetry unavailable. Clearing cached models.",
-                    reason,
-                )
-                cls.clear()
-                gc.collect()
-                cls._try_empty_cuda_cache()
-                cls._last_vram_cleanup = time.monotonic()
+            # Telemetry is genuinely unavailable here (e.g. no CUDA device, or an
+            # Apple/MLX machine). There is no VRAM-pressure signal to act on, and
+            # wiping the entire model cache in this case is destructive for no
+            # benefit (there is no GPU memory to reclaim). Do nothing. Callers
+            # that truly want to drop everything should use free_memory_if_needed
+            # / clear() explicitly.
+            logger.debug(
+                "VRAM cleanup requested (%s) but telemetry is unavailable; "
+                "skipping cache clear (no CUDA telemetry to act on).",
+                reason,
+            )
             return
 
         if not aggressive and not cls._needs_vram_cleanup(snapshot, required_free_gb):
@@ -820,33 +836,44 @@ class ModelManager:
 
     @classmethod
     def _capture_vram_snapshot_via_system_stats(cls) -> VramSnapshot | None:
-        """Fallback VRAM telemetry using NVML via SystemStats, if available."""
+        """Fallback VRAM telemetry.
 
-        try:
-            from nodetool.system.system_stats import get_system_stats
-        except Exception:  # pragma: no cover - avoid hard dependency
+        The previous NVML-via-``nodetool.system.system_stats`` fallback was
+        removed along with that module (it now lives in the TypeScript server),
+        so this method no longer depends on it. As a best-effort fallback it
+        tries ``torch.cuda.mem_get_info`` directly; when torch/CUDA is not
+        available it cleanly returns ``None`` so callers treat VRAM telemetry as
+        unavailable (rather than crashing on a dead import).
+        """
+
+        try:  # pragma: no cover - optional dependency
+            import torch  # type: ignore
+        except Exception:
             return None
 
         try:
-            stats = get_system_stats()
-            if stats.vram_total_gb is None or stats.vram_used_gb is None or stats.vram_percent is None:
+            if not hasattr(torch, "cuda") or not torch.cuda.is_available():  # type: ignore[attr-defined]
                 return None
 
-            available_gb = max(float(stats.vram_total_gb - stats.vram_used_gb), 0.0)
+            free_bytes, total_bytes = torch.cuda.mem_get_info()  # type: ignore[attr-defined]
+            available_gb = float(free_bytes) / (1024**3)
+            total_gb = float(total_bytes) / (1024**3)
+            used_percent = ((total_gb - available_gb) / total_gb) * 100.0 if total_gb > 0 else 0.0
+
             snapshot = VramSnapshot(
-                percent=float(stats.vram_percent),
+                percent=used_percent,
                 available_gb=available_gb,
-                total_gb=float(stats.vram_total_gb),
+                total_gb=total_gb,
                 process_allocated_gb=0.0,
             )
             logger.debug(
-                "VRAM snapshot captured via NVML: %.2f%% used, %.2f GB available",
+                "VRAM snapshot captured via torch.cuda.mem_get_info: %.2f%% used, %.2f GB available",
                 snapshot.percent,
                 snapshot.available_gb,
             )
             return snapshot
         except Exception as exc:  # pragma: no cover - defensive
-            logger.debug("Unable to capture VRAM stats via NVML/SystemStats: %s", exc)
+            logger.debug("Unable to capture VRAM stats via torch fallback: %s", exc)
             return None
 
     @classmethod

--- a/src/nodetool/providers/README.md
+++ b/src/nodetool/providers/README.md
@@ -6,9 +6,6 @@ Cloud/API providers (OpenAI, Anthropic, Gemini, Ollama, etc.) are in the TypeScr
 
 ## Files
 
+- `__init__.py` — Package exports
 - `base.py` — `BaseProvider`, `register_provider`, `get_registered_provider`
 - `types.py` — Shared types (`ImageBytes`, `TextToImageParams`, `ImageToImageParams`)
-- `fake_provider.py` — Mock provider for testing
-- `cost_calculator.py` — Token cost estimation
-- `token_counter.py` — Token counting utilities
-- `comfy_api.py` — ComfyUI API client

--- a/src/nodetool/providers/__init__.py
+++ b/src/nodetool/providers/__init__.py
@@ -6,8 +6,8 @@ caching) used by Python-only providers (HuggingFace Local, MLX).
 Cloud/API providers (OpenAI, Anthropic, Gemini, etc.) are implemented
 in the TypeScript server.
 """
+
 import asyncio
-import sys
 import threading
 import traceback
 from typing import Optional
@@ -75,9 +75,9 @@ def import_providers():
         log.warning(f"Unexpected error importing HuggingFace local provider: {e}")
 
 
-# Provider instance cache
-_provider_cache: dict[ProviderEnum, BaseProvider] = {}
-_provider_cache_lock: asyncio.Lock | None = None
+# Provider instance cache, keyed by (provider type, user id) so one user's
+# secrets are never reused for another user's provider instance.
+_provider_cache: dict[tuple[ProviderEnum, str], BaseProvider] = {}
 _provider_cache_locks: dict[int, asyncio.Lock] = {}
 _provider_cache_locks_lock = threading.Lock()
 
@@ -92,11 +92,7 @@ def clear_provider_cache() -> int:
 
 
 def _get_provider_cache_lock() -> asyncio.Lock:
-    """Get or create the provider cache lock lazily."""
-    global _provider_cache_lock
-    if _provider_cache_lock is None:
-        _provider_cache_lock = asyncio.Lock()
-
+    """Get or create the per-event-loop provider cache lock lazily."""
     loop_id = id(asyncio.get_running_loop())
 
     with _provider_cache_locks_lock:
@@ -110,9 +106,10 @@ async def get_provider(provider_type: ProviderEnum, user_id: str = "1", **kwargs
     Get a provider instance based on the provider type.
     Providers are cached after first creation.
     """
+    cache_key = (provider_type, user_id)
     async with _get_provider_cache_lock():
-        if provider_type in _provider_cache:
-            return _provider_cache[provider_type]
+        if cache_key in _provider_cache:
+            return _provider_cache[cache_key]
 
         import_providers()
 
@@ -129,8 +126,8 @@ async def get_provider(provider_type: ProviderEnum, user_id: str = "1", **kwargs
         for secret in required_secrets:
             secrets[secret] = await get_secret(secret, user_id)
 
-        _provider_cache[provider_type] = provider_cls(secrets=secrets, **kwargs)
-        return _provider_cache[provider_type]
+        _provider_cache[cache_key] = provider_cls(secrets=secrets, **kwargs)
+        return _provider_cache[cache_key]
 
 
 async def list_providers(user_id: str) -> list["BaseProvider"]:

--- a/src/nodetool/security/README.md
+++ b/src/nodetool/security/README.md
@@ -4,11 +4,9 @@ Encrypted secret storage and key management.
 
 ## Components
 
-- `crypto.py` — `SecretCrypto`: AES-256 encryption using Fernet, per-user key derivation (PBKDF2-SHA256)
+- `crypto.py` — `SecretCrypto`: Fernet symmetric encryption (AES-128-CBC with HMAC-SHA256 authentication), per-user key derivation (PBKDF2-SHA256)
 - `master_key.py` — `MasterKeyManager`: Master key from env var or system keychain
-- `secret_helper.py` — `get_secret()`, `get_secret_required()`: Secret resolution (env var → encrypted DB → default)
-- `auth_provider.py` — `AuthProvider` protocol for authentication backends
-- `providers/` — Auth provider implementations (local, static token, multi-user, supabase)
+- `secret_helper.py` — `get_secret()`, `get_secret_required()`: Secret resolution (env var → default)
 
 ## Usage
 
@@ -20,6 +18,8 @@ api_key = await get_secret("OPENAI_API_KEY", user_id)
 
 ## Secret Resolution Order
 
+For the lean Python worker, secrets come from environment variables. The TS
+server handles database-stored secrets and passes them to the worker via env.
+
 1. Environment variable (`os.environ`)
-2. Encrypted database (`Secret` model)
-3. Not found (returns `None` or raises)
+2. Not found (returns the provided default / `None`, or raises for `get_secret_required`)

--- a/src/nodetool/security/crypto.py
+++ b/src/nodetool/security/crypto.py
@@ -87,7 +87,7 @@ class SecretCrypto:
             The decrypted plaintext value.
 
         Raises:
-            cryptography.fernet.InvalidToken: If the master key is incorrect or the data is corrupted.
+            ValueError: If the master key is incorrect or the data is corrupted.
         """
         fernet = SecretCrypto.derive_encryption_key(master_key, user_id)
         try:
@@ -112,8 +112,8 @@ class SecretCrypto:
         try:
             SecretCrypto.decrypt(test_encrypted_value, master_key, user_id)
             return True
-        except (InvalidToken, ValueError, UnicodeDecodeError):
-            # InvalidToken: Wrong key or corrupted data
-            # ValueError: Decryption failed (raised by decrypt())
+        except (ValueError, UnicodeDecodeError):
+            # ValueError: Wrong key or corrupted data (decrypt() converts
+            #   Fernet's InvalidToken into ValueError)
             # UnicodeDecodeError: Decrypted bytes are not valid UTF-8
             return False

--- a/src/nodetool/security/master_key.py
+++ b/src/nodetool/security/master_key.py
@@ -6,8 +6,10 @@ in the system keychain (macOS Keychain, Windows Credential Manager, Linux Secret
 or AWS Secrets Manager.
 """
 
+import asyncio
 import logging
 import os
+import threading
 from typing import Optional
 
 import keyring
@@ -18,6 +20,22 @@ from nodetool.security.crypto import SecretCrypto
 # Keyring service name for storing the master key
 KEYRING_SERVICE = "nodetool"
 KEYRING_USERNAME = "secrets_master_key"
+
+# Serializes the keychain-lookup/generate section of get_master_key so that
+# concurrent callers that all miss the cache do not each generate a different
+# master key. Created lazily to bind to the running event loop.
+_master_key_lock: Optional[asyncio.Lock] = None
+_master_key_lock_guard = threading.Lock()
+
+
+def _get_master_key_lock() -> asyncio.Lock:
+    """Return the shared asyncio lock, creating it on first use."""
+    global _master_key_lock
+    if _master_key_lock is None:
+        with _master_key_lock_guard:
+            if _master_key_lock is None:
+                _master_key_lock = asyncio.Lock()
+    return _master_key_lock
 
 
 class MasterKeyManager:
@@ -61,6 +79,7 @@ class MasterKeyManager:
             # Create Secrets Manager client
             import boto3
             from botocore.exceptions import ClientError
+
             session = boto3.session.Session()
             client = session.client(service_name="secretsmanager", region_name=region)
 
@@ -102,8 +121,6 @@ class MasterKeyManager:
         Raises:
             RuntimeError: If the master key cannot be retrieved or generated.
         """
-        import asyncio
-
         # Return cached key if available
         if cls._cached_master_key is not None:
             return cls._cached_master_key
@@ -119,42 +136,57 @@ class MasterKeyManager:
         aws_secret_name = os.environ.get("AWS_SECRETS_MASTER_KEY_NAME")
         if aws_secret_name:
             cls._get_logger().info(f"Attempting to retrieve master key from AWS Secrets Manager: {aws_secret_name}")
-            aws_key = cls._get_from_aws_secrets(aws_secret_name)
+            # boto3 IO is blocking, so run it off the event loop.
+            aws_key = await asyncio.to_thread(cls._get_from_aws_secrets, aws_secret_name)
             if aws_key:
                 cls._get_logger().info("Using master key from AWS Secrets Manager")
                 cls._cached_master_key = aws_key
                 return aws_key
-            else:
-                cls._get_logger().warning(
-                    "Failed to retrieve master key from AWS Secrets Manager, falling back to keychain"
-                )
-
-        # 3. Try to get from system keychain (using asyncio.to_thread to avoid blocking event loop)
-        try:
-            stored_key = await asyncio.to_thread(keyring.get_password, KEYRING_SERVICE, KEYRING_USERNAME)
-            if stored_key:
-                cls._get_logger().info("Using master key from system keychain")
-                cls._cached_master_key = stored_key
-                return stored_key
-        except KeyringError as e:
-            cls._get_logger().warning(f"Could not access system keychain: {e}")
-
-        # 4. Generate new master key and store in keychain
-        cls._get_logger().info("Generating new master key and storing in system keychain")
-        new_key = SecretCrypto.generate_master_key()
-
-        try:
-            await asyncio.to_thread(keyring.set_password, KEYRING_SERVICE, KEYRING_USERNAME, new_key)
-            cls._get_logger().info("Master key successfully stored in system keychain")
-        except KeyringError as e:
-            cls._get_logger().error(f"Failed to store master key in system keychain: {e}")
+            # AWS is explicitly configured but retrieval failed. Fail closed
+            # instead of falling through to the keychain/generate path, which
+            # would silently create a NEW key and make existing AWS-encrypted
+            # secrets permanently undecryptable.
             raise RuntimeError(
-                "Failed to store master key in system keychain. "
-                "Please set SECRETS_MASTER_KEY environment variable manually or configure AWS_SECRETS_MASTER_KEY_NAME."
-            ) from e
+                f"AWS_SECRETS_MASTER_KEY_NAME is set to '{aws_secret_name}' but the master key "
+                "could not be retrieved from AWS Secrets Manager. Refusing to generate a new key "
+                "to avoid making existing secrets undecryptable. Check AWS credentials, region, "
+                "and that the secret exists."
+            )
 
-        cls._cached_master_key = new_key
-        return new_key
+        # Serialize the keychain-lookup/generate section so that concurrent
+        # callers that all miss the cache generate at most one master key.
+        async with _get_master_key_lock():
+            # Double-checked locking: another task may have populated the cache
+            # while we were waiting to acquire the lock.
+            if cls._cached_master_key is not None:
+                return cls._cached_master_key
+
+            # 3. Try to get from system keychain (using asyncio.to_thread to avoid blocking event loop)
+            try:
+                stored_key = await asyncio.to_thread(keyring.get_password, KEYRING_SERVICE, KEYRING_USERNAME)
+                if stored_key:
+                    cls._get_logger().info("Using master key from system keychain")
+                    cls._cached_master_key = stored_key
+                    return stored_key
+            except KeyringError as e:
+                cls._get_logger().warning(f"Could not access system keychain: {e}")
+
+            # 4. Generate new master key and store in keychain
+            cls._get_logger().info("Generating new master key and storing in system keychain")
+            new_key = SecretCrypto.generate_master_key()
+
+            try:
+                await asyncio.to_thread(keyring.set_password, KEYRING_SERVICE, KEYRING_USERNAME, new_key)
+                cls._get_logger().info("Master key successfully stored in system keychain")
+            except KeyringError as e:
+                cls._get_logger().error(f"Failed to store master key in system keychain: {e}")
+                raise RuntimeError(
+                    "Failed to store master key in system keychain. "
+                    "Please set SECRETS_MASTER_KEY environment variable manually or configure AWS_SECRETS_MASTER_KEY_NAME."
+                ) from e
+
+            cls._cached_master_key = new_key
+            return new_key
 
     @classmethod
     def set_master_key(cls, master_key: str) -> None:

--- a/src/nodetool/security/master_key.py
+++ b/src/nodetool/security/master_key.py
@@ -23,19 +23,21 @@ KEYRING_USERNAME = "secrets_master_key"
 
 # Serializes the keychain-lookup/generate section of get_master_key so that
 # concurrent callers that all miss the cache do not each generate a different
-# master key. Created lazily to bind to the running event loop.
-_master_key_lock: Optional[asyncio.Lock] = None
-_master_key_lock_guard = threading.Lock()
+# master key. asyncio.Lock is bound to the event loop it is created in, so keep
+# one lock per running loop (keyed by loop id), matching the provider caches.
+_master_key_locks: dict[int, asyncio.Lock] = {}
+_master_key_locks_guard = threading.Lock()
 
 
 def _get_master_key_lock() -> asyncio.Lock:
-    """Return the shared asyncio lock, creating it on first use."""
-    global _master_key_lock
-    if _master_key_lock is None:
-        with _master_key_lock_guard:
-            if _master_key_lock is None:
-                _master_key_lock = asyncio.Lock()
-    return _master_key_lock
+    """Return the asyncio lock for the running event loop, creating it on first use."""
+    loop_id = id(asyncio.get_running_loop())
+    with _master_key_locks_guard:
+        lock = _master_key_locks.get(loop_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            _master_key_locks[loop_id] = lock
+        return lock
 
 
 class MasterKeyManager:

--- a/src/nodetool/worker/executor.py
+++ b/src/nodetool/worker/executor.py
@@ -1,6 +1,7 @@
 """
 Instantiate a Python BaseNode, execute it, and collect final outputs.
 """
+
 import asyncio
 import os
 import shutil
@@ -79,11 +80,13 @@ async def _emit_pending_progress(
             progress = 0
         if total is None:
             total = 100
-        await emit_progress({
-            "progress": progress,
-            "total": total,
-            "message": getattr(msg, "message", None),
-        })
+        await emit_progress(
+            {
+                "progress": progress,
+                "total": total,
+                "message": getattr(msg, "message", None),
+            }
+        )
 
 
 def _start_progress_pump(
@@ -178,9 +181,7 @@ async def _prepare_node(
             uri = input_ref_uris.get(field_name, f"blob://{field_name}")
             ref_type = _get_asset_ref_type(field_info.annotation)
             if isinstance(uri, list):
-                resolved_fields[field_name] = [
-                    {"uri": item, "type": ref_type} for item in uri
-                ]
+                resolved_fields[field_name] = [{"uri": item, "type": ref_type} for item in uri]
             else:
                 resolved_fields[field_name] = {
                     "uri": uri,
@@ -309,14 +310,13 @@ def _extract_outputs(
     output_blobs = ctx.get_output_blobs()
 
     if isinstance(result, ASSET_REF_TYPES) and result.uri and result.uri.startswith("blob://"):
-        blob_key = result.uri[len("blob://"):]
+        blob_key = result.uri[len("blob://") :]
         return {}, {"output": output_blobs.get(blob_key, b"")}
 
     # Check if result is a dict with blob values that need extraction
     if isinstance(result, dict):
         has_blobs = any(
-            isinstance(v, ASSET_REF_TYPES) and v.uri and v.uri.startswith("blob://")
-            for v in result.values()
+            isinstance(v, ASSET_REF_TYPES) and v.uri and v.uri.startswith("blob://") for v in result.values()
         )
         if has_blobs:
             # Multi-output with blobs: each key is a separate output slot
@@ -324,7 +324,7 @@ def _extract_outputs(
             blobs = {}
             for key, value in result.items():
                 if isinstance(value, ASSET_REF_TYPES) and value.uri and value.uri.startswith("blob://"):
-                    blob_key = value.uri[len("blob://"):]
+                    blob_key = value.uri[len("blob://") :]
                     if blob_key in output_blobs:
                         blobs[key] = output_blobs[blob_key]
                 else:
@@ -350,14 +350,10 @@ async def _collect_streaming_outputs(
     outputs: dict[str, Any] = {}
     async for item in node.gen_process(ctx):
         if not isinstance(item, dict):
-            raise TypeError(
-                "Streaming worker nodes must yield dictionaries mapping output names to values."
-            )
+            raise TypeError("Streaming worker nodes must yield dictionaries mapping output names to values.")
         for slot_name, value in item.items():
             if not isinstance(slot_name, str):
-                raise TypeError(
-                    "Streaming worker nodes must use string keys for output names."
-                )
+                raise TypeError("Streaming worker nodes must use string keys for output names.")
             if value is not None:
                 outputs[slot_name] = value
     return outputs
@@ -377,14 +373,10 @@ async def _stream_streaming_outputs(
     outputs: dict[str, Any] = {}
     async for item in node.gen_process(ctx):
         if not isinstance(item, dict):
-            raise TypeError(
-                "Streaming worker nodes must yield dictionaries mapping output names to values."
-            )
+            raise TypeError("Streaming worker nodes must yield dictionaries mapping output names to values.")
         for slot_name, value in item.items():
             if not isinstance(slot_name, str):
-                raise TypeError(
-                    "Streaming worker nodes must use string keys for output names."
-                )
+                raise TypeError("Streaming worker nodes must use string keys for output names.")
             if value is not None:
                 outputs[slot_name] = value
 
@@ -404,12 +396,8 @@ def _extract_named_outputs(
     blobs: dict[str, bytes] = {}
 
     for key, value in result.items():
-        if (
-            isinstance(value, ASSET_REF_TYPES)
-            and value.uri
-            and value.uri.startswith("blob://")
-        ):
-            blob_key = value.uri[len("blob://"):]
+        if isinstance(value, ASSET_REF_TYPES) and value.uri and value.uri.startswith("blob://"):
+            blob_key = value.uri[len("blob://") :]
             if blob_key in output_blobs:
                 blobs[key] = output_blobs[blob_key]
             continue
@@ -417,6 +405,33 @@ def _extract_named_outputs(
         outputs[key] = _serialize_value(value)
 
     return outputs, blobs
+
+
+def msgpack_default(obj: Any) -> Any:
+    """Fallback encoder for ``msgpack.packb``.
+
+    ``_serialize_value`` preserves ``datetime``/``Decimal``/``UUID`` and similar
+    types as native Python objects (python-mode ``model_dump``), but msgpack
+    cannot pack them. Transports call ``packb(msg, default=msgpack_default,
+    datetime=True)`` so ``datetime`` becomes a msgpack timestamp ext type and
+    this hook converts the rest to msgpack-native equivalents.
+    """
+    import decimal
+    import uuid
+
+    if isinstance(obj, decimal.Decimal):
+        return float(obj)
+    if isinstance(obj, uuid.UUID):
+        return str(obj)
+    if isinstance(obj, (set, frozenset)):
+        return list(obj)
+    if isinstance(obj, (bytes, bytearray)):
+        return bytes(obj)
+    # date/time/datetime and any object exposing isoformat().
+    isoformat = getattr(obj, "isoformat", None)
+    if callable(isoformat):
+        return isoformat()
+    raise TypeError(f"Object of type {type(obj).__name__} is not msgpack-serializable")
 
 
 def _serialize_value(value: Any) -> Any:
@@ -427,9 +442,11 @@ def _serialize_value(value: Any) -> Any:
             "type": TypeToName.get(type(value), type(value).__name__),
         }
     from enum import Enum
+
     if isinstance(value, Enum):
         return value.value
     from pydantic import BaseModel
+
     if isinstance(value, BaseModel):
         return value.model_dump()
     if isinstance(value, list):

--- a/src/nodetool/worker/executor.py
+++ b/src/nodetool/worker/executor.py
@@ -420,7 +420,9 @@ def msgpack_default(obj: Any) -> Any:
     import uuid
 
     if isinstance(obj, decimal.Decimal):
-        return float(obj)
+        # Encode as string, not float, so the TS side can parse it losslessly
+        # (float() would silently drop precision for cost/token accounting).
+        return str(obj)
     if isinstance(obj, uuid.UUID):
         return str(obj)
     if isinstance(obj, (set, frozenset)):

--- a/src/nodetool/worker/model_handler.py
+++ b/src/nodetool/worker/model_handler.py
@@ -99,14 +99,24 @@ async def _handle_download(
             if ignore:
                 files = [(f, s) for f, s in files if not _matches(f, ignore)]
 
+        # No matching files means the requested model/path does not exist in
+        # the repo. Report it as an error instead of falsely completing — the
+        # loop below would otherwise never run and we'd emit status "completed"
+        # for a download that never happened.
+        if not files:
+            if single:
+                raise ValueError(f"No file matching path {single!r} found in repo {repo_id}")
+            raise ValueError(
+                f"No files in repo {repo_id} matched the requested patterns "
+                f"(allow_patterns={allow}, ignore_patterns={ignore})"
+            )
+
         total_files = len(files)
         total_bytes = sum(s for _, s in files)
         done_bytes = 0
         done_files = 0
 
-        await send_progress(
-            request_id, frame("start", 0, total_bytes, 0, total_files, [])
-        )
+        await send_progress(request_id, frame("start", 0, total_bytes, 0, total_files, []))
 
         # Track in-flight progress sends so the terminal frames cannot race
         # ahead of the per-byte updates fired from the sync callback.
@@ -122,13 +132,15 @@ async def _handle_download(
                 await send_progress(
                     request_id,
                     frame(
-                        "cancelled", done_bytes, total_bytes, done_files,
-                        total_files, [],
+                        "cancelled",
+                        done_bytes,
+                        total_bytes,
+                        done_files,
+                        total_files,
+                        [],
                     ),
                 )
-                await send_result(
-                    request_id, {"repo_id": repo_id, "status": "cancelled"}
-                )
+                await send_result(request_id, {"repo_id": repo_id, "status": "cancelled"})
                 return
 
             file_base = done_bytes
@@ -151,9 +163,7 @@ async def _handle_download(
             ):
                 nonlocal done_bytes
                 _acc["bytes"] += delta
-                progressed = (
-                    min(_acc["bytes"], _fsize) if _fsize else _acc["bytes"]
-                )
+                progressed = min(_acc["bytes"], _fsize) if _fsize else _acc["bytes"]
                 done_bytes = _base + progressed
                 # fire-and-forget; ordering is preserved by the transport
                 # write-lock. Schedule on the running loop captured above so
@@ -162,8 +172,12 @@ async def _handle_download(
                     send_progress(
                         request_id,
                         frame(
-                            "progress", done_bytes, total_bytes, done_files,
-                            total_files, [_filename],
+                            "progress",
+                            done_bytes,
+                            total_bytes,
+                            done_files,
+                            total_files,
+                            [_filename],
                         ),
                     )
                 )
@@ -172,8 +186,11 @@ async def _handle_download(
 
             try:
                 await async_hf_download(
-                    repo_id, filename, token=token,
-                    progress_callback=on_bytes, cancel_event=cancel_event,
+                    repo_id,
+                    filename,
+                    token=token,
+                    progress_callback=on_bytes,
+                    cancel_event=cancel_event,
                 )
             except asyncio.CancelledError:
                 # Cooperative app-level cancel: async_hf_download raises
@@ -187,13 +204,15 @@ async def _handle_download(
                 await send_progress(
                     request_id,
                     frame(
-                        "cancelled", done_bytes, total_bytes, done_files,
-                        total_files, [],
+                        "cancelled",
+                        done_bytes,
+                        total_bytes,
+                        done_files,
+                        total_files,
+                        [],
                     ),
                 )
-                await send_result(
-                    request_id, {"repo_id": repo_id, "status": "cancelled"}
-                )
+                await send_result(request_id, {"repo_id": repo_id, "status": "cancelled"})
                 return
 
             # Snap to the exact file size so the next file's base is correct
@@ -206,9 +225,7 @@ async def _handle_download(
         await drain()
 
         if cancel_event.is_set():
-            await send_result(
-                request_id, {"repo_id": repo_id, "status": "cancelled"}
-            )
+            await send_result(request_id, {"repo_id": repo_id, "status": "cancelled"})
             return
 
         await send_progress(
@@ -241,9 +258,7 @@ async def handle_models_message(
         await transport.send_msg({"type": "result", "request_id": rid, "data": d})
 
     async def send_error(rid: str | None, error: str, tb: str | None = None) -> None:
-        await transport.send_msg(
-            {"type": "error", "request_id": rid, "data": {"error": error, "traceback": tb}}
-        )
+        await transport.send_msg({"type": "error", "request_id": rid, "data": {"error": error, "traceback": tb}})
 
     async def send_progress(rid: str | None, d: dict) -> None:
         await transport.send_msg({"type": "progress", "request_id": rid, "data": d})
@@ -260,9 +275,7 @@ async def handle_models_message(
             await send_result(request_id, {"models": payload})
 
         elif msg_type == "models.download":
-            await _handle_download(
-                data, request_id, cancel_flags, send_progress, send_result
-            )
+            await _handle_download(data, request_id, cancel_flags, send_progress, send_result)
 
         elif msg_type == "models.delete":
             deleted = await delete_cached_hf_model(data["repo_id"])

--- a/src/nodetool/worker/provider_handler.py
+++ b/src/nodetool/worker/provider_handler.py
@@ -8,13 +8,26 @@ so the same code path serves both the WebSocket and stdio workers.
 """
 
 import asyncio
+import hashlib
 import sys
 import traceback
 from typing import Any
 
-# Cached provider instances
-_provider_cache: dict[str, Any] = {}
+# Cached provider instances, keyed by (provider_id, secrets hash) so a
+# different / rotated secret set never reuses another caller's instance.
+_provider_cache: dict[tuple[str, str], Any] = {}
 _providers_imported = False
+
+
+def _hash_secrets(secrets: dict[str, str]) -> str:
+    """Stable hash of a secrets dict for cache keying (never logs values)."""
+    h = hashlib.sha256()
+    for key, value in sorted((secrets or {}).items()):
+        h.update(key.encode("utf-8"))
+        h.update(b"\x00")
+        h.update(str(value).encode("utf-8"))
+        h.update(b"\x00")
+    return h.hexdigest()
 
 
 def _ensure_providers_imported() -> None:
@@ -45,13 +58,14 @@ def _get_provider(provider_id: str, secrets: dict[str, str]) -> Any:
 
     _ensure_providers_imported()
 
-    if provider_id in _provider_cache:
-        return _provider_cache[provider_id]
+    cache_key = (provider_id, _hash_secrets(secrets))
+    if cache_key in _provider_cache:
+        return _provider_cache[cache_key]
 
     provider_enum = Provider(provider_id)
     cls, kwargs = get_registered_provider(provider_enum)
     instance = cls(secrets=secrets, **kwargs)
-    _provider_cache[provider_id] = instance
+    _provider_cache[cache_key] = instance
     return instance
 
 
@@ -96,11 +110,7 @@ def get_available_providers() -> list[dict[str, Any]]:
                 {
                     "id": pid,
                     "capabilities": capabilities,
-                    "required_secrets": (
-                        cls.required_secrets()
-                        if hasattr(cls, "required_secrets")
-                        else []
-                    ),
+                    "required_secrets": (cls.required_secrets() if hasattr(cls, "required_secrets") else []),
                 }
             )
     return result
@@ -141,10 +151,7 @@ def _deserialize_messages(raw_messages: list[dict]) -> list[Any]:
         if m.get("tool_calls"):
             from nodetool.metadata.types import ToolCall
 
-            msg.tool_calls = [
-                ToolCall(id=tc["id"], name=tc["name"], args=tc.get("args", {}))
-                for tc in m["tool_calls"]
-            ]
+            msg.tool_calls = [ToolCall(id=tc["id"], name=tc["name"], args=tc.get("args", {})) for tc in m["tool_calls"]]
         if m.get("tool_call_id"):
             msg.tool_call_id = m["tool_call_id"]
         messages.append(msg)
@@ -163,9 +170,7 @@ def _serialize_message(msg: Any) -> dict:
         result["content"] = str(msg.content)
 
     if msg.tool_calls:
-        result["tool_calls"] = [
-            {"id": tc.id, "name": tc.name, "args": tc.args} for tc in msg.tool_calls
-        ]
+        result["tool_calls"] = [{"id": tc.id, "name": tc.name, "args": tc.args} for tc in msg.tool_calls]
     return result
 
 
@@ -204,11 +209,7 @@ async def _handle_models(data: dict) -> dict:
         return {"models": []}
 
     models = await getter()
-    return {
-        "models": [
-            m.model_dump() if hasattr(m, "model_dump") else m.__dict__ for m in models
-        ]
-    }
+    return {"models": [m.model_dump() if hasattr(m, "model_dump") else m.__dict__ for m in models]}
 
 
 async def _handle_generate(data: dict) -> dict:
@@ -409,9 +410,7 @@ async def handle_provider_message(
 
                 from nodetool.metadata.types import ToolCall
 
-                async for item in provider.generate_messages(
-                    messages=messages, model=model, **kwargs
-                ):
+                async for item in provider.generate_messages(messages=messages, model=model, **kwargs):
                     if cancel_event.is_set():
                         break
                     if isinstance(item, ToolCall):
@@ -470,9 +469,7 @@ async def handle_provider_message(
                 async for audio_chunk in provider.text_to_speech(**kwargs_tts):
                     if cancel_event.is_set():
                         break
-                    await send_chunk(
-                        request_id, {"blobs": {"audio": audio_chunk.tobytes()}}
-                    )
+                    await send_chunk(request_id, {"blobs": {"audio": audio_chunk.tobytes()}})
                 await send_result(request_id, {"done": True})
             finally:
                 if request_id:

--- a/src/nodetool/worker/server.py
+++ b/src/nodetool/worker/server.py
@@ -1,4 +1,6 @@
 import asyncio
+import logging
+import os
 from typing import Any, Awaitable, Callable, cast
 
 import msgpack
@@ -6,9 +8,12 @@ from websockets.asyncio.server import ServerConnection
 from websockets.asyncio.server import serve as ws_serve
 from websockets.exceptions import ConnectionClosed
 
+from nodetool.worker.executor import msgpack_default
 from nodetool.worker.msgpack_codec import decode_message
 from nodetool.worker.protocol import WorkerProtocolServer
 from nodetool.worker.worker_auth import make_process_request
+
+log = logging.getLogger(__name__)
 
 
 class WebSocketTransport:
@@ -24,7 +29,7 @@ class WebSocketTransport:
 
     async def send_msg(self, msg: dict[str, Any]) -> None:
         """Encode and send a dict as msgpack (thread-safe)."""
-        data = cast("bytes", msgpack.packb(msg))
+        data = cast("bytes", msgpack.packb(msg, default=msgpack_default, datetime=True))
         async with self._write_lock:
             await self._ws.send(data)
 
@@ -84,6 +89,20 @@ async def start_server(
     """Start the WebSocket server. Returns (host, port, stop_event, task)."""
     if worker is None:
         worker = WorkerServer()
+
+    # Security: warn loudly when the worker is reachable off-host without a token.
+    # An open bind on a non-loopback interface exposes arbitrary node execution,
+    # model file writes, and worker env vars to any peer that can reach the port.
+    if host not in ("127.0.0.1", "::1", "localhost") and not os.environ.get("NODETOOL_WORKER_TOKEN"):
+        log.warning(
+            "Worker bound to non-loopback host %r with no NODETOOL_WORKER_TOKEN set: "
+            "the bridge is UNAUTHENTICATED and any peer that can reach %s:%s can execute "
+            "nodes, write model files, and read worker environment variables. "
+            "Set NODETOOL_WORKER_TOKEN (on both worker and the TS server) or bind to 127.0.0.1.",
+            host,
+            host,
+            port,
+        )
 
     stop_event = asyncio.Event()
 

--- a/src/nodetool/worker/stdio_server.py
+++ b/src/nodetool/worker/stdio_server.py
@@ -17,6 +17,7 @@ from typing import Any, Awaitable, Callable
 
 import msgpack
 
+from nodetool.worker.executor import msgpack_default
 from nodetool.worker.msgpack_codec import decode_message
 from nodetool.worker.protocol import MAX_BRIDGE_FRAME_SIZE, WorkerProtocolServer
 from nodetool.worker.stdio_stdout_guard import get_protocol_stdout_buffer
@@ -45,9 +46,7 @@ class StdioTransport:
             return None
         length = struct.unpack(">I", header)[0]
         if length > MAX_BRIDGE_FRAME_SIZE:
-            raise ValueError(
-                f"Incoming bridge frame exceeds max size ({length} > {MAX_BRIDGE_FRAME_SIZE})"
-            )
+            raise ValueError(f"Incoming bridge frame exceeds max size ({length} > {MAX_BRIDGE_FRAME_SIZE})")
         payload = await loop.run_in_executor(None, sys.stdin.buffer.read, length)
         if len(payload) < length:
             return None
@@ -57,9 +56,7 @@ class StdioTransport:
         """Write a length-prefixed msgpack payload (thread-safe)."""
         loop = asyncio.get_event_loop()
         if len(data) > MAX_BRIDGE_FRAME_SIZE:
-            raise ValueError(
-                f"Outgoing bridge frame exceeds max size ({len(data)} > {MAX_BRIDGE_FRAME_SIZE})"
-            )
+            raise ValueError(f"Outgoing bridge frame exceeds max size ({len(data)} > {MAX_BRIDGE_FRAME_SIZE})")
         message = struct.pack(">I", len(data)) + data
         async with self._write_lock:
             await loop.run_in_executor(None, self._protocol_stdout.write, message)
@@ -67,7 +64,7 @@ class StdioTransport:
 
     async def send_msg(self, msg: dict[str, Any]) -> None:
         """Encode and send a dict as msgpack."""
-        await self.send(msgpack.packb(msg))
+        await self.send(msgpack.packb(msg, default=msgpack_default, datetime=True))
 
 
 class StdioWorkerServer:
@@ -113,9 +110,7 @@ class StdioWorkerServer:
                     break
                 if msg is None:
                     break
-                task = asyncio.create_task(
-                    self._protocol.dispatch(msg, self._transport)
-                )
+                task = asyncio.create_task(self._protocol.dispatch(msg, self._transport))
                 self._tasks.add(task)
                 task.add_done_callback(self._tasks.discard)
         except KeyboardInterrupt:
@@ -177,12 +172,14 @@ async def run_stdio_worker(namespaces: list[str] | None = None) -> None:
     # server.run() so the first execute() finds the module cached.
     if "huggingface" in resolved_namespaces:
         import time as _time
+
         _t0 = _time.perf_counter()
         print("Warm-importing heavy ML modules...", file=sys.stderr, flush=True)
         try:
             from diffusers.pipelines.flux.pipeline_flux import FluxPipeline  # noqa: F401
+
             print(
-                f"Warm-imported diffusers.FluxPipeline in {_time.perf_counter()-_t0:.1f}s",
+                f"Warm-imported diffusers.FluxPipeline in {_time.perf_counter() - _t0:.1f}s",
                 file=sys.stderr,
                 flush=True,
             )

--- a/src/nodetool/workflows/README.md
+++ b/src/nodetool/workflows/README.md
@@ -13,6 +13,5 @@ This directory contains the node execution primitives. Workflow orchestration (D
 - `processing_offload.py` — `asyncio.to_thread` wrappers for CPU-bound work
 - `torch_support.py` — PyTorch device selection and VRAM management
 - `property.py` — Node property descriptors
-- `recommended_models.py` — Model recommendations per node type
 - `asset_storage.py` — Asset ref content-type detection and auto-save helpers
 - `io.py` — `NodeInputs` / `NodeOutputs` helpers

--- a/src/nodetool/workflows/graph.py
+++ b/src/nodetool/workflows/graph.py
@@ -87,7 +87,9 @@ class Graph(BaseModel):
         """
         Find edges by their source and source_handle.
         """
-        if getattr(self, '_outgoing_edges_cache', None) is None or getattr(self, '_cached_edges_len', -1) != len(self.edges):
+        if getattr(self, "_outgoing_edges_cache", None) is None or getattr(self, "_cached_edges_len", -1) != len(
+            self.edges
+        ):
             self._outgoing_edges_cache = defaultdict(list)
             for edge in self.edges:
                 self._outgoing_edges_cache[(edge.source, edge.sourceHandle)].append(edge)
@@ -148,6 +150,10 @@ class Graph(BaseModel):
 
         # Process nodes, collecting valid ones
         for node_data in graph["nodes"]:
+            # Safe defaults so the except handlers below never raise NameError
+            # if node_data is not a dict (the .get calls would fail before assignment).
+            node_id = None
+            node_type = "<unknown>"
             try:
                 # Filter out properties that have incoming edges
                 node_id = node_data.get("id")
@@ -185,7 +191,7 @@ class Graph(BaseModel):
 
         # Process edges, filtering out invalid ones
         valid_edges = []
-        for edge_data in graph["edges"]:
+        for edge_data in graph.get("edges", []):
             try:
                 # Check if edge has required fields
                 if (

--- a/src/nodetool/workflows/io.py
+++ b/src/nodetool/workflows/io.py
@@ -162,9 +162,9 @@ class NodeOutputs:
         # Lazy imports to avoid cycles
         from .base_node import BaseNode
         from .processing_context import ProcessingContext
-        from .workflow_runner import WorkflowRunner
 
-        assert isinstance(runner, WorkflowRunner)
+        # ``runner`` is duck-typed (WorkflowRunner lives in the TS server now);
+        # it only needs to expose send_messages/node_inboxes/outputs.
         assert isinstance(node, BaseNode)
         assert isinstance(context, ProcessingContext)
 
@@ -271,11 +271,10 @@ class NodeOutputs:
         """
         from .base_node import BaseNode
         from .processing_context import ProcessingContext
-        from .workflow_runner import WorkflowRunner
 
+        # ``self.runner`` is duck-typed (WorkflowRunner lives in the TS server now).
         assert isinstance(self.node, BaseNode)
         assert isinstance(self.context, ProcessingContext)
-        assert isinstance(self.runner, WorkflowRunner)
 
         if self.capture_only:
             return

--- a/src/nodetool/workflows/processing_context.py
+++ b/src/nodetool/workflows/processing_context.py
@@ -12,6 +12,7 @@ from contextlib import suppress
 from datetime import datetime
 from enum import Enum, StrEnum
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -509,10 +510,6 @@ class ProcessingContext:
             value (Any): The value to set.
         """
         self.variables[key] = value
-        self._persist_variable_if_needed(key, value)
-
-
-
 
     def _workspace_path(self, filename: str) -> Path:
         if not self.workspace_dir:
@@ -575,18 +572,6 @@ class ProcessingContext:
         """
         return await require_scope().get_asset_storage().get_url(key)
 
-
-
-
-
-
-
-
-
-
-
-
-
     async def refresh_uri(self, asset: AssetRef):
         """
         Refreshes the URI of the asset.
@@ -613,7 +598,6 @@ class ProcessingContext:
             extension = get_extension_for_content_type(content_type)
             asset.uri = f"asset://{asset.asset_id}{extension}"
 
-
     async def create_asset(
         self,
         name: str,
@@ -622,11 +606,13 @@ class ProcessingContext:
         parent_id: str | None = None,
         instructions: IO | None = None,
         node_id: str | None = None,
-    ) -> dict[str, Any]:
+    ) -> SimpleNamespace:
         """
         Creates an asset and uploads it to storage.
 
-        Returns a dict with asset metadata (id, name, content_type, file_name, size).
+        Returns a lightweight object exposing attribute access to the asset
+        metadata (id, name, content_type, file_name, size, user_id,
+        workflow_id, node_id).
         """
         from nodetool.types.content_types import CONTENT_TYPE_TO_EXTENSION
 
@@ -645,16 +631,16 @@ class ProcessingContext:
         storage = require_scope().get_asset_storage()
         await storage.upload(file_name, BytesIO(content_bytes))
 
-        return {
-            "id": asset_id,
-            "name": name,
-            "content_type": content_type,
-            "file_name": file_name,
-            "size": len(content_bytes),
-            "user_id": self.user_id,
-            "workflow_id": self.workflow_id,
-            "node_id": node_id,
-        }
+        return SimpleNamespace(
+            id=asset_id,
+            name=name,
+            content_type=content_type,
+            file_name=file_name,
+            size=len(content_bytes),
+            user_id=self.user_id,
+            workflow_id=self.workflow_id,
+            node_id=node_id,
+        )
 
     async def download_asset(self, asset_id: str) -> IO:
         """
@@ -864,8 +850,19 @@ class ProcessingContext:
         except Exception as e:
             log.debug(f"Failed to get from URI cache: {e}")
 
-        response = await self.http_get(url)
-        content = response.content
+        # 🛡️ SSRF protection: block private/restricted hosts and resolve via a
+        # guarded resolver, mirroring asset_storage.download_http_uri.
+        import aiohttp
+
+        from nodetool.utils.network import SSRFProtectResolver, is_ip_private
+
+        if url_parsed.hostname and is_ip_private(url_parsed.hostname):
+            raise ValueError(f"Access to private/restricted IP blocked: {url_parsed.hostname}")
+
+        connector = aiohttp.TCPConnector(resolver=SSRFProtectResolver())
+        async with aiohttp.ClientSession(connector=connector) as session, session.get(url) as response:
+            response.raise_for_status()
+            content = await response.read()
 
         # Store downloaded bytes in URI cache for 5 minutes
         with suppress(Exception):
@@ -939,7 +936,13 @@ class ProcessingContext:
                         return BytesIO(await _in_thread(_numpy_image_to_png_bytes, obj))
                     elif isinstance(asset_ref, AudioRef):
                         # Encode numpy audio array as WAV/PCM bytes
-                        return BytesIO(await _in_thread(_numpy_audio_to_wav_bytes, obj, asset_ref.metadata.get("sample_rate", 44100)))
+                        return BytesIO(
+                            await _in_thread(
+                                _numpy_audio_to_wav_bytes,
+                                obj,
+                                asset_ref.metadata.get("sample_rate", 44100) if asset_ref.metadata else 44100,
+                            )
+                        )
                     elif isinstance(asset_ref, VideoRef):
                         # Encode numpy video array as MP4 using shared utility (T,H,W,C)
                         try:
@@ -2263,7 +2266,6 @@ class ProcessingContext:
         else:
             return value
 
-
     async def is_huggingface_model_cached(self, repo_id: str):
         """
         Check if a Hugging Face model is already cached locally.
@@ -2311,9 +2313,6 @@ class ProcessingContext:
             return MODEL_3D_FORMAT_MAPPING.get(asset.format or "glb", ("model/gltf-binary", "glb"))
         return "application/octet-stream", "bin"
 
-
-
-
     async def _asset_to_workspace_file(self, asset: AssetRef) -> dict[str, Any] | AssetRef:
         """Persist asset to local workspace and return file path reference."""
         if isinstance(asset, DataframeRef):
@@ -2334,8 +2333,6 @@ class ProcessingContext:
             "asset_id": asset.asset_id,
         }
 
-
-
     async def assets_to_workspace_files(self, value: Any) -> Any:
         """Recursively persist AssetRefs to the workspace directory."""
         if isinstance(value, AssetRef):
@@ -2353,7 +2350,27 @@ class ProcessingContext:
         else:
             return value
 
+    async def assets_to_data_uri(self, value: Any) -> Any:
+        """Encode AssetRefs as base64 data URIs (DATA_URI output mode)."""
+        raise NotImplementedError(
+            f"asset_output_mode {AssetOutputMode.DATA_URI} is not supported in the Python node runner"
+        )
 
+    async def upload_assets_to_temp(self, value: Any) -> Any:
+        """Upload AssetRefs to temporary storage (TEMP_URL output mode)."""
+        raise NotImplementedError(
+            f"asset_output_mode {AssetOutputMode.TEMP_URL} is not supported in the Python node runner"
+        )
+
+    async def assets_to_storage_url(self, value: Any) -> Any:
+        """Persist AssetRefs to storage and return URLs (STORAGE_URL output mode)."""
+        raise NotImplementedError(
+            f"asset_output_mode {AssetOutputMode.STORAGE_URL} is not supported in the Python node runner"
+        )
+
+    async def embed_assets_in_data(self, value: Any) -> Any:
+        """Embed asset bytes inline in the value (RAW output mode)."""
+        raise NotImplementedError(f"asset_output_mode {AssetOutputMode.RAW} is not supported in the Python node runner")
 
     async def normalize_output_value(self, value: Any) -> Any:
         """
@@ -2450,9 +2467,6 @@ class ProcessingContext:
 
         return resolve_workspace_path(self.workspace_dir, path)
 
-
-
-
     def clear_memory(self, pattern: str | None = None):
         """
         Clear memory objects, optionally matching a pattern.
@@ -2473,7 +2487,6 @@ class ProcessingContext:
         # Node cache interface does not expose iteration over items.
         # Return an empty summary to avoid leaking implementation details.
         return {"total_objects": 0, "types": {}}
-
 
     async def cleanup(self):
         """

--- a/src/nodetool/workflows/processing_context.py
+++ b/src/nodetool/workflows/processing_context.py
@@ -851,18 +851,40 @@ class ProcessingContext:
             log.debug(f"Failed to get from URI cache: {e}")
 
         # 🛡️ SSRF protection: block private/restricted hosts and resolve via a
-        # guarded resolver, mirroring asset_storage.download_http_uri.
+        # guarded resolver, mirroring asset_storage.download_http_uri. Redirects
+        # are followed manually so each hop's hostname is re-validated — aiohttp's
+        # automatic redirects (and the connector's IP-literal short-circuit) would
+        # otherwise let a redirect to an IP literal such as http://169.254.169.254/
+        # bypass the SSRF check.
         import aiohttp
+        from urllib.parse import urljoin, urlparse
 
         from nodetool.utils.network import SSRFProtectResolver, is_ip_private
 
-        if url_parsed.hostname and is_ip_private(url_parsed.hostname):
-            raise ValueError(f"Access to private/restricted IP blocked: {url_parsed.hostname}")
+        def _block_private(target: str) -> None:
+            host = urlparse(target).hostname
+            if host and is_ip_private(host):
+                raise ValueError(f"Access to private/restricted IP blocked: {host}")
 
+        max_redirects = 5
+        current_url = url
         connector = aiohttp.TCPConnector(resolver=SSRFProtectResolver())
-        async with aiohttp.ClientSession(connector=connector) as session, session.get(url) as response:
-            response.raise_for_status()
-            content = await response.read()
+        async with aiohttp.ClientSession(connector=connector) as session:
+            for _ in range(max_redirects + 1):
+                _block_private(current_url)
+                async with session.get(current_url, allow_redirects=False) as response:
+                    if response.status in (301, 302, 303, 307, 308):
+                        location = response.headers.get("Location")
+                        if not location:
+                            response.raise_for_status()
+                            raise ValueError(f"Redirect with no Location header: {current_url}")
+                        current_url = urljoin(current_url, location)
+                        continue
+                    response.raise_for_status()
+                    content = await response.read()
+                    break
+            else:
+                raise ValueError(f"Too many redirects while fetching: {url}")
 
         # Store downloaded bytes in URI cache for 5 minutes
         with suppress(Exception):

--- a/src/nodetool/workflows/property.py
+++ b/src/nodetool/workflows/property.py
@@ -112,9 +112,9 @@ class Property(BaseModel):
         schema = self.type.get_json_schema()
         if self.description and self.description != "":
             schema["description"] = self.description
-        if self.min:
+        if self.min is not None:
             schema["minimum"] = self.min if self.type.type != "int" else int(self.min)
-        if self.max:
+        if self.max is not None:
             schema["maximum"] = self.max if self.type.type != "int" else int(self.max)
         return schema
 

--- a/tests/common/test_async_chroma_client.py
+++ b/tests/common/test_async_chroma_client.py
@@ -5,11 +5,14 @@ These tests use a real ChromaDB instance (on-disk persistent client) to ensure
 all functionality works correctly with actual data storage and retrieval.
 """
 
-import chromadb
-import chromadb.errors
 import pytest
 import pytest_asyncio
 from packaging import version
+
+pytest.importorskip("chromadb")
+
+import chromadb
+import chromadb.errors
 
 from nodetool.integrations.vectorstores.chroma.async_chroma_client import (
     AsyncChromaClient,

--- a/tests/common/test_media_utils.py
+++ b/tests/common/test_media_utils.py
@@ -2,9 +2,12 @@ import os
 import shutil
 from io import BytesIO
 
-import cv2
 import numpy as np
 import pytest
+
+pytest.importorskip("cv2")
+
+import cv2
 
 from nodetool.media.common.media_utils import (
     create_image_thumbnail,

--- a/tests/common/test_video_export_optimization.py
+++ b/tests/common/test_video_export_optimization.py
@@ -6,10 +6,13 @@ import io
 import os
 import tempfile
 
-import imageio
 import numpy as np
 import pytest
 from PIL import Image
+
+pytest.importorskip("imageio")
+
+import imageio
 
 from nodetool.media.video.video_utils import export_to_video_bytes
 
@@ -34,7 +37,7 @@ class TestVideoExportOptimization:
             tmp_path = tmp.name
 
         try:
-            reader = imageio.get_reader(tmp_path, format='ffmpeg')
+            reader = imageio.get_reader(tmp_path, format="ffmpeg")
             read_frame = reader.get_data(0)
             reader.close()
 
@@ -60,7 +63,7 @@ class TestVideoExportOptimization:
             tmp_path = tmp.name
 
         try:
-            reader = imageio.get_reader(tmp_path, format='ffmpeg')
+            reader = imageio.get_reader(tmp_path, format="ffmpeg")
             read_frame = reader.get_data(0)
             reader.close()
 
@@ -84,7 +87,7 @@ class TestVideoExportOptimization:
             tmp_path = tmp.name
 
         try:
-            reader = imageio.get_reader(tmp_path, format='ffmpeg')
+            reader = imageio.get_reader(tmp_path, format="ffmpeg")
             read_frame = reader.get_data(0)
             reader.close()
 
@@ -101,7 +104,7 @@ class TestVideoExportOptimization:
         # If frames are same size, mixed types should work due to lazy conversion loop.
 
         frame1 = np.full((64, 64, 3), 100, dtype=np.uint8)
-        frame2 = np.full((64, 64, 3), 0.5, dtype=np.float32) # should become ~127
+        frame2 = np.full((64, 64, 3), 0.5, dtype=np.float32)  # should become ~127
         frames = [frame1, frame2]
 
         video_bytes = export_to_video_bytes(frames, fps=2)
@@ -111,7 +114,7 @@ class TestVideoExportOptimization:
             tmp_path = tmp.name
 
         try:
-            reader = imageio.get_reader(tmp_path, format='ffmpeg')
+            reader = imageio.get_reader(tmp_path, format="ffmpeg")
             f1 = reader.get_data(0)
             f2 = reader.get_data(1)
             reader.close()

--- a/tests/integrations/test_safetensor_layout.py
+++ b/tests/integrations/test_safetensor_layout.py
@@ -4,6 +4,10 @@ from pathlib import Path
 from typing import Iterable
 
 import numpy as np
+import pytest
+
+pytest.importorskip("safetensors")
+
 from safetensors.numpy import save_file
 
 from nodetool.integrations.huggingface.safetensor_layout import (

--- a/tests/integrations/test_safetensors_inspector.py
+++ b/tests/integrations/test_safetensors_inspector.py
@@ -3,6 +3,10 @@
 from pathlib import Path
 
 import numpy as np
+import pytest
+
+pytest.importorskip("safetensors")
+
 from safetensors.numpy import save_file
 
 from nodetool.integrations.huggingface.safetensors_inspector import (

--- a/tests/integrations/vectorstores/test_async_chroma_client.py
+++ b/tests/integrations/vectorstores/test_async_chroma_client.py
@@ -2,6 +2,8 @@ import inspect
 
 import pytest
 
+pytest.importorskip("chromadb")
+
 from nodetool.integrations.vectorstores.chroma.async_chroma_client import (
     AsyncChromaClient,
 )

--- a/tests/integrations/vectorstores/test_chroma_client.py
+++ b/tests/integrations/vectorstores/test_chroma_client.py
@@ -5,8 +5,11 @@ These tests use a real ChromaDB instance (on-disk persistent client) to ensure
 all functionality works correctly with actual data storage and retrieval.
 """
 
-import chromadb.errors
 import pytest
+
+pytest.importorskip("chromadb")
+
+import chromadb.errors
 
 from nodetool.integrations.vectorstores.chroma.chroma_client import (
     DEFAULT_SEPARATORS,

--- a/tests/test_joblib_security.py
+++ b/tests/test_joblib_security.py
@@ -1,15 +1,19 @@
 import io
 import os
 
-import joblib
 import numpy as np
 import pytest
+
+pytest.importorskip("joblib")
+
+import joblib
 
 from nodetool.workflows.processing_offload import _joblib_load_from_io
 
 
 def test_exploit_fails():
     """Test that loading an exploit payload raises a ValueError."""
+
     class Exploit:
         def __reduce__(self):
             return (os.system, ("echo 'VULNERABILITY EXPLOITED' > exploit_result_test.txt",))
@@ -23,8 +27,10 @@ def test_exploit_fails():
 
     assert not os.path.exists("exploit_result_test.txt")
 
+
 def test_exploit_eval_fails():
     """Test that loading an exploit payload using builtins.eval raises a ValueError."""
+
     class Exploit:
         def __reduce__(self):
             return (eval, ("print('VULNERABILITY EXPLOITED')",))
@@ -36,6 +42,7 @@ def test_exploit_eval_fails():
     with pytest.raises(ValueError, match="Unsafe or invalid model data"):
         _joblib_load_from_io(buffer)
 
+
 def test_valid_load_numpy():
     """Test that loading a valid numpy array works."""
     data = np.array([[1, 2], [3, 4]])
@@ -46,6 +53,7 @@ def test_valid_load_numpy():
     loaded = _joblib_load_from_io(buffer)
     assert np.array_equal(data, loaded)
 
+
 def test_valid_load_basic():
     """Test that loading basic python types works."""
     data = {"a": 1, "b": [2, 3], "c": "test"}
@@ -55,6 +63,7 @@ def test_valid_load_basic():
 
     loaded = _joblib_load_from_io(buffer)
     assert loaded == data
+
 
 def test_valid_load_compressed():
     """Test that loading a compressed joblib file works."""

--- a/tests/workflows/test_processing_context_dataframe.py
+++ b/tests/workflows/test_processing_context_dataframe.py
@@ -1,5 +1,8 @@
-import pandas as pd
 import pytest
+
+pytest.importorskip("pandas")
+
+import pandas as pd
 
 from nodetool.metadata.types import ColumnDef, DataframeRef
 from nodetool.workflows.processing_context import ProcessingContext

--- a/tests/workflows/test_processing_offload_module.py
+++ b/tests/workflows/test_processing_offload_module.py
@@ -38,7 +38,10 @@ def test_joblib_dump_load_roundtrip():
 
 
 def _has_ffmpeg() -> bool:
-    from pydub.utils import which
+    try:
+        from pydub.utils import which
+    except ImportError:
+        return False
 
     return which("ffmpeg") is not None
 
@@ -70,4 +73,3 @@ def test_numpy_audio_mp3_export_and_import_without_mocking():
 
     decoded = _audio_segment_from_file(BytesIO(mp3_bytes))
     assert 50 <= len(decoded) <= 500
-

--- a/uv.lock
+++ b/uv.lock
@@ -2536,6 +2536,7 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "safetensors" },
     { name = "ty" },
 ]
 documents = [
@@ -2627,6 +2628,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.17" },
+    { name = "safetensors", marker = "extra == 'dev'", specifier = ">=0.4.0" },
     { name = "seaborn", marker = "extra == 'viz'", specifier = ">=0.13.2" },
     { name = "tiktoken", marker = "extra == 'data'" },
     { name = "tqdm", specifier = ">=4.67.0" },


### PR DESCRIPTION
Addresses issues found in a full code-review audit of the repo.

Workflows core (crash bugs left by the TS migration):
- processing_context.set(): drop call to nonexistent _persist_variable_if_needed
- create_asset(): return an attribute-accessible object (7 callers used .id/.file_name)
- normalize_output_value(): raise clear NotImplementedError for unsupported
  asset_output_modes instead of AttributeError on missing dispatch methods
- io.NodeOutputs: remove dead import of deleted workflow_runner module
- asset_to_io: guard AssetRef.metadata None before .get(sample_rate)
- download_file(): route http(s) through SSRF-protected fetch (private-IP block
  + SSRFProtectResolver), matching asset_storage

Media / fetch:
- resize_audio(): fix negative padding so audio actually pads when grown
- media_fetch/web_font_utils: re-validate every redirect hop against private IPs
  (close SSRF-via-redirect bypass); parse non-base64 data URIs correctly
- web_font_utils: run font-download coroutine safely from within a running loop

HF / ml:
- model_manager: remove import of deleted nodetool.system; stop wiping the whole
  model cache when VRAM telemetry is unavailable; reconcile unload_model key format
- async_downloader/llama_cpp_download/hf_fast_cache: sanitize server- and
  listing-controlled path components to prevent cache-dir traversal
- artifact_inspector: correct GGUF header parsing (uint64 lengths, string/array types)

Worker:
- provider caches: key by secrets/user so rotated or per-user secrets aren't reused
- model_handler: report an error (not success) when a download matches no files
- executor/server/stdio_server: msgpack-encode datetime/Decimal/UUID/set so result
  frames don't fail to pack (and hang the parent)
- server: warn loudly when bound to a non-loopback host without a worker token

Config / security:
- environment: remove duplicated @classmethod on get_logger; fix .env precedence;
  make env vars win over settings.yaml (matching documented contract)
- master_key: fail closed when AWS Secrets Manager is configured but unavailable;
  guard key generation with a lock; run boto3 IO off the event loop
- logging_config: don't destroy a host application's logging configuration on import
- settings: register SERVER_AUTH_TOKEN only as a secret, not a plaintext setting
- crypto: correct docstring/unreachable branch

Metadata / types:
- typecheck: match dict payloads against union members
- comfy_model_to_folder: cover both comfy.X and comfy.X_file type variants
- Task.to_markdown: stop emitting description twice; Step.is_running: honor end_time
- property: keep min=0/max=0 constraints in JSON schema
- graph: tolerate missing edges key; avoid NameError masking parse errors

Build / tests / docs:
- declare safetensors; add importorskip guards so pytest collects on a base install
- correct stale file trees and commands in CLAUDE.md and provider/security/workflows READMEs

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013aeZ9Vo7AnsAtxc9uwdvM1