### PR TITLE
Bolt: [performance improvement] Optimize NumPy clip operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -52,3 +52,7 @@
 ## 2025-07-28 - PyTorch Tensor to NumPy Array Optimization
 **Learning:** When converting PyTorch tensors to `uint8` NumPy image arrays, using NumPy's `clip` or explicitly multiplying integers by a Python float upcasts the arrays implicitly to `float64` and creates intermediate allocations. Using PyTorch's native `.mul()`, `.clamp_()`, and `.byte()` operations before moving to NumPy allows PyTorch to utilize its optimized C++ backend to execute the operations in-place, drastically reducing both execution time and memory footprint.
 **Action:** Use PyTorch's native `.mul()`, `.clamp_()`, and `.byte()` methods when scaling and clipping PyTorch tensors to `uint8` arrays, making sure to explicitly cast non-floating point tensors to `.float()` to prevent implicit conversion OOM errors and to maintain accurate math boundaries.
+
+## 2026-08-02 - NumPy array.clip() vs np.clip() optimization
+**Learning:** Replacing the module-level `np.clip(array, min, max)` function with the instance method `array.clip(min, max)` avoids the overhead of NumPy's `__array_function__` dispatcher. This generic dispatcher performs type checking, method lookups, and argument parsing, which adds measurable overhead, especially in hot paths like audio processing loops.
+**Action:** Always prefer the instance method `array.clip(min, max)` over `np.clip(array, min, max)` when the object is known to be a NumPy array.

--- a/src/nodetool/media/audio/audio_helpers.py
+++ b/src/nodetool/media/audio/audio_helpers.py
@@ -273,7 +273,7 @@ def numpy_to_audio_segment(arr: np.ndarray, sample_rate=44100) -> AudioSegment:
     """
     # Convert the float array to int16 format, which is used by WAV files.
     # Clip first so out-of-range samples saturate instead of wrapping around.
-    arr_int16 = np.int16(np.clip(arr, -1.0, 1.0) * 32767.0).tobytes()
+    arr_int16 = np.int16(arr.clip(-1.0, 1.0) * 32767.0).tobytes()
 
     # Create a pydub AudioSegment from raw data.
     return AudioSegment(arr_int16, sample_width=2, frame_rate=sample_rate, channels=1)

--- a/src/nodetool/worker/context_stub.py
+++ b/src/nodetool/worker/context_stub.py
@@ -91,7 +91,7 @@ class WorkerContext(ProcessingContext):
         if data.dtype == np.int16:
             raw = data.tobytes()
         elif data.dtype in (np.float16, np.float32, np.float64):
-            raw = (np.clip(data, -1.0, 1.0) * 32767).astype(np.int16).tobytes()
+            raw = (data.clip(-1.0, 1.0) * 32767).astype(np.int16).tobytes()
         else:
             raise ValueError(f"Unsupported dtype {data.dtype}")
         # Always honour the caller's channel count, like the base

--- a/src/nodetool/workflows/processing_context.py
+++ b/src/nodetool/workflows/processing_context.py
@@ -1412,7 +1412,7 @@ class ProcessingContext:
                 data_bytes = data.tobytes()
             elif data.dtype in (np.float32, np.float64, np.float16):
                 # Full-scale conversion: clip to [-1.0, 1.0] then scale to int16
-                data_bytes = (np.clip(data, -1.0, 1.0) * 32767).astype(np.int16).tobytes()
+                data_bytes = (data.clip(-1.0, 1.0) * 32767).astype(np.int16).tobytes()
             else:
                 raise ValueError(f"Unsupported dtype {data.dtype}")
             return AudioSegment(

--- a/src/nodetool/workflows/processing_offload.py
+++ b/src/nodetool/workflows/processing_offload.py
@@ -122,7 +122,7 @@ def _numpy_audio_to_mp3_bytes(arr: Any, sample_rate: int = DEFAULT_AUDIO_SAMPLE_
     if audio_arr.dtype == np.int16:
         raw = audio_arr.tobytes()
     elif audio_arr.dtype in (np.float32, np.float64, np.float16):
-        raw = (np.clip(audio_arr, -1.0, 1.0) * 32767).astype(np.int16).tobytes()
+        raw = (audio_arr.clip(-1.0, 1.0) * 32767).astype(np.int16).tobytes()
     else:
         raise ValueError(f"Unsupported audio ndarray dtype {audio_arr.dtype}")
 
@@ -148,7 +148,7 @@ def _numpy_audio_to_wav_bytes(arr: Any, sample_rate: int = DEFAULT_AUDIO_SAMPLE_
     if audio_arr.dtype == np.int16:
         raw = audio_arr.tobytes()
     elif audio_arr.dtype in (np.float32, np.float64, np.float16):
-        raw = (np.clip(audio_arr, -1.0, 1.0) * 32767).astype(np.int16).tobytes()
+        raw = (audio_arr.clip(-1.0, 1.0) * 32767).astype(np.int16).tobytes()
     else:
         raise ValueError(f"Unsupported audio ndarray dtype {audio_arr.dtype}")
 


### PR DESCRIPTION
## What
Replaced module-level `np.clip(array, min, max)` with the instance method `array.clip(min, max)` across audio and data processing modules.

## Why
Using the module-level `np.clip()` function incurs extra overhead because NumPy must route the call through its generic `__array_function__` dispatcher, which performs type checking, method lookups, and argument parsing. The instance method `.clip()` bypasses this dispatcher and calls the underlying C implementation directly.

## Impact
This provides a small but measurable execution speedup during audio scaling and conversion operations, reducing CPU overhead in these hot paths without altering any functionality.

## Verification
- Verified that all replaced instances operated strictly on NumPy arrays (checked via explicit `.dtype` conditions or type hints).
- Ran the full test suite via `uv run pytest` which passed successfully.
- Ran linting via `uv run ruff check` which passed successfully.

---
*PR created automatically by Jules for task [8497367093847210058](https://jules.google.com/task/8497367093847210058) started by @georgi*