### PR TITLE
Bolt: [performance improvement] Optimize NumPy clip calls

### DIFF
--- a/src/nodetool/media/audio/audio_helpers.py
+++ b/src/nodetool/media/audio/audio_helpers.py
@@ -273,7 +273,7 @@ def numpy_to_audio_segment(arr: np.ndarray, sample_rate=44100) -> AudioSegment:
     """
     # Convert the float array to int16 format, which is used by WAV files.
     # Clip first so out-of-range samples saturate instead of wrapping around.
-    arr_int16 = np.int16(np.clip(arr, -1.0, 1.0) * 32767.0).tobytes()
+    arr_int16 = np.int16(arr.clip(-1.0, 1.0) * 32767.0).tobytes()
 
     # Create a pydub AudioSegment from raw data.
     return AudioSegment(arr_int16, sample_width=2, frame_rate=sample_rate, channels=1)

--- a/src/nodetool/worker/context_stub.py
+++ b/src/nodetool/worker/context_stub.py
@@ -91,7 +91,7 @@ class WorkerContext(ProcessingContext):
         if data.dtype == np.int16:
             raw = data.tobytes()
         elif data.dtype in (np.float16, np.float32, np.float64):
-            raw = (np.clip(data, -1.0, 1.0) * 32767).astype(np.int16).tobytes()
+            raw = (data.clip(-1.0, 1.0) * 32767).astype(np.int16).tobytes()
         else:
             raise ValueError(f"Unsupported dtype {data.dtype}")
         # Always honour the caller's channel count, like the base

--- a/src/nodetool/workflows/processing_context.py
+++ b/src/nodetool/workflows/processing_context.py
@@ -1412,7 +1412,7 @@ class ProcessingContext:
                 data_bytes = data.tobytes()
             elif data.dtype in (np.float32, np.float64, np.float16):
                 # Full-scale conversion: clip to [-1.0, 1.0] then scale to int16
-                data_bytes = (np.clip(data, -1.0, 1.0) * 32767).astype(np.int16).tobytes()
+                data_bytes = (data.clip(-1.0, 1.0) * 32767).astype(np.int16).tobytes()
             else:
                 raise ValueError(f"Unsupported dtype {data.dtype}")
             return AudioSegment(

--- a/src/nodetool/workflows/processing_offload.py
+++ b/src/nodetool/workflows/processing_offload.py
@@ -122,7 +122,7 @@ def _numpy_audio_to_mp3_bytes(arr: Any, sample_rate: int = DEFAULT_AUDIO_SAMPLE_
     if audio_arr.dtype == np.int16:
         raw = audio_arr.tobytes()
     elif audio_arr.dtype in (np.float32, np.float64, np.float16):
-        raw = (np.clip(audio_arr, -1.0, 1.0) * 32767).astype(np.int16).tobytes()
+        raw = (audio_arr.clip(-1.0, 1.0) * 32767).astype(np.int16).tobytes()
     else:
         raise ValueError(f"Unsupported audio ndarray dtype {audio_arr.dtype}")
 
@@ -148,7 +148,7 @@ def _numpy_audio_to_wav_bytes(arr: Any, sample_rate: int = DEFAULT_AUDIO_SAMPLE_
     if audio_arr.dtype == np.int16:
         raw = audio_arr.tobytes()
     elif audio_arr.dtype in (np.float32, np.float64, np.float16):
-        raw = (np.clip(audio_arr, -1.0, 1.0) * 32767).astype(np.int16).tobytes()
+        raw = (audio_arr.clip(-1.0, 1.0) * 32767).astype(np.int16).tobytes()
     else:
         raise ValueError(f"Unsupported audio ndarray dtype {audio_arr.dtype}")
 


### PR DESCRIPTION
## What
Replaces `np.clip(arr, ...)` calls with `arr.clip(...)` across audio processing and stub modules.

## Why
Using `np.clip()` on an array incurs overhead from NumPy's `__array_function__` dispatcher and Python function calls. Calling the built-in instance method `.clip()` directly bypasses this overhead, resulting in a small but measurable speedup.

## Impact
Improves execution speed during audio array clipping, a frequent operation in high-throughput audio offloading tasks. Reduces overhead by avoiding the module-level dispatcher.

## Verification
- Wrote and executed a microbenchmark demonstrating `.clip()` is faster than `np.clip()`.
- Verified type safety (changes only apply to `np.ndarray`).
- Ran `uv run pytest` specifically on affected tests (`tests/workflows/test_processing_offload_audio_scaling.py`, `tests/media/test_audio_helpers_clipping.py`, `tests/worker/test_context_stub.py`) to confirm no regressions.
- Ran `uv run ruff check src` to ensure clean linting in the modified directories.

---
*PR created automatically by Jules for task [941856140596962677](https://jules.google.com/task/941856140596962677) started by @georgi*