### PR TITLE
Bolt: [performance improvement] Optimize NumPy clip with instance method

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -52,3 +52,6 @@
 ## 2025-07-28 - PyTorch Tensor to NumPy Array Optimization
 **Learning:** When converting PyTorch tensors to `uint8` NumPy image arrays, using NumPy's `clip` or explicitly multiplying integers by a Python float upcasts the arrays implicitly to `float64` and creates intermediate allocations. Using PyTorch's native `.mul()`, `.clamp_()`, and `.byte()` operations before moving to NumPy allows PyTorch to utilize its optimized C++ backend to execute the operations in-place, drastically reducing both execution time and memory footprint.
 **Action:** Use PyTorch's native `.mul()`, `.clamp_()`, and `.byte()` methods when scaling and clipping PyTorch tensors to `uint8` arrays, making sure to explicitly cast non-floating point tensors to `.float()` to prevent implicit conversion OOM errors and to maintain accurate math boundaries.
+## 2025-05-15 - NumPy .clip() Instance Method Performance
+**Learning:** The instance method `.clip(min, max)` is faster than the module-level function `np.clip(array, min, max)` because it avoids NumPy's internal dispatcher (`__array_function__`) and argument parsing overhead.
+**Action:** Always prefer `.clip(...)` on the array object instead of `np.clip(...)` for better performance.

--- a/src/nodetool/media/audio/audio_helpers.py
+++ b/src/nodetool/media/audio/audio_helpers.py
@@ -273,7 +273,7 @@ def numpy_to_audio_segment(arr: np.ndarray, sample_rate=44100) -> AudioSegment:
     """
     # Convert the float array to int16 format, which is used by WAV files.
     # Clip first so out-of-range samples saturate instead of wrapping around.
-    arr_int16 = np.int16(np.clip(arr, -1.0, 1.0) * 32767.0).tobytes()
+    arr_int16 = np.int16(arr.clip(-1.0, 1.0) * 32767.0).tobytes()
 
     # Create a pydub AudioSegment from raw data.
     return AudioSegment(arr_int16, sample_width=2, frame_rate=sample_rate, channels=1)

--- a/src/nodetool/worker/context_stub.py
+++ b/src/nodetool/worker/context_stub.py
@@ -91,7 +91,7 @@ class WorkerContext(ProcessingContext):
         if data.dtype == np.int16:
             raw = data.tobytes()
         elif data.dtype in (np.float16, np.float32, np.float64):
-            raw = (np.clip(data, -1.0, 1.0) * 32767).astype(np.int16).tobytes()
+            raw = (data.clip(-1.0, 1.0) * 32767).astype(np.int16).tobytes()
         else:
             raise ValueError(f"Unsupported dtype {data.dtype}")
         # Always honour the caller's channel count, like the base

--- a/src/nodetool/workflows/processing_context.py
+++ b/src/nodetool/workflows/processing_context.py
@@ -1412,7 +1412,7 @@ class ProcessingContext:
                 data_bytes = data.tobytes()
             elif data.dtype in (np.float32, np.float64, np.float16):
                 # Full-scale conversion: clip to [-1.0, 1.0] then scale to int16
-                data_bytes = (np.clip(data, -1.0, 1.0) * 32767).astype(np.int16).tobytes()
+                data_bytes = (data.clip(-1.0, 1.0) * 32767).astype(np.int16).tobytes()
             else:
                 raise ValueError(f"Unsupported dtype {data.dtype}")
             return AudioSegment(

--- a/src/nodetool/workflows/processing_offload.py
+++ b/src/nodetool/workflows/processing_offload.py
@@ -122,7 +122,7 @@ def _numpy_audio_to_mp3_bytes(arr: Any, sample_rate: int = DEFAULT_AUDIO_SAMPLE_
     if audio_arr.dtype == np.int16:
         raw = audio_arr.tobytes()
     elif audio_arr.dtype in (np.float32, np.float64, np.float16):
-        raw = (np.clip(audio_arr, -1.0, 1.0) * 32767).astype(np.int16).tobytes()
+        raw = (audio_arr.clip(-1.0, 1.0) * 32767).astype(np.int16).tobytes()
     else:
         raise ValueError(f"Unsupported audio ndarray dtype {audio_arr.dtype}")
 
@@ -148,7 +148,7 @@ def _numpy_audio_to_wav_bytes(arr: Any, sample_rate: int = DEFAULT_AUDIO_SAMPLE_
     if audio_arr.dtype == np.int16:
         raw = audio_arr.tobytes()
     elif audio_arr.dtype in (np.float32, np.float64, np.float16):
-        raw = (np.clip(audio_arr, -1.0, 1.0) * 32767).astype(np.int16).tobytes()
+        raw = (audio_arr.clip(-1.0, 1.0) * 32767).astype(np.int16).tobytes()
     else:
         raise ValueError(f"Unsupported audio ndarray dtype {audio_arr.dtype}")
 


### PR DESCRIPTION
## What
Replaced module-level `np.clip(arr, ...)` with the faster instance method `arr.clip(...)` across audio processing and context modules.

## Why
The module-level function `np.clip` incurs overhead due to NumPy's internal dispatcher (`__array_function__`) and argument parsing. Benchmarks indicate that the instance method `.clip(...)` avoids this overhead and runs faster.

## Impact
Using `.clip(...)` slightly speeds up boundary clamping operations during array processing, reducing overhead in hot loops like image or audio normalization.

## Verification
- Validated performance improvement locally with isolated benchmarking scripts.
- Verified functional correctness via `uv run pytest`.
- Ensured code standards are met by running `uv run ruff format` and `uv run ruff check`.

---
*PR created automatically by Jules for task [1455821924186547979](https://jules.google.com/task/1455821924186547979) started by @georgi*