### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in download_http_uri

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -57,3 +57,7 @@
 **Vulnerability:** The functions `download_google_font` and `download_font_from_url` in `src/nodetool/media/image/web_font_utils.py` used `urllib.request.urlopen` with DNS checking that was susceptible to DNS rebinding (TOCTOU), allowing for Server-Side Request Forgery (SSRF) vulnerabilities when accessing external font URLs.
 **Learning:** `urllib.request` does not allow custom DNS resolvers, making it inherently vulnerable to DNS rebinding bypass techniques even when pre-flight IP checks (like `is_ip_private`) are implemented.
 **Prevention:** Always replace `urllib.request` with `aiohttp` using a custom connector configured with `SSRFProtectResolver` (`aiohttp.TCPConnector(resolver=SSRFProtectResolver())`) to guarantee robust DNS rebinding SSRF protection when downloading user-provided external URLs.
+## YYYY-MM-DD - SSRF bypass in HTTP URI asset downloading
+**Vulnerability:** `aiohttp.ClientSession` was instantiated with `SSRFProtectResolver`, but redirects were not manually handled and `is_ip_private` was only checked on the initial URL. This allowed SSRF attacks where a public URL redirected to a private IP, bypassing the protection.
+**Learning:** When using `aiohttp` for SSRF protection, `allow_redirects=False` must be set, and redirects must be followed manually to ensure the hostname at every hop is validated against private/restricted IPs.
+**Prevention:** Use the pattern established in `_fetch_http_uri_async` and `download_google_font` when creating a new HTTP download function.

--- a/src/nodetool/workflows/asset_storage.py
+++ b/src/nodetool/workflows/asset_storage.py
@@ -296,17 +296,35 @@ async def download_http_uri(uri: str, path: str) -> BytesIO | None:
     Returns:
         BytesIO containing the downloaded data, or None if download failed
     """
-    parsed = urlparse(uri)
-    if parsed.hostname and is_ip_private(parsed.hostname):
-        logger.warning("Access to private/restricted IP blocked: %s at %s", parsed.hostname, path)
-        return None
+    from urllib.parse import urljoin
+
+    max_redirects = 5
+    current_uri = uri
 
     try:
         connector = aiohttp.TCPConnector(resolver=SSRFProtectResolver())
-        async with aiohttp.ClientSession(connector=connector) as session, session.get(uri) as response:
-            response.raise_for_status()
-            data = await response.read()
-            return BytesIO(data)
+        async with aiohttp.ClientSession(connector=connector) as session:
+            for _ in range(max_redirects + 1):
+                parsed = urlparse(current_uri)
+                if parsed.hostname and is_ip_private(parsed.hostname):
+                    logger.warning("Access to private/restricted IP blocked: %s at %s", parsed.hostname, path)
+                    return None
+
+                async with session.get(current_uri, allow_redirects=False) as response:
+                    if response.status in (301, 302, 303, 307, 308):
+                        location = response.headers.get("Location")
+                        if not location:
+                            logger.warning("Redirect response without Location header from %s at %s", current_uri, path)
+                            return None
+                        current_uri = urljoin(current_uri, location)
+                        continue
+
+                    response.raise_for_status()
+                    data = await response.read()
+                    return BytesIO(data)
+
+            logger.warning("Too many redirects while downloading asset from URL %s at %s", uri, path)
+            return None
     except aiohttp.ClientError as http_err:
         logger.warning("Failed to download asset from URL %s at %s: %s", uri, path, http_err)
         return None


### PR DESCRIPTION
## What
Fixed an SSRF vulnerability in `download_http_uri` in `src/nodetool/workflows/asset_storage.py` by manually handling redirects and checking for private IPs at each hop.

## Why
While `SSRFProtectResolver` was used, `aiohttp` follows redirects automatically. If an initial valid URL redirected to a private IP literal, the protection would be bypassed because the `is_ip_private` check only occurred on the initial URL.

## Impact
Prevents Server-Side Request Forgery (SSRF) bypasses in asset fetching.

## Verification
- Added an entry to `.jules/sentinel.md`
- Ran the test suite using `uv run pytest tests/`
- Ran `uv run ruff check src/nodetool/workflows/asset_storage.py`

---
*PR created automatically by Jules for task [2275354572072464718](https://jules.google.com/task/2275354572072464718) started by @georgi*