### PR TITLE
Fix seven bugs found in a typing-driven audit; tighten annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,10 @@ ignore = [
 "tests/**/*.py" = ["ARG", "S101", "F401"]  # Allow unused args, assert, and unused imports in tests
 "**/__init__.py" = ["F401"]  # Allow unused imports in __init__
 "**/conftest.py" = ["F401"]  # Allow unused imports in conftest
+# Pydantic models need their field types importable at runtime, so TC001's
+# "move into a type-checking block" would break model construction.
+"src/nodetool/metadata/node_metadata.py" = ["TC001"]
+"src/nodetool/package_tools/enrich.py" = ["TC001"]
 
 [tool.ruff.format]
 # Use double quotes for strings

--- a/src/nodetool/integrations/huggingface/async_downloader.py
+++ b/src/nodetool/integrations/huggingface/async_downloader.py
@@ -21,6 +21,10 @@ HF_HEADER_X_LINKED_SIZE = "X-Linked-Size"
 # Simple in-process cache for the resolved HF token
 _CACHED_HF_TOKEN: Optional[str] = None
 
+# Exponential backoff between resumable-download retries, in seconds.
+_RETRY_BACKOFF_BASE = 1.0
+_RETRY_BACKOFF_MAX = 30.0
+
 
 @dataclass
 class HfFileMeta:
@@ -366,18 +370,30 @@ async def _download_with_resume(
                 follow_redirects=True,
                 timeout=timeout,
             ) as resp:
-                # Server ignored Range; start over
-                if resume_from > 0 and resp.status_code == 200 and accept_ranges:
-                    if tmp.exists():
-                        tmp.unlink()
-                    resume_from = 0
-
                 # Handle 416 Range Not Satisfiable
                 if resp.status_code == 416:
                     log.warning(f"Range not satisfiable (resume_from={resume_from}). Restarting download.")
                     if tmp.exists():
                         tmp.unlink()
+                    if attempt >= max_retries:
+                        raise RuntimeError(f"Download failed after {attempt} attempts: server kept returning 416")
                     continue
+
+                # Only keep the partial file when the server actually served a
+                # partial response. Any other status carries the WHOLE body, so
+                # appending it to the partial file would corrupt the result —
+                # silently so when expected_size is unknown and the size check
+                # below cannot run. This covers the ``accept_ranges is False``
+                # case too, where no Range header was ever sent.
+                if resume_from > 0 and resp.status_code != 206:
+                    log.warning(
+                        "Server did not honour Range for %s (status %s); restarting download.",
+                        url,
+                        resp.status_code,
+                    )
+                    if tmp.exists():
+                        tmp.unlink()
+                    resume_from = 0
 
                 resp.raise_for_status()
 
@@ -404,13 +420,27 @@ async def _download_with_resume(
         except (httpx.TimeoutException, httpx.TransportError) as exc:
             if attempt >= max_retries:
                 raise RuntimeError(f"Download failed after {attempt} attempts") from exc
-            # loop again, resuming from whatever is on disk
+            # Back off before resuming from whatever is on disk. Without this,
+            # a fast-failing error (connection refused, DNS failure) burns every
+            # attempt in a tight loop, so the retries buy nothing.
+            delay = min(_RETRY_BACKOFF_BASE * (2 ** (attempt - 1)), _RETRY_BACKOFF_MAX)
+            log.warning(
+                "Download of %s failed (%s); retrying in %.1fs (attempt %d/%d)",
+                url,
+                exc,
+                delay,
+                attempt,
+                max_retries,
+            )
+            await asyncio.sleep(delay)
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code == 416:
                 # Should be handled above, but just in case raise_for_status catches it first
                 log.warning("Range not satisfiable (caught via exception). Restarting download.")
                 if tmp.exists():
                     tmp.unlink()
+                if attempt >= max_retries:
+                    raise RuntimeError(f"Download failed after {attempt} attempts: server kept returning 416") from exc
                 continue
             raise
 

--- a/src/nodetool/media/audio/audio_helpers.py
+++ b/src/nodetool/media/audio/audio_helpers.py
@@ -94,7 +94,9 @@ def concatenate_audios(audios: list[AudioSegment]) -> AudioSegment:
         and a.channels == first_audio.channels
         for a in audios
     ):
-        raw_data = b"".join([a._data for a in audios])
+        # ``raw_data`` is pydub's public accessor for the same buffer as the
+        # private ``_data``, and is typed as bytes.
+        raw_data = b"".join(a.raw_data for a in audios)
         return first_audio._spawn(raw_data)
 
     # ⚡ Bolt Optimization: Use divide-and-conquer to avoid O(N^2) byte-copying

--- a/src/nodetool/ml/core/model_manager.py
+++ b/src/nodetool/ml/core/model_manager.py
@@ -194,6 +194,28 @@ class ModelManager:
             return cls._locks[cache_key]
 
     @classmethod
+    def _discard_lock(cls, cache_key: str) -> bool:
+        """Drop a per-model lock, but only when nobody is holding it.
+
+        Evicting a held lock would let the next ``get_model_lock`` hand out a
+        brand-new :class:`asyncio.Lock` for the same key, so two coroutines
+        could enter the same critical section at once — e.g. both loading the
+        model into VRAM. A still-held lock is left in place; whichever eviction
+        runs next (or :meth:`clear`) collects it.
+
+        Returns:
+            True if the lock was removed.
+        """
+        lock = cls._locks.get(cache_key)
+        if lock is None:
+            return False
+        if lock.locked():
+            logger.debug("🔒 Keeping in-use lock for evicted model: %s", cache_key)
+            return False
+        del cls._locks[cache_key]
+        return True
+
+    @classmethod
     @asynccontextmanager
     async def lock_model(cls, cache_key: str) -> AsyncIterator[None]:
         """Context manager for acquiring exclusive access to a model.
@@ -361,8 +383,7 @@ class ModelManager:
                         logger.debug(f"- Cleared cached model for node {node_id}: {model_id}")
 
                         # Clean up associated lock
-                        if key in cls._locks:
-                            del cls._locks[key]
+                        if cls._discard_lock(key):
                             cleared_locks += 1
                             logger.debug(f"🔒 Removed lock for cleared model: {key}")
 
@@ -397,7 +418,7 @@ class ModelManager:
             return False
 
         cls._move_model_to_cpu(model)
-        cls._locks.pop(key, None)
+        cls._discard_lock(key)
         cls._model_last_used.pop(key, None)
         cls._model_device.pop(key, None)
         cls._model_size_bytes.pop(key, None)
@@ -447,7 +468,10 @@ class ModelManager:
 
         cls._models.clear()
         cls._models_by_node.clear()
-        cls._locks.clear()
+        # Locks currently held survive the purge — see _discard_lock().
+        for key in list(cls._locks):
+            cls._discard_lock(key)
+        lock_count -= len(cls._locks)
         cls._model_last_used.clear()
         cls._node_last_used.clear()
         cls._model_device.clear()

--- a/src/nodetool/package_tools/__main__.py
+++ b/src/nodetool/package_tools/__main__.py
@@ -14,7 +14,8 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from importlib.metadata import PackageNotFoundError, version as _pkg_version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 
 from nodetool.metadata.node_metadata import EnumEncoder

--- a/src/nodetool/package_tools/enrich.py
+++ b/src/nodetool/package_tools/enrich.py
@@ -89,11 +89,12 @@ async def enrich_nodes_with_model_info(
 
         updated_models: list[Any] = []
         for model in node.recommended_models:
-            if not getattr(model, "repo_id", None):
+            repo_id: str | None = getattr(model, "repo_id", None)
+            if not repo_id:
                 updated_models.append(model)
                 continue
 
-            info = model_info_map.get(model.repo_id)
+            info = model_info_map.get(repo_id)
             if not info:
                 updated_models.append(model)
                 continue
@@ -105,7 +106,7 @@ async def enrich_nodes_with_model_info(
                     updates["size_on_disk"] = size
 
             if getattr(model, "type", None) is None:
-                inferred_type = model_type_from_model_info(repo_to_models, model.repo_id, info)
+                inferred_type = model_type_from_model_info(repo_to_models, repo_id, info)
                 if inferred_type:
                     updates["type"] = inferred_type
 

--- a/src/nodetool/storage/file_storage.py
+++ b/src/nodetool/storage/file_storage.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import IO
+
 from nodetool.storage.abstract_storage import AbstractStorage
 
 

--- a/src/nodetool/storage/memory_storage.py
+++ b/src/nodetool/storage/memory_storage.py
@@ -1,4 +1,5 @@
 from typing import IO
+
 from nodetool.storage.abstract_storage import AbstractStorage
 
 

--- a/src/nodetool/utils/network.py
+++ b/src/nodetool/utils/network.py
@@ -1,30 +1,47 @@
 import ipaddress
 import socket
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import aiohttp
+from aiohttp.abc import AbstractResolver
+
 
 def is_ip_private(ip_str: str) -> bool:
-    """Check if an IP address is private, loopback, or otherwise restricted."""
+    """Check if an IP address is private, loopback, or otherwise restricted.
+
+    Non-IP strings (i.e. hostnames) return False — they must be resolved first
+    and the resulting addresses checked individually.
+    """
     try:
         ip = ipaddress.ip_address(ip_str)
-        return (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_multicast
-            or ip.is_reserved
-            or ip.is_unspecified
-        )
     except ValueError:
         return False
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
 
-class SSRFProtectResolver(aiohttp.DefaultResolver):
+
+# ``aiohttp.DefaultResolver`` is an alias that resolves to AsyncResolver or
+# ThreadedResolver depending on whether aiodns is installed, so type checkers
+# see a union of classes rather than a single base. Bind it to a name typed as
+# a plain class object to keep the subclass below checkable.
+_DefaultResolver: type[AbstractResolver] = aiohttp.DefaultResolver
+
+
+class SSRFProtectResolver(_DefaultResolver):  # type: ignore[misc,valid-type]
     """
     A custom aiohttp resolver that prevents Server-Side Request Forgery (SSRF)
     by blocking resolution to private, loopback, and restricted IP addresses.
     """
-    async def resolve(self, host: str, port: int = 0, family: int = socket.AF_INET) -> List[Dict[str, Any]]:
+
+    async def resolve(
+        self, host: str, port: int = 0, family: int = socket.AF_INET
+    ) -> list[dict[str, Any]]:
         # Check if the host itself is a private IP string before resolution
         if is_ip_private(host):
             raise ValueError(f"Access to private/restricted IP blocked: {host}")
@@ -32,16 +49,18 @@ class SSRFProtectResolver(aiohttp.DefaultResolver):
         # Resolve the hostname
         ips = await super().resolve(host, port, family)
 
-        # Filter out any private/restricted IPs from the resolved list
-        valid_ips = []
-        for ip_info in ips:
-            ip = ip_info.get("host")
-            if ip and not is_ip_private(ip):
-                valid_ips.append(ip_info)
-            else:
-                pass # Optionally log that a private IP was filtered
+        # Filter out any private/restricted IPs from the resolved list. This is
+        # what stops obfuscated literals (e.g. "2130706433", which getaddrinfo
+        # happily turns into 127.0.0.1) from slipping past the check above.
+        valid_ips = [
+            ip_info
+            for ip_info in ips
+            if ip_info.get("host") and not is_ip_private(ip_info["host"])
+        ]
 
         if not valid_ips:
-            raise ValueError(f"Access to host '{host}' blocked because it resolved to a private/restricted IP.")
+            raise ValueError(
+                f"Access to host '{host}' blocked because it resolved to a private/restricted IP."
+            )
 
         return valid_ips

--- a/src/nodetool/worker/context_stub.py
+++ b/src/nodetool/worker/context_stub.py
@@ -9,10 +9,10 @@ import asyncio
 import os
 import uuid
 from io import BytesIO
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from nodetool.metadata.types import AudioRef, ImageRef, Model3DRef
 from nodetool.workflows.processing_context import ProcessingContext
-from nodetool.metadata.types import ImageRef, AudioRef, Model3DRef
 
 if TYPE_CHECKING:
     import numpy as np
@@ -84,8 +84,9 @@ class WorkerContext(ProcessingContext):
         name: str | None = None,
         parent_id: str | None = None,
     ) -> AudioRef:
-        import numpy as np
         import struct
+
+        import numpy as np
 
         if data.dtype == np.int16:
             raw = data.tobytes()

--- a/src/nodetool/worker/model_handler.py
+++ b/src/nodetool/worker/model_handler.py
@@ -155,12 +155,12 @@ async def _handle_download(
 
             def on_bytes(
                 delta: int,
-                _file_total=None,
-                _filename=filename,
-                _base=file_base,
-                _fsize=_size,
-                _acc=file_acc,
-            ):
+                _file_total: int | None = None,
+                _filename: str = filename,
+                _base: int = file_base,
+                _fsize: int | None = _size,
+                _acc: dict[str, int] = file_acc,
+            ) -> None:
                 nonlocal done_bytes
                 _acc["bytes"] += delta
                 progressed = min(_acc["bytes"], _fsize) if _fsize else _acc["bytes"]
@@ -175,7 +175,11 @@ async def _handle_download(
                             "progress",
                             done_bytes,
                             total_bytes,
-                            done_files,
+                            # Deliberately late-bound, unlike the per-file
+                            # values above: this must report how many files
+                            # have completed *now*, not when the callback was
+                            # defined (which is always 0 for the current file).
+                            done_files,  # noqa: B023
                             total_files,
                             [_filename],
                         ),
@@ -219,7 +223,10 @@ async def _handle_download(
             # even if the callback under-reported (e.g. size metadata missing).
             if _size:
                 done_bytes = file_base + _size
-            done_files += 1
+            # Not enumerate(): on_bytes closes over this and must observe the
+            # count as it advances, and the early-return paths above report it
+            # mid-loop.
+            done_files += 1  # noqa: SIM113
 
         # Drain any in-flight progress frames before the terminal frames.
         await drain()

--- a/src/nodetool/worker/msgpack_codec.py
+++ b/src/nodetool/worker/msgpack_codec.py
@@ -38,10 +38,14 @@ def _ext_hook(code: int, data: bytes) -> Any:
     return None
 
 
-def decode_message(payload: bytes) -> Any:
+def decode_message(payload: bytes | bytearray | memoryview | str) -> Any:
     """Decode a msgpack payload from a worker transport.
 
     Uses :func:`_ext_hook` so unknown extension types become ``None`` instead
     of raw ``ExtType`` objects.
+
+    ``str`` is accepted in the signature only because the websockets transport
+    hands text frames straight through; ``msgpack.unpackb`` rejects them, and
+    the caller answers the resulting error with an ``error`` frame.
     """
     return msgpack.unpackb(payload, raw=False, ext_hook=_ext_hook)

--- a/src/nodetool/worker/protocol.py
+++ b/src/nodetool/worker/protocol.py
@@ -75,7 +75,10 @@ class WorkerProtocolServer:
 
     async def dispatch(self, msg: dict[str, Any], transport: WorkerTransport) -> None:
         msg_type = msg.get("type")
-        request_id = msg.get("request_id")
+        raw_request_id = msg.get("request_id")
+        # A peer can send any msgpack value here; coerce to the str the
+        # _cancel_flags map and the downstream handlers are typed for.
+        request_id: str | None = raw_request_id if isinstance(raw_request_id, str) else None
 
         if msg_type == "discover":
             await transport.send_msg({
@@ -162,11 +165,12 @@ class WorkerProtocolServer:
                     },
                 })
             finally:
-                self._cancel_flags.pop(request_id, None)
+                if request_id:
+                    self._cancel_flags.pop(request_id, None)
             return
 
         if msg_type == "cancel":
-            cancel_event = self._cancel_flags.get(request_id)
+            cancel_event = self._cancel_flags.get(request_id) if request_id else None
             if cancel_event:
                 cancel_event.set()
             return

--- a/src/nodetool/worker/provider_handler.py
+++ b/src/nodetool/worker/provider_handler.py
@@ -13,7 +13,12 @@ import os
 import sys
 import traceback
 from collections import OrderedDict
+from functools import lru_cache
 from typing import Any
+
+from nodetool.config.logging_config import get_logger
+
+log = get_logger(__name__)
 
 # Cached provider instances, keyed by (provider_id, secrets hash) so a
 # different / rotated secret set never reuses another caller's instance.
@@ -148,29 +153,55 @@ def get_available_providers() -> list[dict[str, Any]]:
 # ── Handler implementations ─────────────────────────────────────────────
 
 
-def _deserialize_messages(raw_messages: list[dict]) -> list[Any]:
+@lru_cache(maxsize=1)
+def _content_part_types() -> dict[str, tuple[type[Any], str]]:
+    """Map wire content-part ``type`` values to (model class, payload field).
+
+    The wire protocol names the image part ``"image"`` while
+    :class:`MessageImageContent` declares ``Literal["image_url"]``, so the
+    discriminator can never be forwarded verbatim — only the payload field is.
+    """
+    from nodetool.metadata.types import (
+        MessageAudioContent,
+        MessageImageContent,
+        MessageTextContent,
+        MessageVideoContent,
+    )
+
+    return {
+        "text": (MessageTextContent, "text"),
+        "image": (MessageImageContent, "image"),
+        "image_url": (MessageImageContent, "image"),
+        "audio": (MessageAudioContent, "audio"),
+        "video": (MessageVideoContent, "video"),
+    }
+
+
+def _deserialize_messages(raw_messages: list[dict[str, Any]]) -> list[Any]:
     """Convert wire-format messages to Python Message objects."""
     from nodetool.metadata.types import Message
 
-    messages = []
+    messages: list[Any] = []
     for m in raw_messages:
-        content = m.get("content")
+        content: Any = m.get("content")
         # content can be string, list of content parts, or None
         if isinstance(content, list):
-            from nodetool.metadata.types import (
-                MessageAudioContent,
-                MessageImageContent,
-                MessageTextContent,
-            )
-
-            parts = []
+            parts: list[Any] = []
             for part in content:
-                if part.get("type") == "text":
-                    parts.append(MessageTextContent(type="text", text=part["text"]))
-                elif part.get("type") == "image":
-                    parts.append(MessageImageContent(type="image", image=part["image"]))
-                elif part.get("type") == "audio":
-                    parts.append(MessageAudioContent(type="audio", audio=part["audio"]))
+                # Note: the discriminator is never passed explicitly — the wire
+                # names ("image") differ from the model's own Literal defaults
+                # ("image_url"), and passing the wire name raises a pydantic
+                # ValidationError.
+                wire_type = part.get("type")
+                factory = _content_part_types().get(wire_type)
+                if factory is None:
+                    log.warning("Dropping message content part with unknown type %r", wire_type)
+                    continue
+                model_cls, field = factory
+                if field not in part:
+                    log.warning("Dropping %r content part with no %r field", wire_type, field)
+                    continue
+                parts.append(model_cls(**{field: part[field]}))
             content = parts
 
         msg = Message(
@@ -203,14 +234,20 @@ def _serialize_message(msg: Any) -> dict:
     return result
 
 
-def _serialize_content_part(part: Any) -> dict:
-    """Serialize a MessageContent part."""
-    if hasattr(part, "text"):
-        return {"type": "text", "text": part.text}
-    if hasattr(part, "image"):
-        return {"type": "image", "image": part.image}
-    if hasattr(part, "audio"):
-        return {"type": "audio", "audio": part.audio}
+def _serialize_content_part(part: Any) -> dict[str, Any]:
+    """Serialize a MessageContent part to the wire format.
+
+    Mirrors :func:`_content_part_types` so a round-trip through the bridge is
+    lossless — including video parts, which previously degraded to ``str(part)``
+    text because they were not recognised here.
+    """
+    for wire_type, (_model_cls, field) in _content_part_types().items():
+        # "image_url" is only accepted on the way in; emit the canonical "image".
+        if wire_type == "image_url":
+            continue
+        value = getattr(part, field, None)
+        if value is not None:
+            return {"type": wire_type, field: value}
     return {"type": "text", "text": str(part)}
 
 

--- a/src/nodetool/worker/stdio_server.py
+++ b/src/nodetool/worker/stdio_server.py
@@ -270,7 +270,7 @@ async def run_stdio_worker(namespaces: list[str] | None = None) -> None:
         _t0 = _time.perf_counter()
         print("Warm-importing heavy ML modules...", file=sys.stderr, flush=True)
         try:
-            from diffusers.pipelines.flux.pipeline_flux import FluxPipeline  # noqa: F401
+            from diffusers.pipelines.flux.pipeline_flux import FluxPipeline
 
             print(
                 f"Warm-imported diffusers.FluxPipeline in {_time.perf_counter() - _t0:.1f}s",

--- a/src/nodetool/worker/stdio_stdout_guard.py
+++ b/src/nodetool/worker/stdio_stdout_guard.py
@@ -50,7 +50,7 @@ def get_protocol_stdout_buffer() -> BinaryIO:
         raise RuntimeError(
             "Protocol stdout is not initialized; call install_stdio_stdout_guard() first"
         )
-    return cast(BinaryIO, _ProtocolStdoutBuffer(_protocol_stdout_fd))
+    return cast("BinaryIO", _ProtocolStdoutBuffer(_protocol_stdout_fd))
 
 
 def install_stdio_stdout_guard() -> None:

--- a/src/nodetool/worker/worker_auth.py
+++ b/src/nodetool/worker/worker_auth.py
@@ -47,7 +47,7 @@ def authorize(auth_header: str | None, expected_token: str | None) -> bool:
     return hmac.compare_digest(auth_header, BEARER_PREFIX + expected_token)
 
 
-def make_process_request() -> Callable[["ServerConnection", "Request"], "Response | None"]:
+def make_process_request() -> Callable[[ServerConnection, Request], Response | None]:
     """Build a ``process_request`` hook that enforces the worker token.
 
     The expected token is read from ``NODETOOL_WORKER_TOKEN`` on each handshake,
@@ -60,8 +60,8 @@ def make_process_request() -> Callable[["ServerConnection", "Request"], "Respons
     """
 
     def process_request(
-        connection: "ServerConnection", request: "Request"
-    ) -> "Response | None":
+        connection: ServerConnection, request: Request
+    ) -> Response | None:
         expected_token = os.environ.get("NODETOOL_WORKER_TOKEN")
         if authorize(request.headers.get("Authorization"), expected_token):
             return None

--- a/src/nodetool/workflows/asset_storage.py
+++ b/src/nodetool/workflows/asset_storage.py
@@ -197,7 +197,12 @@ def object_to_bytes(obj: Any, asset_ref: AssetRef) -> bytes | None:
 
             if isinstance(obj, AudioSegment):
                 buf = BytesIO()
-                obj.export(buf, format="mp3")
+                # Must match get_content_type_for_asset_ref(), which reports
+                # "audio/wav" for audio assets — auto_save_assets() derives both
+                # the stored content type and the ``asset://…`` extension from
+                # it, so exporting mp3 here mislabels the bytes. wav also
+                # encodes via the stdlib, so it works without ffmpeg.
+                obj.export(buf, format="wav")
                 return buf.getvalue()
         except Exception as e:
             logger.debug(f"Failed to convert audio object: {e}")

--- a/src/nodetool/workflows/base_node.py
+++ b/src/nodetool/workflows/base_node.py
@@ -163,6 +163,7 @@ if TYPE_CHECKING:
     from nodetool.types.model import ModelPack
 
     from .io import NodeInputs, NodeOutputs
+    from .property import Property
 
 
 def sanitize_node_name(node_name: str) -> str:

--- a/src/nodetool/workflows/inbox.py
+++ b/src/nodetool/workflows/inbox.py
@@ -94,6 +94,11 @@ class NodeInbox:
         self._closed: bool = False
         # Buffer limit for backpressure (None = unlimited)
         self._buffer_limit: int | None = buffer_limit
+        # Strong references to in-flight notify tasks. asyncio only keeps weak
+        # references to running tasks, so a fire-and-forget notify task can be
+        # garbage-collected before it ever runs — which would silently drop an
+        # EOS/arrival wakeup and hang every consumer blocked in iter_input.
+        self._notify_tasks: set[asyncio.Task[None]] = set()
         assert self._loop is not None, "Event loop is not running"
 
     def _notify_waiters_threadsafe(self) -> None:
@@ -115,7 +120,10 @@ class NodeInbox:
                 async with self._cond:
                     self._cond.notify_all()
 
-            self._loop.create_task(_notify())
+            task = self._loop.create_task(_notify())
+            # Retain until done so the task cannot be collected mid-flight.
+            self._notify_tasks.add(task)
+            task.add_done_callback(self._notify_tasks.discard)
 
         self._loop.call_soon_threadsafe(_schedule_notify)
 

--- a/src/nodetool/workflows/io.py
+++ b/src/nodetool/workflows/io.py
@@ -18,7 +18,9 @@ from .types import EdgeUpdate
 log = get_logger(__name__)
 
 if TYPE_CHECKING:
+    from .base_node import BaseNode
     from .inbox import MessageEnvelope, NodeInbox
+    from .processing_context import ProcessingContext
 
 
 class NodeInputs:
@@ -150,11 +152,19 @@ class NodeOutputs:
     through the node graph via MessageEnvelopes.
     """
 
-    def __init__(self, runner, node, context, capture_only: bool = False) -> None:
+    def __init__(
+        self,
+        runner: Any,
+        node: BaseNode,
+        context: ProcessingContext,
+        capture_only: bool = False,
+    ) -> None:
         """Initialize a NodeOutputs view.
 
         Args:
-            runner: The active ``WorkflowRunner`` instance.
+            runner: The active workflow runner. Duck-typed (``Any``) because the
+                runner lives in the TS server; it only needs to expose
+                ``send_messages``, ``node_inboxes`` and ``outputs``.
             node: The current ``BaseNode`` instance producing outputs.
             context: The workflow ``ProcessingContext``.
             capture_only: If True, collect outputs without routing them downstream.

--- a/src/nodetool/workflows/processing_context.py
+++ b/src/nodetool/workflows/processing_context.py
@@ -192,12 +192,15 @@ HTTP_HEADERS = {
 }
 
 
-def _resolve_default_device(explicit_device: str | None = None) -> str | None:
+def _resolve_default_device(explicit_device: str | None = None) -> str:
     """
     Pick the default execution device for workflows.
 
     Prefers Apple Metal (MPS) when available so that HuggingFace workloads run on
     the GPU by default, otherwise falls back to CUDA (if available) or CPU.
+
+    Always resolves to a concrete device name — "cpu" is the final fallback — so
+    callers such as ``BaseNode.move_to_device(device: str)`` never see ``None``.
     """
     if explicit_device:
         return explicit_device
@@ -298,7 +301,7 @@ class ProcessingContext:
         self.job_id = job_id
         self.graph = graph or Graph()
         self.message_queue = message_queue if message_queue else queue.Queue()
-        self.device = _resolve_default_device(device)
+        self.device: str = _resolve_default_device(device)
         self.variables: dict[str, Any] = variables if variables else {}
         self.environment: dict[str, str] = Environment.get_environment()
         if environment:

--- a/src/nodetool/workflows/processing_context.py
+++ b/src/nodetool/workflows/processing_context.py
@@ -880,11 +880,22 @@ class ProcessingContext:
                 return BytesIO(content)
 
         if url_parsed.scheme == "data":
-            fname, data = url.split(",", 1)
-            image_bytes = await _in_thread(_b64decode_to_bytes, data)
-            file = BytesIO(image_bytes)
-            # parse file ext from data uri
-            ext = fname.split(";")[0].split("/")[1]
+            # Format: data:[<mediatype>][;base64],<data>
+            if "," not in url:
+                raise ValueError(f"Malformed data URI (no comma): {url[:64]}")
+            header, data = url.split(",", 1)
+            # Only base64-decode when the URI says so; a percent-encoded
+            # payload (e.g. "data:text/plain,hi") is not valid base64 and
+            # previously raised binascii.Error here.
+            if ";base64" in header:
+                payload = await _in_thread(_b64decode_to_bytes, data)
+            else:
+                payload = urllib.parse.unquote(data).encode("utf-8")
+            file = BytesIO(payload)
+            # Derive an extension from the media type when there is one;
+            # "data:,hi" and "data:;base64,aGk=" carry no media type.
+            media_type = header[len("data:") :].split(";")[0]
+            ext = media_type.split("/")[1] if "/" in media_type else "bin"
             file.name = f"{uuid.uuid4()}.{ext}"
             return file
 

--- a/tests/integrations/test_async_downloader_resume.py
+++ b/tests/integrations/test_async_downloader_resume.py
@@ -1,0 +1,131 @@
+"""Regression tests for resumable HuggingFace downloads.
+
+The resume path decided whether to append based on the *request* (was a Range
+header sent) rather than the *response* (did the server actually serve one).
+When the server ignored the range — or when ``accept_ranges`` was False so no
+Range header was sent at all — the full body was appended onto the partial
+``.incomplete`` file, producing a corrupt result. With ``expected_size`` unknown
+the size check could not catch it, so the corruption was silent.
+"""
+
+import httpx
+import pytest
+
+from nodetool.integrations.huggingface.async_downloader import _download_with_resume
+
+FULL_BODY = b"0123456789ABCDEF"
+PARTIAL = FULL_BODY[:6]
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+@pytest.mark.asyncio
+async def test_full_body_response_replaces_partial_file(tmp_path):
+    """A 200 (range ignored) must restart, not append onto the partial file."""
+    dest = tmp_path / "weights.bin"
+    tmp = dest.with_suffix(dest.suffix + ".incomplete")
+    tmp.write_bytes(PARTIAL)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # Server ignores the Range header and returns the whole file.
+        return httpx.Response(200, content=FULL_BODY)
+
+    async with _client(handler) as client:
+        await _download_with_resume(
+            client,
+            "https://example.invalid/weights.bin",
+            dest,
+            token=None,
+            expected_size=None,  # no size check to mask the corruption
+            accept_ranges=True,
+        )
+
+    assert dest.read_bytes() == FULL_BODY
+    assert not tmp.exists()
+
+
+@pytest.mark.asyncio
+async def test_no_range_support_replaces_partial_file(tmp_path):
+    """With accept_ranges False no Range is sent, so the body is the whole file."""
+    dest = tmp_path / "weights.bin"
+    tmp = dest.with_suffix(dest.suffix + ".incomplete")
+    tmp.write_bytes(PARTIAL)
+
+    seen_headers = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_headers.append(request.headers.get("Range"))
+        return httpx.Response(200, content=FULL_BODY)
+
+    async with _client(handler) as client:
+        await _download_with_resume(
+            client,
+            "https://example.invalid/weights.bin",
+            dest,
+            token=None,
+            expected_size=None,
+            accept_ranges=False,
+        )
+
+    assert seen_headers == [None]
+    assert dest.read_bytes() == FULL_BODY
+
+
+@pytest.mark.asyncio
+async def test_partial_content_response_is_appended(tmp_path):
+    """A genuine 206 still resumes — the fix must not disable resuming."""
+    dest = tmp_path / "weights.bin"
+    tmp = dest.with_suffix(dest.suffix + ".incomplete")
+    tmp.write_bytes(PARTIAL)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers.get("Range") == f"bytes={len(PARTIAL)}-"
+        return httpx.Response(
+            206,
+            content=FULL_BODY[len(PARTIAL) :],
+            headers={
+                "Content-Range": f"bytes {len(PARTIAL)}-{len(FULL_BODY) - 1}/{len(FULL_BODY)}"
+            },
+        )
+
+    async with _client(handler) as client:
+        await _download_with_resume(
+            client,
+            "https://example.invalid/weights.bin",
+            dest,
+            token=None,
+            expected_size=len(FULL_BODY),
+            accept_ranges=True,
+        )
+
+    assert dest.read_bytes() == FULL_BODY
+
+
+@pytest.mark.asyncio
+async def test_persistent_416_gives_up_instead_of_looping(tmp_path):
+    """A server stuck on 416 must exhaust retries rather than spin forever."""
+    dest = tmp_path / "weights.bin"
+    dest.with_suffix(dest.suffix + ".incomplete").write_bytes(PARTIAL)
+
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(416)
+
+    async with _client(handler) as client:
+        with pytest.raises(RuntimeError, match="416"):
+            await _download_with_resume(
+                client,
+                "https://example.invalid/weights.bin",
+                dest,
+                token=None,
+                expected_size=len(FULL_BODY),
+                accept_ranges=True,
+                max_retries=3,
+            )
+
+    assert calls == 3

--- a/tests/ml/test_model_manager.py
+++ b/tests/ml/test_model_manager.py
@@ -83,3 +83,61 @@ def test_free_memory_if_snapshot_unavailable_triggers_cleanup(monkeypatch):
 
     assert ModelManager._models == {}
     assert ModelManager._models_by_node == {}
+
+
+class TestLockEviction:
+    """Evicting a model must not hand out a second lock for the same key.
+
+    Dropping a held lock lets the next ``get_model_lock`` mint a fresh
+    ``asyncio.Lock``, so two coroutines could enter the same critical section
+    (e.g. both loading the same model into VRAM) at once.
+    """
+
+    def setup_method(self):
+        ModelManager.clear()
+
+    def teardown_method(self):
+        ModelManager.clear()
+
+    @pytest.mark.asyncio
+    async def test_unload_keeps_a_held_lock(self):
+        ModelManager.set_model("node1", "m", "task", object())
+        key = ModelManager._make_cache_key("m", "task")
+
+        async with ModelManager.lock_model(key):
+            assert ModelManager.unload_model("m", "task") is True
+            # Same lock object, still held — a concurrent waiter blocks.
+            same_lock = await ModelManager.get_model_lock(key)
+            assert same_lock.locked()
+
+        # Released; a later eviction can now collect it.
+        assert ModelManager._discard_lock(key) is True
+        assert key not in ModelManager._locks
+
+    @pytest.mark.asyncio
+    async def test_unload_drops_an_idle_lock(self):
+        ModelManager.set_model("node1", "m", "task", object())
+        key = ModelManager._make_cache_key("m", "task")
+        await ModelManager.get_model_lock(key)
+
+        assert ModelManager.unload_model("m", "task") is True
+        assert key not in ModelManager._locks
+
+    @pytest.mark.asyncio
+    async def test_clear_keeps_a_held_lock(self):
+        ModelManager.set_model("node1", "m", "task", object())
+        key = ModelManager._make_cache_key("m", "task")
+
+        async with ModelManager.lock_model(key):
+            ModelManager.clear()
+            assert key in ModelManager._locks
+
+    @pytest.mark.asyncio
+    async def test_clear_unused_keeps_a_held_lock(self):
+        ModelManager.set_model("node1", "m", "task", object())
+        key = ModelManager._make_cache_key("m", "task")
+
+        async with ModelManager.lock_model(key):
+            ModelManager.clear_unused(["node1"])
+            assert key in ModelManager._locks
+            assert ModelManager._models == {}

--- a/tests/worker/test_provider_message_parts.py
+++ b/tests/worker/test_provider_message_parts.py
@@ -1,0 +1,101 @@
+"""Regression tests for wire <-> Message content-part conversion.
+
+The wire protocol names the image part ``"image"`` while
+:class:`MessageImageContent` declares ``Literal["image_url"]``. Forwarding the
+wire name into the constructor raised a pydantic ValidationError, so every
+provider request carrying image content failed before reaching the provider.
+"""
+
+import pytest
+
+from nodetool.metadata.types import (
+    ImageRef,
+    MessageAudioContent,
+    MessageImageContent,
+    MessageTextContent,
+    MessageVideoContent,
+    VideoRef,
+)
+from nodetool.worker.provider_handler import (
+    _deserialize_messages,
+    _serialize_content_part,
+)
+
+
+def _parts(content):
+    return _deserialize_messages([{"role": "user", "content": content}])[0].content
+
+
+def test_image_part_deserializes_without_validation_error():
+    parts = _parts([{"type": "image", "image": {"type": "image", "uri": "http://x/y.png"}}])
+
+    assert len(parts) == 1
+    assert isinstance(parts[0], MessageImageContent)
+    # The model keeps its own discriminator, not the wire name.
+    assert parts[0].type == "image_url"
+    assert parts[0].image.uri == "http://x/y.png"
+
+
+def test_image_url_wire_type_is_also_accepted():
+    parts = _parts([{"type": "image_url", "image": {"type": "image", "uri": "http://x/y.png"}}])
+
+    assert len(parts) == 1
+    assert isinstance(parts[0], MessageImageContent)
+
+
+def test_video_part_is_preserved():
+    parts = _parts([{"type": "video", "video": {"type": "video", "uri": "http://x/y.mp4"}}])
+
+    assert len(parts) == 1
+    assert isinstance(parts[0], MessageVideoContent)
+    assert parts[0].video.uri == "http://x/y.mp4"
+
+
+def test_text_and_audio_parts_still_work():
+    parts = _parts([
+        {"type": "text", "text": "hello"},
+        {"type": "audio", "audio": {"type": "audio", "uri": "http://x/y.wav"}},
+    ])
+
+    assert isinstance(parts[0], MessageTextContent)
+    assert parts[0].text == "hello"
+    assert isinstance(parts[1], MessageAudioContent)
+
+
+@pytest.mark.parametrize(
+    "part",
+    [
+        {"type": "bogus", "value": 1},
+        {"type": "image"},  # missing payload field
+        {},
+    ],
+)
+def test_unknown_or_incomplete_parts_are_dropped_not_raised(part):
+    assert _parts([part]) == []
+
+
+@pytest.mark.parametrize(
+    ("part", "expected_type", "field"),
+    [
+        (MessageTextContent(text="hi"), "text", "text"),
+        (MessageImageContent(image=ImageRef(uri="http://x/y.png")), "image", "image"),
+        (MessageVideoContent(video=VideoRef(uri="http://x/y.mp4")), "video", "video"),
+    ],
+)
+def test_serialize_uses_wire_names(part, expected_type, field):
+    wire = _serialize_content_part(part)
+
+    assert wire["type"] == expected_type
+    assert field in wire
+
+
+def test_round_trip_preserves_part_types():
+    original = [
+        {"type": "text", "text": "hello"},
+        {"type": "image", "image": {"type": "image", "uri": "http://x/y.png"}},
+        {"type": "video", "video": {"type": "video", "uri": "http://x/y.mp4"}},
+    ]
+
+    round_tripped = [_serialize_content_part(p) for p in _parts(original)]
+
+    assert [p["type"] for p in round_tripped] == ["text", "image", "video"]

--- a/tests/workflows/test_asset_storage.py
+++ b/tests/workflows/test_asset_storage.py
@@ -463,3 +463,28 @@ class TestObjectToBytes:
         result = object_to_bytes({"not": "an image"}, asset)
 
         assert result is None
+
+    def test_audio_segment_encodes_as_declared_content_type(self):
+        """AudioSegment bytes must match the content type auto_save_assets stores.
+
+        Regression: the exporter emitted mp3 while
+        ``get_content_type_for_asset_ref`` reported ``audio/wav``, so saved
+        audio assets were mp3 bytes labelled (and named ``.wav``) as WAV.
+        """
+        from pydub import AudioSegment
+
+        from nodetool.workflows.asset_storage import get_extension_for_content_type
+
+        asset = AudioRef(uri="test://")
+        segment = AudioSegment.silent(duration=50, frame_rate=8000)
+
+        result = object_to_bytes(segment, asset)
+
+        assert result is not None
+        # RIFF....WAVE header — i.e. actually a wav, not an mp3.
+        assert result[:4] == b"RIFF"
+        assert result[8:12] == b"WAVE"
+
+        content_type = get_content_type_for_asset_ref(asset)
+        assert content_type == "audio/wav"
+        assert get_extension_for_content_type(content_type) == ".wav"

--- a/tests/workflows/test_download_file_data_uri.py
+++ b/tests/workflows/test_download_file_data_uri.py
@@ -1,0 +1,58 @@
+"""Regression tests for data: URI handling in ProcessingContext.download_file.
+
+The handler unconditionally base64-decoded the payload, so a percent-encoded
+data URI (``data:text/plain,hi`` — the non-base64 form the RFC allows) raised
+``binascii.Error``. It also indexed the media type blindly, so a URI without
+one (``data:,hi``) raised IndexError.
+"""
+
+import base64
+
+import pytest
+
+from nodetool.workflows.processing_context import ProcessingContext
+
+
+@pytest.fixture
+def ctx():
+    return ProcessingContext()
+
+
+@pytest.mark.asyncio
+async def test_percent_encoded_data_uri(ctx):
+    f = await ctx.download_file("data:text/plain,hello world!")
+
+    assert f.read() == b"hello world!"
+    assert f.name.endswith(".plain")
+
+
+@pytest.mark.asyncio
+async def test_percent_escapes_are_decoded(ctx):
+    f = await ctx.download_file("data:text/plain;charset=utf-8,a%20b")
+
+    assert f.read() == b"a b"
+
+
+@pytest.mark.asyncio
+async def test_base64_data_uri_still_works(ctx):
+    payload = b"\x89PNG\r\n\x1a\n"
+    uri = "data:image/png;base64," + base64.b64encode(payload).decode()
+
+    f = await ctx.download_file(uri)
+
+    assert f.read() == payload
+    assert f.name.endswith(".png")
+
+
+@pytest.mark.asyncio
+async def test_data_uri_without_media_type(ctx):
+    f = await ctx.download_file("data:,bare")
+
+    assert f.read() == b"bare"
+    assert f.name.endswith(".bin")
+
+
+@pytest.mark.asyncio
+async def test_malformed_data_uri_raises_value_error(ctx):
+    with pytest.raises(ValueError, match="Malformed data URI"):
+        await ctx.download_file("data:text/plain;base64")

--- a/tests/workflows/test_inbox.py
+++ b/tests/workflows/test_inbox.py
@@ -858,3 +858,52 @@ async def test_backward_compat_unwrap():
     assert len(envelopes) == 1
     assert envelopes[0].data == {"nested": "data"}
     assert envelopes[0].metadata == {"meta": "value"}
+
+
+@pytest.mark.asyncio
+async def test_notify_tasks_are_retained_until_done():
+    """The threadsafe notify task must hold a strong reference while in flight.
+
+    asyncio only keeps weak references to running tasks, so a bare
+    ``create_task(...)`` can be collected before it runs — silently dropping an
+    EOS wakeup and hanging every consumer blocked in ``iter_input``.
+    """
+    inbox = NodeInbox()
+    inbox.add_upstream("a", 1)
+
+    assert inbox._notify_tasks == set()
+
+    inbox.mark_source_done("a")
+    # call_soon_threadsafe defers _schedule_notify; let it run.
+    await asyncio.sleep(0)
+    assert len(inbox._notify_tasks) == 1
+
+    # Once the notify coroutine completes the reference is released again, so
+    # the set cannot grow without bound over a long-lived run.
+    await asyncio.sleep(0.05)
+    assert inbox._notify_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_eos_from_thread_wakes_consumer_under_gc_pressure():
+    """A consumer blocked on iter_input still reaches EOS when GC runs."""
+    import gc
+
+    inbox = NodeInbox()
+    inbox.add_upstream("a", 1)
+
+    received = []
+
+    async def consume():
+        async for item in inbox.iter_input("a"):
+            received.append(item)
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.05)
+
+    threading.Thread(target=lambda: inbox.mark_source_done("a")).start()
+    await asyncio.sleep(0)
+    gc.collect()
+
+    await asyncio.wait_for(task, timeout=2.0)
+    assert received == []


### PR DESCRIPTION
Another bug-hunting pass, this time driven by the type checker: every `ty` and `ruff` finding on `src/` was investigated rather than silenced, and several turned out to be sitting on top of real defects.

`ty` and `ruff` now report **no findings on `src/`** (was 10 and 26). Test suite: **949 passed** (was 922), including 27 new regression tests.

## Bugs fixed

**`worker/provider_handler` — image content parts crashed deserialization.**
The wire format names the part `"image"` but `MessageImageContent` declares `Literal["image_url"]`, so forwarding the wire name raised a pydantic `ValidationError` and *every* provider request carrying an image failed before reaching the provider. Content parts are now built from a wire-name → (model, field) map that never forwards the discriminator. Video parts — previously dropped on the way in and degraded to `str(part)` on the way out — now round-trip, and unknown/incomplete parts are logged and skipped instead of raising.

**`huggingface/async_downloader` — silent file corruption on resume.**
The resume path decided whether to append based on whether a `Range` header was *sent*, not whether the server *served* one. A `200` response (range ignored), or `accept_ranges=False` with a `.incomplete` file on disk, appended the whole body onto the partial file. With `expected_size` unknown the size check could not run, so the corruption was silent. Now keyed on `206`. Two more issues on the same path: the `416` branch could spin forever (verified — it hung a 5-minute test run against the old code), and the transient-error retry had no backoff, burning all 5 attempts in a tight loop on a fast-failing error like connection-refused.

**`ml/model_manager` — evicting a model dropped a held lock.**
`unload_model` / `clear_unused` / `clear` deleted the per-model `asyncio.Lock` even while a coroutine held it, so the next `get_model_lock` minted a fresh one and two callers could enter the same critical section — e.g. both loading the same model into VRAM. Held locks now survive eviction.

**`workflows/inbox` — fire-and-forget notify task could be collected.**
asyncio holds only weak references to running tasks, so the threadsafe notify task could be garbage-collected before running, dropping an EOS wakeup and hanging every consumer blocked in `iter_input`. Retained until done.

**`workflows/asset_storage` — audio saved as mp3 but labelled wav.**
pydub `AudioSegment`s were exported as mp3 while `get_content_type_for_asset_ref` reports `audio/wav`, so `auto_save_assets` stored mp3 bytes under `audio/wav` with an `asset://….wav` URI. Exports wav to match; this also drops the ffmpeg dependency for the path.

**`processing_context.download_file` — non-base64 data URIs crashed.**
The payload was unconditionally base64-decoded, so `data:text/plain,hello%20world` raised `binascii.Error`, and a URI with no media type (`data:,hi`) raised `IndexError`. Now mirrors `io.media_fetch._parse_data_uri`, which already handled both forms.

## Typing

- `base_node`: the `"Property"` annotation referenced a name that was never imported (`F821`).
- `processing_context`: `_resolve_default_device` always returns a device, so it is `str`, not `str | None`. This annotation was the source of the `str | None` that flowed into `ProcessingContext.device` and on into `BaseNode.move_to_device(device: str)`.
- `worker/protocol`: coerce a peer-supplied `request_id` to `str | None` and guard the `_cancel_flags` lookups.
- `utils/network`: bind `aiohttp.DefaultResolver` to a checkable base and type the `resolve()` return; `audio_helpers` now uses pydub's public `raw_data` instead of `_data`.
- Real annotations on `io.NodeOutputs.__init__`, `msgpack_codec.decode_message`, `package_tools.enrich`, and the `model_handler` progress callback.

Two ruff findings were false positives and are documented in place rather than silenced blindly: the deliberate late binding of `done_files` (it must report the live count, unlike the per-file values bound as defaults beside it), and pydantic field imports that `TC001` wants moved into a type-checking block, which would break model construction.

## Test plan

- `uv run pytest -q` — 949 passed, 13 skipped (from 922 on `main`; needs `uv sync --all-extras` or the optional-dep tests error out).
- `uv run ty check src …` (the exact CI invocation) — clean.
- `uv run ruff check src` — clean.
- New regression tests: `tests/worker/test_provider_message_parts.py`, `tests/integrations/test_async_downloader_resume.py`, `tests/workflows/test_download_file_data_uri.py`, plus additions to the inbox, asset-storage, and model-manager suites. The downloader tests were confirmed to fail (and hang) against the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pXgCjABnZyRpnAupDRqAa

---
_Generated by [Claude Code](https://claude.ai/code/session_011pXgCjABnZyRpnAupDRqAa)_